### PR TITLE
fix(runtime): gate native inference on wasm

### DIFF
--- a/crates/traverse-runtime/Cargo.toml
+++ b/crates/traverse-runtime/Cargo.toml
@@ -25,8 +25,11 @@ zip = { version = "8", default-features = false, features = ["deflate"] }
 aes-gcm = { version = "0.11.0", optional = true, features = ["zeroize"] }
 
 [features]
-default = ["native-executors", "wasmtime-executor", "datastore-encryption"]
+default = ["native-executors", "native-inference", "wasmtime-executor", "datastore-encryption"]
 native-executors = ["dep:rayon"]
+# The Ollama provider uses blocking native TCP sockets. Keep it out of the
+# portable, no-default-features wasm runtime surface.
+native-inference = []
 wasmtime-executor = ["dep:wasmtime", "dep:wasmtime-wasi"]
 # Local-file private-record AEAD (Spec 084). Omitted from wasm32
 # `--no-default-features` checks so getrandom backends are not required.

--- a/crates/traverse-runtime/src/lib.rs
+++ b/crates/traverse-runtime/src/lib.rs
@@ -7,6 +7,10 @@ pub use artifact_router::*;
 pub mod data_store;
 pub mod events;
 pub mod executor;
+/// Native-only governed inference providers, enabled by the `native-inference`
+/// feature. This surface is intentionally unavailable to no-default-features
+/// wasm32 builds because its Ollama implementation requires TCP sockets.
+#[cfg(feature = "native-inference")]
 pub mod inference;
 pub mod placement;
 pub mod router;
@@ -278,6 +282,7 @@ impl<E> Runtime<E> {
     /// Returns [`inference::GovernedModelExecutionError`] when the app or
     /// interface is not registered, model resolution fails, or provider
     /// execution fails.
+    #[cfg(feature = "native-inference")]
     pub fn execute_governed_model_dependency(
         &self,
         app_id: &str,

--- a/docs/model-dependency-authoring-guide.md
+++ b/docs/model-dependency-authoring-guide.md
@@ -1,5 +1,15 @@
 # Governed Model Dependency Authoring Guide
 
+## Runtime target availability
+
+The initial Ollama-backed governed inference provider uses blocking native TCP
+sockets. It is enabled by the `traverse-runtime` `native-inference` feature,
+which is included in the default feature set. Portable `wasm32` consumers
+should build `traverse-runtime` with `--no-default-features`; that build does
+not expose the `inference` module or `Runtime::execute_governed_model_dependency`.
+Use a future compatible browser-native provider before declaring an inference
+workflow for a wasm32 host.
+
 Spec `045-governed-model-dependency-resolution` defines app manifest model
 dependencies for real inference. These declarations belong in application
 manifests, not inside downstream product code.


### PR DESCRIPTION
## Summary

- Gate the blocking TCP-backed Ollama inference API behind the default-enabled `native-inference` feature.
- Keep the portable `wasm32` no-default-features runtime surface free of governed inference APIs.
- Document the target availability boundary for model-dependency authors.

## Governing Spec

- `045-governed-model-dependency-resolution`
- `065-sigstore-bundle-verification`

The approved model-dependency spec is immutable; this change enforces its portability boundary without changing it.

## Project Item

Closes #1065.

## Definition of Done

- [x] Native TCP inference is unavailable from the no-default-features wasm32 surface.
- [x] Native inference remains enabled by default.
- [x] Target availability is documented.

## Validation

- `cargo fmt --check`
- `cargo test -p traverse-runtime --test inference_tests`
- `PATH=/Users/enricopiovesan/.rustup/toolchains/1.94.0-aarch64-apple-darwin/bin:$PATH cargo check -p traverse-runtime --target wasm32-unknown-unknown --no-default-features`
