### PR TITLE
docs: govern cross-host registry cache

### DIFF
--- a/docs/adr/0041-cross-host-embedded-registry-cache.md
+++ b/docs/adr/0041-cross-host-embedded-registry-cache.md
@@ -1,0 +1,42 @@
+# ADR-0041: Cross-Host Embedded Registry Cache Contract
+
+- Status: Accepted
+- Governing specs: `080-embedded-registry-cache`, `107-cross-host-embedded-registry-cache`
+- Related issues: #826, #1071, #1072
+
+## Context
+
+Rust and Web embedders already support explicit preparation followed by offline
+`registry_ref` resolution from a host-owned verified cache. Swift, Kotlin, and
+.NET expose runtime bridge packages but have no equivalent governed cache
+surface. Leaving them to materialize local paths in consumer tooling duplicates
+resolution behavior and makes registry-only application bundles non-portable.
+
+## Decision
+
+Define one semantic cache contract for every host. Each platform provides an
+idiomatic adapter and retains ownership of storage, network fetch, lifecycle,
+and platform policy. The adapter's preparation operation validates the synced
+index, deterministically selects a non-yanked version, verifies digests, and
+atomically records non-secret evidence. Initialization and execution only read
+verified entries and are offline-only.
+
+The contract standardizes observable errors and evidence, not cache layout or
+language-level API names. No adapter may fall back to local examples or a
+network fetch when an offline entry is missing or invalid.
+
+## Consequences
+
+Swift, Kotlin, and .NET can consume registry-only bundles without an App-Refs
+manifest rewrite. Hosts retain control over storage and credentials while users
+receive consistent failure handling and provenance evidence across platforms.
+Existing Rust/Web APIs remain compatible.
+
+## Alternatives Considered
+
+- Require native hosts to use Rust's file-cache implementation: rejected because
+  it couples host packaging and storage policy to one language/runtime.
+- Give every platform independent cache semantics: rejected because errors,
+  provenance, and fail-closed behavior would drift.
+- Retain App-Refs materialization as the product path: rejected because it
+  duplicates resolution outside Traverse and cannot support registry-only bundles.

--- a/specs/107-cross-host-embedded-registry-cache/spec.md
+++ b/specs/107-cross-host-embedded-registry-cache/spec.md
@@ -1,0 +1,89 @@
+# Feature Specification: Cross-Host Embedded Registry Cache
+
+**Status**: Approved
+**Canonical governing ID**: `107-cross-host-embedded-registry-cache`
+**Version**: 1.0.0
+**Extends**: `080-embedded-registry-cache`, `054-public-scope-registry-ref`,
+`055-registry-sync`, `068-public-platform-embedder-packages`.
+**Input**: #1071, #1072; ADR-0041.
+
+## Purpose
+
+Provide one portable host-owned registry-cache contract for Swift, Kotlin, and
+.NET embedders. Each platform exposes idiomatic APIs, but every implementation
+has the same preparation, offline-resolution, evidence, error, and compatibility
+semantics as the approved Rust and Web paths.
+
+## Boundary and Ownership
+
+| Concern | Owner |
+| --- | --- |
+| Fetching registry index and artifacts during explicit preparation | Host application or deployment tooling |
+| Selecting a compatible record, digest verification, and evidence schema | Traverse public resolver contract |
+| Cache root, persistence, encryption, backup, and eviction | Host application |
+| Initialization and execution after preparation | Embedded runtime using verified local entries only |
+| Registry release and lifecycle provenance | Registry |
+
+## Functional Requirements
+
+- **FR-001**: Swift, Kotlin, and .NET MUST expose an explicit preparation
+  operation and an offline resolution operation for `registry_ref` dependencies.
+  Their public APIs MAY be idiomatic, but MUST preserve this contract's semantics.
+- **FR-002**: Preparation MUST accept a validated synced-index snapshot, a
+  `registry_ref`, a host-supplied fetcher, and a host-owned cache writer. It MUST
+  select the highest non-yanked version satisfying `version_range`
+  deterministically.
+- **FR-003**: Preparation MUST verify published artifact and contract digests
+  before atomically making an entry usable. Partial or failed entries MUST NOT be
+  executable.
+- **FR-004**: Initialization, submission, subscription, and execution MUST be
+  offline-only. They MUST NOT fetch an index or artifact, synthesize a cache
+  root, fall back to local examples, or use `traverse-cli serve`.
+- **FR-005**: A verified cache entry MUST retain namespace, capability id,
+  selected version, requested version range, source release, index digest,
+  artifact digest, verification timestamp, and outcome. It MUST NOT expose cache
+  paths, credentials, configuration values, or artifact contents.
+- **FR-006**: All platforms MUST use these stable secret-free failure codes:
+  `registry_sync_missing`, `registry_version_not_found`,
+  `registry_dependency_yanked`, `registry_prepare_failed`,
+  `registry_artifact_digest_mismatch`, and `registry_cache_entry_missing`.
+- **FR-007**: A platform adapter MUST reject cache entries whose artifact or
+  contract bytes no longer match their recorded digest, and MUST fail closed
+  rather than silently re-resolving or accepting a local-path substitute.
+- **FR-008**: Cache lifecycle and platform storage mechanics remain host-owned.
+  Traverse MUST not require a shared file layout across Swift, Kotlin, .NET,
+  Rust, and Web implementations.
+- **FR-009**: Cross-host conformance fixtures MUST demonstrate equivalent
+  observable results for preparation success, missing cache, yanked dependency,
+  and artifact digest mismatch.
+
+## Acceptance Scenarios
+
+1. Given a synced index and matching artifact, each native host prepares a
+   `registry_ref`, then initializes and executes from verified local cache bytes
+   with non-secret provenance evidence.
+2. Given no verified entry, native embedded initialization returns
+   `registry_cache_entry_missing` and performs no network request.
+3. Given a yanked matching record, preparation returns
+   `registry_dependency_yanked`, preserves prior verified entries, and makes no
+   new entry usable.
+4. Given an artifact whose bytes do not match its published digest, preparation
+   returns `registry_artifact_digest_mismatch`; later initialization cannot use
+   it.
+5. Given a cache entry modified after preparation, resolution fails closed with
+   `registry_artifact_digest_mismatch` and does not select another artifact.
+
+## Compatibility
+
+This is additive. Spec 080's Rust/Web API and evidence remain supported. Native
+adapters may choose language-native method names and storage backends, but they
+MUST preserve the stable error codes, required evidence fields, offline boundary,
+and version-selection rules in this specification. Existing local-path bundle
+loading remains available for bundles that do not declare `registry_ref`.
+
+## Out of Scope
+
+- Runtime network fetching, hosted registry APIs, or a remote runtime host.
+- Cache encryption, retention, backup, restore, or storage-engine selection.
+- Application activation-time artifact selection or connector invocation.
+- App-Refs-specific materialization scripts as a supported product path.

--- a/specs/governance/approved-specs.json
+++ b/specs/governance/approved-specs.json
@@ -1396,6 +1396,22 @@
         "docs/adr/0040-standalone-capability-packages-and-activation-resolution.md",
         "specs/106-activation-artifact-resolution/"
       ]
+    },
+    {
+      "id": "107-cross-host-embedded-registry-cache",
+      "version": "1.0.0",
+      "status": "approved",
+      "immutable": true,
+      "path": "specs/107-cross-host-embedded-registry-cache/spec.md",
+      "governs": [
+        "crates/traverse-embedder/",
+        "packages/web/TraverseEmbedder/",
+        "packages/swift/TraverseEmbedder/",
+        "packages/kotlin/TraverseEmbedder/",
+        "packages/dotnet/TraverseEmbedder/",
+        "docs/adr/0041-cross-host-embedded-registry-cache.md",
+        "specs/107-cross-host-embedded-registry-cache/"
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Add the approved cross-host registry-cache contract for Swift, Kotlin, and .NET embedders.
- Record ADR-0041: platform adapters share cache semantics without sharing storage implementation.

## Governing Spec

- `080-embedded-registry-cache`
- `068-public-platform-embedder-packages`
- `004-spec-alignment-gate`
- `107-cross-host-embedded-registry-cache`

## Project Item

- Closes #1072

## Definition of Done

- [x] Specifies the portable prepare/offline-resolve boundary, stable errors, evidence, and native conformance scenarios.
- [x] Registers immutable approval metadata and documents the compatibility decision.

## Validation

- `jq empty specs/governance/approved-specs.json`
- `BASE_SHA=origin/main bash scripts/ci/spec_alignment_check.sh /private/tmp/traverse-pr-1072-body.md`
