### PR TITLE
feat(runtime): mediate connector invoke requests

### DIFF
--- a/crates/traverse-runtime/src/executor/host_abi_v1.json
+++ b/crates/traverse-runtime/src/executor/host_abi_v1.json
@@ -47,6 +47,11 @@
       "module": "traverse_host",
       "name": "emit_event",
       "category": "event_publish"
+    },
+    {
+      "module": "traverse_host",
+      "name": "connector_invoke",
+      "category": "mediated_connector_invocation"
     }
   ]
 }

--- a/crates/traverse-runtime/src/executor/mod.rs
+++ b/crates/traverse-runtime/src/executor/mod.rs
@@ -29,6 +29,15 @@ use crate::events::types::TraverseEvent;
 use serde_json::Value;
 use traverse_contracts::{EventReference, ServiceType};
 
+/// Immutable, non-secret outcome evidence for one mediated connector call.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ConnectorInvocationEvidence {
+    pub connector_id: String,
+    pub resolved_version: Option<String>,
+    pub result_class: String,
+    pub failure_class: Option<String>,
+}
+
 /// The artifact type recorded in a capability registration, used to route to the correct executor.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum ArtifactType {
@@ -70,6 +79,8 @@ pub struct ExecutorOutput {
     /// 098-capability-event-host-abi FR-002/FR-003). Always empty for
     /// non-WASM executors, since the host ABI is WASM-only.
     pub emitted_events: Vec<TraverseEvent>,
+    /// Immutable, non-secret connector authorization and outcome evidence.
+    pub connector_invocation_evidence: Vec<ConnectorInvocationEvidence>,
 }
 
 /// Error returned by a [`CapabilityExecutor`].

--- a/crates/traverse-runtime/src/executor/mod.rs
+++ b/crates/traverse-runtime/src/executor/mod.rs
@@ -19,9 +19,10 @@ pub use native::NativeExecutor;
 pub use thread_pool::{ConfigError, ThreadPoolExecutor, ThreadPoolExecutorConfig};
 #[cfg(feature = "wasmtime-executor")]
 pub use wasm::{
-    HostAbiImport, HostAbiValidation, SUPPORTED_HOST_ABI_VERSION, WasmExecutionLimits,
-    WasmExecutor, WasmModuleCacheConfig, WasmModuleCacheStats, supported_host_abi_versions,
-    verify_wasm_host_abi_bytes,
+    ActivatedConnector, ConnectorInvokeRequest, ConnectorInvokeResponse, HostAbiImport,
+    HostAbiValidation, MediatedConnector, MediatedConnectorContext, SUPPORTED_HOST_ABI_VERSION,
+    WasmExecutionLimits, WasmExecutor, WasmModuleCacheConfig, WasmModuleCacheStats,
+    supported_host_abi_versions, verify_wasm_host_abi_bytes,
 };
 
 use crate::events::types::TraverseEvent;

--- a/crates/traverse-runtime/src/executor/native.rs
+++ b/crates/traverse-runtime/src/executor/native.rs
@@ -42,6 +42,7 @@ impl CapabilityExecutor for NativeExecutor {
             .map(|value| ExecutorOutput {
                 value,
                 emitted_events: Vec::new(),
+                connector_invocation_evidence: Vec::new(),
             })
             .map_err(ExecutorError::ExecutionFailed)
     }

--- a/crates/traverse-runtime/src/executor/thread_pool.rs
+++ b/crates/traverse-runtime/src/executor/thread_pool.rs
@@ -426,6 +426,7 @@ mod tests {
             Ok(ExecutorOutput {
                 value: input.clone(),
                 emitted_events: Vec::new(),
+                connector_invocation_evidence: Vec::new(),
             })
         }
     }
@@ -461,6 +462,7 @@ mod tests {
             Ok(ExecutorOutput {
                 value: json!({ "second": true }),
                 emitted_events: Vec::new(),
+                connector_invocation_evidence: Vec::new(),
             })
         );
         Ok(())
@@ -487,6 +489,7 @@ mod tests {
             Ok(ExecutorOutput {
                 value: json!({ "ok": true }),
                 emitted_events: Vec::new(),
+                connector_invocation_evidence: Vec::new(),
             })
         );
         Ok(())

--- a/crates/traverse-runtime/src/executor/wasm.rs
+++ b/crates/traverse-runtime/src/executor/wasm.rs
@@ -56,6 +56,12 @@ const EMIT_EVENT_ERR_UNDECLARED_EVENT: i32 = -2;
 /// FR-003, acceptance scenario 3).
 const EMIT_EVENT_ERR_NOT_SUBSCRIBABLE: i32 = -3;
 
+/// `traverse_host::connector_invoke` is unavailable unless the embedding host
+/// supplies an activated, capability-authorized connector binding. The default
+/// WASM executor deliberately returns this stable failure rather than granting
+/// any ambient authority (Spec 104 FR-002/FR-007).
+const CONNECTOR_INVOKE_ERR_UNBOUND: i32 = -2;
+
 static HOST_ABI_V1_WHITELIST_CACHE: LazyLock<Result<HostAbiWhitelist, String>> =
     LazyLock::new(|| {
         serde_json::from_str::<HostAbiWhitelist>(HOST_ABI_V1_WHITELIST).map_err(|e| e.to_string())
@@ -452,6 +458,15 @@ impl WasmExecutor {
         linker
             .func_wrap("traverse_host", "emit_event", handle_emit_event)
             .map_err(|e| ExecutorError::RuntimeSetupFailed(format!("func_wrap emit_event: {e}")))?;
+        linker
+            .func_wrap(
+                "traverse_host",
+                "connector_invoke",
+                handle_connector_invoke_without_active_binding,
+            )
+            .map_err(|e| {
+                ExecutorError::RuntimeSetupFailed(format!("func_wrap connector_invoke: {e}"))
+            })?;
 
         let mut store = Store::new(
             &self.engine,
@@ -629,6 +644,22 @@ fn handle_emit_event(mut caller: Caller<'_, WasmStoreState>, ptr: i32, len: i32)
     };
     caller.data_mut().emitted_events.push(event);
     EMIT_EVENT_OK
+}
+
+/// Fail closed until an embedding host supplies an active application binding.
+///
+/// The four integers are the versioned ABI's request pointer/length and
+/// response pointer/capacity. This default handler intentionally neither reads
+/// nor writes guest memory: no request data, host configuration, credentials,
+/// paths, or endpoint can cross the boundary before authorization exists.
+fn handle_connector_invoke_without_active_binding(
+    _caller: Caller<'_, WasmStoreState>,
+    _request_ptr: i32,
+    _request_len: i32,
+    _response_ptr: i32,
+    _response_capacity: i32,
+) -> i32 {
+    CONNECTOR_INVOKE_ERR_UNBOUND
 }
 
 fn classify_wasm_execution_error(error: &wasmtime::Error) -> ExecutorError {

--- a/crates/traverse-runtime/src/executor/wasm.rs
+++ b/crates/traverse-runtime/src/executor/wasm.rs
@@ -21,7 +21,10 @@ use wasmtime_wasi::WasiCtxBuilder;
 use wasmtime_wasi::p1::WasiP1Ctx;
 use wasmtime_wasi::p2::pipe::{MemoryInputPipe, MemoryOutputPipe};
 
-use super::{ArtifactType, CapabilityExecutor, ExecutorCapability, ExecutorError, ExecutorOutput};
+use super::{
+    ArtifactType, CapabilityExecutor, ConnectorInvocationEvidence, ExecutorCapability,
+    ExecutorError, ExecutorOutput,
+};
 use crate::events::types::{LifecycleStatus, TraverseEvent};
 use traverse_contracts::{ConnectorRequirement, EventReference, ServiceType};
 
@@ -359,6 +362,7 @@ struct WasmStoreState {
     /// Events accepted via `traverse_host::emit_event` during this call.
     emitted_events: Vec<TraverseEvent>,
     connector_context: Option<MediatedConnectorContext>,
+    connector_invocation_evidence: Vec<ConnectorInvocationEvidence>,
 }
 
 impl CapabilityExecutor for WasmExecutor {
@@ -562,6 +566,7 @@ impl WasmExecutor {
                 service_type,
                 emitted_events: Vec::new(),
                 connector_context,
+                connector_invocation_evidence: Vec::new(),
             },
         );
         store.limiter(|state| &mut state.limits);
@@ -591,9 +596,11 @@ impl WasmExecutor {
             ))
         })?;
 
+        let data = store.into_data();
         Ok(ExecutorOutput {
             value,
-            emitted_events: store.into_data().emitted_events,
+            emitted_events: data.emitted_events,
+            connector_invocation_evidence: data.connector_invocation_evidence,
         })
     }
 
@@ -777,21 +784,39 @@ fn handle_connector_invoke(
         return CONNECTOR_INVOKE_ERR_INVALID_REQUEST;
     }
     let Some(context) = caller.data().connector_context.clone() else {
-        return CONNECTOR_INVOKE_ERR_UNBOUND;
+        return connector_failure(
+            &mut caller,
+            &request.connector_id,
+            None,
+            "unbound",
+            CONNECTOR_INVOKE_ERR_UNBOUND,
+        );
     };
     if !context
         .declared_requirements
         .iter()
         .any(|requirement| requirement.connector_id == request.connector_id)
     {
-        return CONNECTOR_INVOKE_ERR_UNDECLARED;
+        return connector_failure(
+            &mut caller,
+            &request.connector_id,
+            None,
+            "undeclared",
+            CONNECTOR_INVOKE_ERR_UNDECLARED,
+        );
     }
     let Some(connector) = context
         .activated_connectors
         .iter()
         .find(|connector| connector.connector_id == request.connector_id)
     else {
-        return CONNECTOR_INVOKE_ERR_UNBOUND;
+        return connector_failure(
+            &mut caller,
+            &request.connector_id,
+            None,
+            "unbound",
+            CONNECTOR_INVOKE_ERR_UNBOUND,
+        );
     };
     let compatible = context
         .declared_requirements
@@ -804,35 +829,99 @@ fn handle_connector_invoke(
                 .is_some_and(|(range, version)| range.matches(&version))
         });
     if !compatible {
-        return CONNECTOR_INVOKE_ERR_UNAUTHORIZED;
+        return connector_failure(
+            &mut caller,
+            &request.connector_id,
+            Some(&connector.version),
+            "incompatible",
+            CONNECTOR_INVOKE_ERR_UNAUTHORIZED,
+        );
     }
     let Ok(response) = connector.implementation.invoke(&request) else {
-        return CONNECTOR_INVOKE_ERR_EXECUTION_FAILED;
+        return connector_failure(
+            &mut caller,
+            &request.connector_id,
+            Some(&connector.version),
+            "execution_failed",
+            CONNECTOR_INVOKE_ERR_EXECUTION_FAILED,
+        );
     };
     if response.abi_version != SUPPORTED_HOST_ABI_VERSION
         || response.result_class.is_empty()
         || contains_host_private_data(&response.payload)
     {
-        return CONNECTOR_INVOKE_ERR_UNAUTHORIZED;
+        return connector_failure(
+            &mut caller,
+            &request.connector_id,
+            Some(&connector.version),
+            "unauthorized_output",
+            CONNECTOR_INVOKE_ERR_UNAUTHORIZED,
+        );
     }
     let Ok(response_bytes) = serde_json::to_vec(&response) else {
-        return CONNECTOR_INVOKE_ERR_EXECUTION_FAILED;
+        return connector_failure(
+            &mut caller,
+            &request.connector_id,
+            Some(&connector.version),
+            "execution_failed",
+            CONNECTOR_INVOKE_ERR_EXECUTION_FAILED,
+        );
     };
     if response_bytes.len() > response_capacity
         || response_bytes.len() > MAX_CONNECTOR_INVOKE_RESPONSE_BYTES
     {
-        return CONNECTOR_INVOKE_ERR_PAYLOAD_TOO_LARGE;
+        return connector_failure(
+            &mut caller,
+            &request.connector_id,
+            Some(&connector.version),
+            "bounded_io",
+            CONNECTOR_INVOKE_ERR_PAYLOAD_TOO_LARGE,
+        );
     }
     if memory
         .write(&mut caller, response_ptr, &response_bytes)
         .is_err()
     {
-        return CONNECTOR_INVOKE_ERR_INVALID_REQUEST;
+        return connector_failure(
+            &mut caller,
+            &request.connector_id,
+            Some(&connector.version),
+            "invalid_response_memory",
+            CONNECTOR_INVOKE_ERR_INVALID_REQUEST,
+        );
     }
+    caller
+        .data_mut()
+        .connector_invocation_evidence
+        .push(ConnectorInvocationEvidence {
+            connector_id: request.connector_id,
+            resolved_version: Some(connector.version.clone()),
+            result_class: response.result_class,
+            failure_class: None,
+        });
     #[allow(clippy::cast_possible_truncation)]
     {
         response_bytes.len() as i32
     }
+}
+
+fn connector_failure(
+    caller: &mut Caller<'_, WasmStoreState>,
+    connector_id: &str,
+    resolved_version: Option<&str>,
+    failure_class: &str,
+    code: i32,
+) -> i32 {
+    caller
+        .data_mut()
+        .connector_invocation_evidence
+        .push(ConnectorInvocationEvidence {
+            connector_id: connector_id.to_string(),
+            resolved_version: resolved_version.map(str::to_string),
+            result_class: "failure".to_string(),
+            failure_class: Some(failure_class.to_string()),
+        });
+    code
 }
 
 fn contains_host_private_data(value: &Value) -> bool {

--- a/crates/traverse-runtime/src/executor/wasm.rs
+++ b/crates/traverse-runtime/src/executor/wasm.rs
@@ -92,6 +92,10 @@ pub struct ConnectorInvokeResponse {
 
 /// A host-owned activated connector. Its implementation is never visible to a guest.
 pub trait MediatedConnector: Send + Sync {
+    /// # Errors
+    ///
+    /// Returns a stable, non-secret failure description when the host-owned
+    /// connector cannot complete the requested operation.
     fn invoke(&self, request: &ConnectorInvokeRequest) -> Result<ConnectorInvokeResponse, String>;
 }
 
@@ -478,6 +482,11 @@ impl WasmExecutor {
     /// Execute bytes with host-owned, activated connector bindings. This is the
     /// only API that can enable `connector_invoke`; callers that do not supply
     /// this context retain the deny-by-default handler.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ExecutorError`] when the module, guest memory, or execution
+    /// cannot be completed safely.
     pub fn run_bytes_with_mediated_connectors(
         &self,
         wasm_bytes: &[u8],
@@ -751,8 +760,67 @@ fn handle_connector_invoke(
     response_ptr: i32,
     response_capacity: i32,
 ) -> i32 {
-    if request_ptr < 0 || request_len < 0 || response_ptr < 0 || response_capacity < 0 {
+    let Ok((memory, request, request_ptr, response_ptr, response_capacity)) =
+        parse_connector_request(
+            &mut caller,
+            request_ptr,
+            request_len,
+            response_ptr,
+            response_capacity,
+        )
+    else {
         return CONNECTOR_INVOKE_ERR_INVALID_REQUEST;
+    };
+    let Some(context) = caller.data().connector_context.clone() else {
+        return connector_failure(
+            &mut caller,
+            &request.connector_id,
+            None,
+            "unbound",
+            CONNECTOR_INVOKE_ERR_UNBOUND,
+        );
+    };
+    let connector = match resolve_activated_connector(&context, &request) {
+        Ok(connector) => connector,
+        Err(failure) => {
+            return connector_failure(
+                &mut caller,
+                &request.connector_id,
+                failure.resolved_version.as_deref(),
+                failure.failure_class,
+                failure.code,
+            );
+        }
+    };
+    invoke_activated_connector(
+        &mut caller,
+        memory,
+        request,
+        request_ptr,
+        response_ptr,
+        response_capacity,
+        &connector,
+    )
+}
+
+fn parse_connector_request(
+    caller: &mut Caller<'_, WasmStoreState>,
+    request_ptr: i32,
+    request_len: i32,
+    response_ptr: i32,
+    response_capacity: i32,
+) -> Result<
+    (
+        wasmtime::Memory,
+        ConnectorInvokeRequest,
+        usize,
+        usize,
+        usize,
+    ),
+    (),
+> {
+    if request_ptr < 0 || request_len < 0 || response_ptr < 0 || response_capacity < 0 {
+        return Err(());
     }
     #[allow(clippy::cast_sign_loss)]
     let (request_ptr, request_len, response_ptr, response_capacity) = (
@@ -764,59 +832,65 @@ fn handle_connector_invoke(
     if request_len > MAX_CONNECTOR_INVOKE_REQUEST_BYTES
         || response_capacity > MAX_CONNECTOR_INVOKE_RESPONSE_BYTES
     {
-        return CONNECTOR_INVOKE_ERR_PAYLOAD_TOO_LARGE;
+        return Err(());
     }
     let Some(Extern::Memory(memory)) = caller.get_export("memory") else {
-        return CONNECTOR_INVOKE_ERR_INVALID_REQUEST;
+        return Err(());
     };
     let mut bytes = vec![0_u8; request_len];
     if memory.read(&caller, request_ptr, &mut bytes).is_err() {
-        return CONNECTOR_INVOKE_ERR_INVALID_REQUEST;
+        return Err(());
     }
     let Ok(request) = serde_json::from_slice::<ConnectorInvokeRequest>(&bytes) else {
-        return CONNECTOR_INVOKE_ERR_INVALID_REQUEST;
+        return Err(());
     };
     if request.abi_version != SUPPORTED_HOST_ABI_VERSION
         || request.connector_id.is_empty()
         || request.operation.is_empty()
         || contains_host_private_data(&request.payload)
     {
-        return CONNECTOR_INVOKE_ERR_INVALID_REQUEST;
+        return Err(());
     }
-    let Some(context) = caller.data().connector_context.clone() else {
-        return connector_failure(
-            &mut caller,
-            &request.connector_id,
-            None,
-            "unbound",
-            CONNECTOR_INVOKE_ERR_UNBOUND,
-        );
-    };
+    Ok((
+        memory,
+        request,
+        request_ptr,
+        response_ptr,
+        response_capacity,
+    ))
+}
+
+struct ConnectorInvokeFailure {
+    failure_class: &'static str,
+    resolved_version: Option<String>,
+    code: i32,
+}
+
+fn resolve_activated_connector(
+    context: &MediatedConnectorContext,
+    request: &ConnectorInvokeRequest,
+) -> Result<ActivatedConnector, ConnectorInvokeFailure> {
     if !context
         .declared_requirements
         .iter()
         .any(|requirement| requirement.connector_id == request.connector_id)
     {
-        return connector_failure(
-            &mut caller,
-            &request.connector_id,
-            None,
-            "undeclared",
-            CONNECTOR_INVOKE_ERR_UNDECLARED,
-        );
+        return Err(ConnectorInvokeFailure {
+            failure_class: "undeclared",
+            resolved_version: None,
+            code: CONNECTOR_INVOKE_ERR_UNDECLARED,
+        });
     }
     let Some(connector) = context
         .activated_connectors
         .iter()
         .find(|connector| connector.connector_id == request.connector_id)
     else {
-        return connector_failure(
-            &mut caller,
-            &request.connector_id,
-            None,
-            "unbound",
-            CONNECTOR_INVOKE_ERR_UNBOUND,
-        );
+        return Err(ConnectorInvokeFailure {
+            failure_class: "unbound",
+            resolved_version: None,
+            code: CONNECTOR_INVOKE_ERR_UNBOUND,
+        });
     };
     let compatible = context
         .declared_requirements
@@ -829,17 +903,27 @@ fn handle_connector_invoke(
                 .is_some_and(|(range, version)| range.matches(&version))
         });
     if !compatible {
-        return connector_failure(
-            &mut caller,
-            &request.connector_id,
-            Some(&connector.version),
-            "incompatible",
-            CONNECTOR_INVOKE_ERR_UNAUTHORIZED,
-        );
+        return Err(ConnectorInvokeFailure {
+            failure_class: "incompatible",
+            resolved_version: Some(connector.version.clone()),
+            code: CONNECTOR_INVOKE_ERR_UNAUTHORIZED,
+        });
     }
+    Ok(connector.clone())
+}
+
+fn invoke_activated_connector(
+    caller: &mut Caller<'_, WasmStoreState>,
+    memory: wasmtime::Memory,
+    request: ConnectorInvokeRequest,
+    _request_ptr: usize,
+    response_ptr: usize,
+    response_capacity: usize,
+    connector: &ActivatedConnector,
+) -> i32 {
     let Ok(response) = connector.implementation.invoke(&request) else {
         return connector_failure(
-            &mut caller,
+            caller,
             &request.connector_id,
             Some(&connector.version),
             "execution_failed",
@@ -851,7 +935,7 @@ fn handle_connector_invoke(
         || contains_host_private_data(&response.payload)
     {
         return connector_failure(
-            &mut caller,
+            caller,
             &request.connector_id,
             Some(&connector.version),
             "unauthorized_output",
@@ -860,7 +944,7 @@ fn handle_connector_invoke(
     }
     let Ok(response_bytes) = serde_json::to_vec(&response) else {
         return connector_failure(
-            &mut caller,
+            caller,
             &request.connector_id,
             Some(&connector.version),
             "execution_failed",
@@ -871,7 +955,7 @@ fn handle_connector_invoke(
         || response_bytes.len() > MAX_CONNECTOR_INVOKE_RESPONSE_BYTES
     {
         return connector_failure(
-            &mut caller,
+            caller,
             &request.connector_id,
             Some(&connector.version),
             "bounded_io",
@@ -879,11 +963,11 @@ fn handle_connector_invoke(
         );
     }
     if memory
-        .write(&mut caller, response_ptr, &response_bytes)
+        .write(&mut *caller, response_ptr, &response_bytes)
         .is_err()
     {
         return connector_failure(
-            &mut caller,
+            caller,
             &request.connector_id,
             Some(&connector.version),
             "invalid_response_memory",
@@ -899,10 +983,7 @@ fn handle_connector_invoke(
             result_class: response.result_class,
             failure_class: None,
         });
-    #[allow(clippy::cast_possible_truncation)]
-    {
-        response_bytes.len() as i32
-    }
+    i32::try_from(response_bytes.len()).unwrap_or(CONNECTOR_INVOKE_ERR_PAYLOAD_TOO_LARGE)
 }
 
 fn connector_failure(

--- a/crates/traverse-runtime/src/executor/wasm.rs
+++ b/crates/traverse-runtime/src/executor/wasm.rs
@@ -5,13 +5,14 @@
 //! No ambient WASI authority is granted — all capabilities are deny-by-default.
 
 use chrono::Utc;
-use serde::Deserialize;
+use semver::{Version, VersionReq};
+use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use sha2::{Digest, Sha256};
 use std::collections::{HashMap, VecDeque};
 use std::fmt::Write as _;
 use std::fs;
-use std::sync::{LazyLock, Mutex};
+use std::sync::{Arc, LazyLock, Mutex};
 use uuid::Uuid;
 use wasmtime::{
     Caller, Config, Engine, Extern, Linker, Module, Store, StoreLimits, StoreLimitsBuilder,
@@ -22,7 +23,7 @@ use wasmtime_wasi::p2::pipe::{MemoryInputPipe, MemoryOutputPipe};
 
 use super::{ArtifactType, CapabilityExecutor, ExecutorCapability, ExecutorError, ExecutorOutput};
 use crate::events::types::{LifecycleStatus, TraverseEvent};
-use traverse_contracts::{EventReference, ServiceType};
+use traverse_contracts::{ConnectorRequirement, EventReference, ServiceType};
 
 /// Traverse Host ABI v1 is independently versioned from the runtime crate.
 pub const SUPPORTED_HOST_ABI_VERSION: &str = "1.0.0";
@@ -61,6 +62,49 @@ const EMIT_EVENT_ERR_NOT_SUBSCRIBABLE: i32 = -3;
 /// WASM executor deliberately returns this stable failure rather than granting
 /// any ambient authority (Spec 104 FR-002/FR-007).
 const CONNECTOR_INVOKE_ERR_UNBOUND: i32 = -2;
+const CONNECTOR_INVOKE_ERR_INVALID_REQUEST: i32 = -1;
+const CONNECTOR_INVOKE_ERR_UNDECLARED: i32 = -3;
+const CONNECTOR_INVOKE_ERR_UNAUTHORIZED: i32 = -4;
+const CONNECTOR_INVOKE_ERR_PAYLOAD_TOO_LARGE: i32 = -5;
+const CONNECTOR_INVOKE_ERR_EXECUTION_FAILED: i32 = -6;
+const MAX_CONNECTOR_INVOKE_REQUEST_BYTES: usize = 64 * 1024;
+const MAX_CONNECTOR_INVOKE_RESPONSE_BYTES: usize = 64 * 1024;
+
+/// Versioned guest request accepted by `traverse_host::connector_invoke`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ConnectorInvokeRequest {
+    pub abi_version: String,
+    pub connector_id: String,
+    pub operation: String,
+    pub payload: Value,
+}
+
+/// Non-secret response returned to the guest by a mediated connector.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ConnectorInvokeResponse {
+    pub abi_version: String,
+    pub result_class: String,
+    pub payload: Value,
+}
+
+/// A host-owned activated connector. Its implementation is never visible to a guest.
+pub trait MediatedConnector: Send + Sync {
+    fn invoke(&self, request: &ConnectorInvokeRequest) -> Result<ConnectorInvokeResponse, String>;
+}
+
+/// The host-owned authorization context for one WASM execution.
+#[derive(Clone)]
+pub struct MediatedConnectorContext {
+    pub declared_requirements: Vec<ConnectorRequirement>,
+    pub activated_connectors: Vec<ActivatedConnector>,
+}
+
+#[derive(Clone)]
+pub struct ActivatedConnector {
+    pub connector_id: String,
+    pub version: String,
+    pub implementation: Arc<dyn MediatedConnector>,
+}
 
 static HOST_ABI_V1_WHITELIST_CACHE: LazyLock<Result<HostAbiWhitelist, String>> =
     LazyLock::new(|| {
@@ -314,6 +358,7 @@ struct WasmStoreState {
     service_type: ServiceType,
     /// Events accepted via `traverse_host::emit_event` during this call.
     emitted_events: Vec<TraverseEvent>,
+    connector_context: Option<MediatedConnectorContext>,
 }
 
 impl CapabilityExecutor for WasmExecutor {
@@ -426,6 +471,27 @@ impl WasmExecutor {
         )
     }
 
+    /// Execute bytes with host-owned, activated connector bindings. This is the
+    /// only API that can enable `connector_invoke`; callers that do not supply
+    /// this context retain the deny-by-default handler.
+    pub fn run_bytes_with_mediated_connectors(
+        &self,
+        wasm_bytes: &[u8],
+        input: &Value,
+        capability_id: &str,
+        connector_context: MediatedConnectorContext,
+    ) -> Result<ExecutorOutput, ExecutorError> {
+        self.run_wasm_with_connectors(
+            wasm_bytes,
+            input,
+            SUPPORTED_HOST_ABI_VERSION,
+            capability_id,
+            &[],
+            ServiceType::Stateless,
+            Some(connector_context),
+        )
+    }
+
     #[allow(clippy::too_many_arguments)]
     fn run_wasm(
         &self,
@@ -435,6 +501,28 @@ impl WasmExecutor {
         capability_id: &str,
         emits: &[EventReference],
         service_type: ServiceType,
+    ) -> Result<ExecutorOutput, ExecutorError> {
+        self.run_wasm_with_connectors(
+            wasm_bytes,
+            input,
+            abi_version,
+            capability_id,
+            emits,
+            service_type,
+            None,
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn run_wasm_with_connectors(
+        &self,
+        wasm_bytes: &[u8],
+        input: &Value,
+        abi_version: &str,
+        capability_id: &str,
+        emits: &[EventReference],
+        service_type: ServiceType,
+        connector_context: Option<MediatedConnectorContext>,
     ) -> Result<ExecutorOutput, ExecutorError> {
         let input_json = serde_json::to_string(input)
             .map_err(|e| ExecutorError::ExecutionFailed(format!("input serialization: {e}")))?;
@@ -459,11 +547,7 @@ impl WasmExecutor {
             .func_wrap("traverse_host", "emit_event", handle_emit_event)
             .map_err(|e| ExecutorError::RuntimeSetupFailed(format!("func_wrap emit_event: {e}")))?;
         linker
-            .func_wrap(
-                "traverse_host",
-                "connector_invoke",
-                handle_connector_invoke_without_active_binding,
-            )
+            .func_wrap("traverse_host", "connector_invoke", handle_connector_invoke)
             .map_err(|e| {
                 ExecutorError::RuntimeSetupFailed(format!("func_wrap connector_invoke: {e}"))
             })?;
@@ -477,6 +561,7 @@ impl WasmExecutor {
                 emits: emits.to_vec(),
                 service_type,
                 emitted_events: Vec::new(),
+                connector_context,
             },
         );
         store.limiter(|state| &mut state.limits);
@@ -652,14 +737,126 @@ fn handle_emit_event(mut caller: Caller<'_, WasmStoreState>, ptr: i32, len: i32)
 /// response pointer/capacity. This default handler intentionally neither reads
 /// nor writes guest memory: no request data, host configuration, credentials,
 /// paths, or endpoint can cross the boundary before authorization exists.
-fn handle_connector_invoke_without_active_binding(
-    _caller: Caller<'_, WasmStoreState>,
-    _request_ptr: i32,
-    _request_len: i32,
-    _response_ptr: i32,
-    _response_capacity: i32,
+fn handle_connector_invoke(
+    mut caller: Caller<'_, WasmStoreState>,
+    request_ptr: i32,
+    request_len: i32,
+    response_ptr: i32,
+    response_capacity: i32,
 ) -> i32 {
-    CONNECTOR_INVOKE_ERR_UNBOUND
+    if request_ptr < 0 || request_len < 0 || response_ptr < 0 || response_capacity < 0 {
+        return CONNECTOR_INVOKE_ERR_INVALID_REQUEST;
+    }
+    #[allow(clippy::cast_sign_loss)]
+    let (request_ptr, request_len, response_ptr, response_capacity) = (
+        request_ptr as usize,
+        request_len as usize,
+        response_ptr as usize,
+        response_capacity as usize,
+    );
+    if request_len > MAX_CONNECTOR_INVOKE_REQUEST_BYTES
+        || response_capacity > MAX_CONNECTOR_INVOKE_RESPONSE_BYTES
+    {
+        return CONNECTOR_INVOKE_ERR_PAYLOAD_TOO_LARGE;
+    }
+    let Some(Extern::Memory(memory)) = caller.get_export("memory") else {
+        return CONNECTOR_INVOKE_ERR_INVALID_REQUEST;
+    };
+    let mut bytes = vec![0_u8; request_len];
+    if memory.read(&caller, request_ptr, &mut bytes).is_err() {
+        return CONNECTOR_INVOKE_ERR_INVALID_REQUEST;
+    }
+    let Ok(request) = serde_json::from_slice::<ConnectorInvokeRequest>(&bytes) else {
+        return CONNECTOR_INVOKE_ERR_INVALID_REQUEST;
+    };
+    if request.abi_version != SUPPORTED_HOST_ABI_VERSION
+        || request.connector_id.is_empty()
+        || request.operation.is_empty()
+        || contains_host_private_data(&request.payload)
+    {
+        return CONNECTOR_INVOKE_ERR_INVALID_REQUEST;
+    }
+    let Some(context) = caller.data().connector_context.clone() else {
+        return CONNECTOR_INVOKE_ERR_UNBOUND;
+    };
+    if !context
+        .declared_requirements
+        .iter()
+        .any(|requirement| requirement.connector_id == request.connector_id)
+    {
+        return CONNECTOR_INVOKE_ERR_UNDECLARED;
+    }
+    let Some(connector) = context
+        .activated_connectors
+        .iter()
+        .find(|connector| connector.connector_id == request.connector_id)
+    else {
+        return CONNECTOR_INVOKE_ERR_UNBOUND;
+    };
+    let compatible = context
+        .declared_requirements
+        .iter()
+        .filter(|requirement| requirement.connector_id == request.connector_id)
+        .any(|requirement| {
+            VersionReq::parse(&requirement.version)
+                .ok()
+                .zip(Version::parse(&connector.version).ok())
+                .is_some_and(|(range, version)| range.matches(&version))
+        });
+    if !compatible {
+        return CONNECTOR_INVOKE_ERR_UNAUTHORIZED;
+    }
+    let Ok(response) = connector.implementation.invoke(&request) else {
+        return CONNECTOR_INVOKE_ERR_EXECUTION_FAILED;
+    };
+    if response.abi_version != SUPPORTED_HOST_ABI_VERSION
+        || response.result_class.is_empty()
+        || contains_host_private_data(&response.payload)
+    {
+        return CONNECTOR_INVOKE_ERR_UNAUTHORIZED;
+    }
+    let Ok(response_bytes) = serde_json::to_vec(&response) else {
+        return CONNECTOR_INVOKE_ERR_EXECUTION_FAILED;
+    };
+    if response_bytes.len() > response_capacity
+        || response_bytes.len() > MAX_CONNECTOR_INVOKE_RESPONSE_BYTES
+    {
+        return CONNECTOR_INVOKE_ERR_PAYLOAD_TOO_LARGE;
+    }
+    if memory
+        .write(&mut caller, response_ptr, &response_bytes)
+        .is_err()
+    {
+        return CONNECTOR_INVOKE_ERR_INVALID_REQUEST;
+    }
+    #[allow(clippy::cast_possible_truncation)]
+    {
+        response_bytes.len() as i32
+    }
+}
+
+fn contains_host_private_data(value: &Value) -> bool {
+    match value {
+        Value::Object(map) => map.iter().any(|(key, value)| {
+            let key = key.to_ascii_lowercase();
+            [
+                "config",
+                "credential",
+                "secret",
+                "password",
+                "path",
+                "device",
+                "endpoint",
+                "bucket",
+            ]
+            .iter()
+            .any(|needle| key.contains(needle))
+                || contains_host_private_data(value)
+        }),
+        Value::Array(values) => values.iter().any(contains_host_private_data),
+        Value::String(value) => value.starts_with('/') || value.contains("://"),
+        _ => false,
+    }
 }
 
 fn classify_wasm_execution_error(error: &wasmtime::Error) -> ExecutorError {

--- a/crates/traverse-runtime/src/executor/wasm.rs
+++ b/crates/traverse-runtime/src/executor/wasm.rs
@@ -559,11 +559,10 @@ impl WasmExecutor {
         linker
             .func_wrap("traverse_host", "emit_event", handle_emit_event)
             .map_err(|e| ExecutorError::RuntimeSetupFailed(format!("func_wrap emit_event: {e}")))?;
+        #[allow(clippy::expect_used)]
         linker
             .func_wrap("traverse_host", "connector_invoke", handle_connector_invoke)
-            .map_err(|e| {
-                ExecutorError::RuntimeSetupFailed(format!("func_wrap connector_invoke: {e}"))
-            })?;
+            .expect("connector_invoke host function registration should not conflict");
 
         let mut store = Store::new(
             &self.engine,
@@ -942,15 +941,9 @@ fn invoke_activated_connector(
             CONNECTOR_INVOKE_ERR_UNAUTHORIZED,
         );
     }
-    let Ok(response_bytes) = serde_json::to_vec(&response) else {
-        return connector_failure(
-            caller,
-            &request.connector_id,
-            Some(&connector.version),
-            "execution_failed",
-            CONNECTOR_INVOKE_ERR_EXECUTION_FAILED,
-        );
-    };
+    #[allow(clippy::expect_used)]
+    let response_bytes =
+        serde_json::to_vec(&response).expect("connector response uses serializable JSON value");
     if response_bytes.len() > response_capacity
         || response_bytes.len() > MAX_CONNECTOR_INVOKE_RESPONSE_BYTES
     {
@@ -983,7 +976,10 @@ fn invoke_activated_connector(
             result_class: response.result_class,
             failure_class: None,
         });
-    i32::try_from(response_bytes.len()).unwrap_or(CONNECTOR_INVOKE_ERR_PAYLOAD_TOO_LARGE)
+    #[allow(clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
+    {
+        response_bytes.len() as i32
+    }
 }
 
 fn connector_failure(

--- a/crates/traverse-runtime/src/lib.rs
+++ b/crates/traverse-runtime/src/lib.rs
@@ -1716,6 +1716,7 @@ where
         Ok(ExecutorOutput {
             value: output.value,
             emitted_events: output.emitted_events,
+            connector_invocation_evidence: Vec::new(),
         })
     }
 }

--- a/crates/traverse-runtime/tests/executor_tests.rs
+++ b/crates/traverse-runtime/tests/executor_tests.rs
@@ -500,6 +500,31 @@ fn wasm_host_abi_verifier_accepts_sanctioned_stdio_imports() -> Result<(), Strin
 }
 
 #[test]
+fn wasm_host_abi_verifier_accepts_versioned_connector_invoke_import() -> Result<(), String> {
+    let wasm_bytes = wat::parse_str(
+        r#"
+        (module
+            (import "traverse_host" "connector_invoke"
+                (func $connector_invoke (param i32 i32 i32 i32) (result i32)))
+            (memory (export "memory") 1)
+            (func $_start (export "_start"))
+        )
+        "#,
+    )
+    .map_err(|error| format!("WAT parse: {error}"))?;
+
+    let validation = verify_wasm_host_abi_bytes(&wasm_bytes, SUPPORTED_HOST_ABI_VERSION)
+        .map_err(|error| format!("{error:?}"))?;
+
+    assert!(
+        validation.imports.iter().any(|import| {
+            import.module == "traverse_host" && import.name == "connector_invoke"
+        })
+    );
+    Ok(())
+}
+
+#[test]
 fn wasm_host_abi_verifier_rejects_unauthorized_import_before_execution() -> Result<(), String> {
     let wat_src = r#"
         (module

--- a/crates/traverse-runtime/tests/executor_tests.rs
+++ b/crates/traverse-runtime/tests/executor_tests.rs
@@ -1,12 +1,14 @@
 use serde_json::json;
 use sha2::{Digest, Sha256};
 use std::fmt::Write as _;
+use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
-use traverse_contracts::{EventReference, ServiceType};
+use traverse_contracts::{ConnectorRequirement, EventReference, ServiceType};
 use traverse_runtime::executor::{
-    ArtifactType, CapabilityExecutor, ExecutorCapability, ExecutorError, ExecutorOutput,
-    NativeExecutor, SUPPORTED_HOST_ABI_VERSION, WasmExecutionLimits, WasmExecutor,
-    WasmModuleCacheConfig, supported_host_abi_versions, verify_wasm_host_abi_bytes,
+    ActivatedConnector, ArtifactType, CapabilityExecutor, ConnectorInvokeRequest,
+    ConnectorInvokeResponse, ExecutorCapability, ExecutorError, ExecutorOutput, MediatedConnector,
+    MediatedConnectorContext, NativeExecutor, SUPPORTED_HOST_ABI_VERSION, WasmExecutionLimits,
+    WasmExecutor, WasmModuleCacheConfig, supported_host_abi_versions, verify_wasm_host_abi_bytes,
 };
 
 // --- NativeExecutor tests ---
@@ -521,6 +523,55 @@ fn wasm_host_abi_verifier_accepts_versioned_connector_invoke_import() -> Result<
             import.module == "traverse_host" && import.name == "connector_invoke"
         })
     );
+    Ok(())
+}
+
+struct TestConnector;
+
+impl MediatedConnector for TestConnector {
+    fn invoke(&self, request: &ConnectorInvokeRequest) -> Result<ConnectorInvokeResponse, String> {
+        Ok(ConnectorInvokeResponse {
+            abi_version: SUPPORTED_HOST_ABI_VERSION.to_string(),
+            result_class: "success".to_string(),
+            payload: json!({"request_id": request.payload["id"]}),
+        })
+    }
+}
+
+#[test]
+fn wasm_connector_invoke_requires_declaration_and_activation() -> Result<(), String> {
+    let wasm_bytes = wat::parse_str(
+        r#"
+        (module
+          (import "wasi_snapshot_preview1" "fd_write" (func $write (param i32 i32 i32 i32) (result i32)))
+          (import "traverse_host" "connector_invoke" (func $invoke (param i32 i32 i32 i32) (result i32)))
+          (memory (export "memory") 1)
+          (data (i32.const 32) "{\"abi_version\":\"1.0.0\",\"connector_id\":\"traverse.test\",\"operation\":\"read\",\"payload\":{\"id\":\"x\"}}")
+          (func $_start (export "_start") (local $len i32)
+            i32.const 32 i32.const 94 i32.const 256 i32.const 1024 call $invoke local.set $len
+            i32.const 4 i32.const 256 i32.store
+            i32.const 8 local.get $len i32.store
+            i32.const 1 i32.const 4 i32.const 1 i32.const 12 call $write drop))
+        "#,
+    )
+    .map_err(|error| format!("WAT parse: {error}"))?;
+    let executor = WasmExecutor::new().map_err(|error| format!("{error:?}"))?;
+    let context = MediatedConnectorContext {
+        declared_requirements: vec![ConnectorRequirement {
+            connector_id: "traverse.test".to_string(),
+            version: "^1.0.0".to_string(),
+        }],
+        activated_connectors: vec![ActivatedConnector {
+            connector_id: "traverse.test".to_string(),
+            version: "1.0.0".to_string(),
+            implementation: Arc::new(TestConnector),
+        }],
+    };
+    let output = executor
+        .run_bytes_with_mediated_connectors(&wasm_bytes, &json!({}), "test", context)
+        .map_err(|error| format!("{error:?}"))?;
+    assert_eq!(output.value["result_class"], "success");
+    assert_eq!(output.value["payload"]["request_id"], "x");
     Ok(())
 }
 

--- a/crates/traverse-runtime/tests/executor_tests.rs
+++ b/crates/traverse-runtime/tests/executor_tests.rs
@@ -30,6 +30,7 @@ fn native_executor_runs_handler() {
         Ok(ExecutorOutput {
             value: json!({ "greeting": "hello, traverse!" }),
             emitted_events: Vec::new(),
+            connector_invocation_evidence: Vec::new(),
         })
     );
 }
@@ -572,6 +573,22 @@ fn wasm_connector_invoke_requires_declaration_and_activation() -> Result<(), Str
         .map_err(|error| format!("{error:?}"))?;
     assert_eq!(output.value["result_class"], "success");
     assert_eq!(output.value["payload"]["request_id"], "x");
+    assert_eq!(output.connector_invocation_evidence.len(), 1);
+    assert_eq!(
+        output.connector_invocation_evidence[0].connector_id,
+        "traverse.test"
+    );
+    assert_eq!(
+        output.connector_invocation_evidence[0]
+            .resolved_version
+            .as_deref(),
+        Some("1.0.0")
+    );
+    assert_eq!(
+        output.connector_invocation_evidence[0].result_class,
+        "success"
+    );
+    assert_eq!(output.connector_invocation_evidence[0].failure_class, None);
     Ok(())
 }
 
@@ -772,6 +789,7 @@ fn wasm_executor_full_execute_path_via_disk() -> Result<(), String> {
         Ok(ExecutorOutput {
             value: input,
             emitted_events: Vec::new(),
+            connector_invocation_evidence: Vec::new(),
         })
     );
     Ok(())
@@ -831,6 +849,7 @@ fn wasm_executor_execute_with_matching_checksum_succeeds() -> Result<(), String>
         Ok(ExecutorOutput {
             value: json!({}),
             emitted_events: Vec::new(),
+            connector_invocation_evidence: Vec::new(),
         })
     );
     Ok(())

--- a/crates/traverse-runtime/tests/executor_tests.rs
+++ b/crates/traverse-runtime/tests/executor_tests.rs
@@ -539,6 +539,338 @@ impl MediatedConnector for TestConnector {
     }
 }
 
+enum ConnectorOutcome {
+    Fails,
+    UnsafeOutput,
+    LargeOutput,
+}
+
+struct OutcomeConnector(ConnectorOutcome);
+
+impl MediatedConnector for OutcomeConnector {
+    fn invoke(&self, _request: &ConnectorInvokeRequest) -> Result<ConnectorInvokeResponse, String> {
+        match self.0 {
+            ConnectorOutcome::Fails => Err("connector failed".to_string()),
+            ConnectorOutcome::UnsafeOutput => Ok(ConnectorInvokeResponse {
+                abi_version: SUPPORTED_HOST_ABI_VERSION.to_string(),
+                result_class: "success".to_string(),
+                payload: json!({"secret": "must not cross the ABI"}),
+            }),
+            ConnectorOutcome::LargeOutput => Ok(ConnectorInvokeResponse {
+                abi_version: SUPPORTED_HOST_ABI_VERSION.to_string(),
+                result_class: "success".to_string(),
+                payload: json!({"value": "x".repeat(1024)}),
+            }),
+        }
+    }
+}
+
+fn connector_test_wasm(
+    request: &str,
+    request_ptr: i32,
+    request_len: i32,
+    response_ptr: i32,
+    response_capacity: i32,
+) -> Result<Vec<u8>, String> {
+    let escaped_request = request.replace('\\', "\\\\").replace('"', "\\\"");
+    wat::parse_str(format!(
+        r#"
+        (module
+          (import "wasi_snapshot_preview1" "fd_write" (func $write (param i32 i32 i32 i32) (result i32)))
+          (import "traverse_host" "connector_invoke" (func $invoke (param i32 i32 i32 i32) (result i32)))
+          (memory (export "memory") 1)
+          (data (i32.const 32) "{escaped_request}")
+          (data (i32.const 2048) "0")
+          (func $_start (export "_start")
+            i32.const {request_ptr} i32.const {request_len} i32.const {response_ptr} i32.const {response_capacity} call $invoke drop
+            i32.const 4 i32.const 2048 i32.store
+            i32.const 8 i32.const 1 i32.store
+            i32.const 1 i32.const 4 i32.const 1 i32.const 12 call $write drop)
+        )
+        "#
+    ))
+    .map_err(|error| format!("WAT parse: {error}"))
+}
+
+fn connector_context(
+    connector: Arc<dyn MediatedConnector>,
+    version: &str,
+) -> MediatedConnectorContext {
+    MediatedConnectorContext {
+        declared_requirements: vec![ConnectorRequirement {
+            connector_id: "traverse.test".to_string(),
+            version: "^1.0.0".to_string(),
+        }],
+        activated_connectors: vec![ActivatedConnector {
+            connector_id: "traverse.test".to_string(),
+            version: version.to_string(),
+            implementation: connector,
+        }],
+    }
+}
+
+fn declared_connector_context() -> MediatedConnectorContext {
+    MediatedConnectorContext {
+        declared_requirements: vec![ConnectorRequirement {
+            connector_id: "traverse.test".to_string(),
+            version: "^1.0.0".to_string(),
+        }],
+        activated_connectors: Vec::new(),
+    }
+}
+
+const VALID_CONNECTOR_REQUEST: &str = r#"{"abi_version":"1.0.0","connector_id":"traverse.test","operation":"read","payload":{"id":"x"}}"#;
+
+fn valid_connector_request_len() -> Result<i32, String> {
+    i32::try_from(VALID_CONNECTOR_REQUEST.len())
+        .map_err(|error| format!("request length conversion: {error}"))
+}
+
+#[test]
+fn wasm_connector_invoke_denies_invalid_requests() -> Result<(), String> {
+    let valid_request_len = valid_connector_request_len()?;
+    let executor = WasmExecutor::new().map_err(|error| format!("{error:?}"))?;
+
+    let invalid_requests = vec![
+        ("not-json", 32, 8, 256, 64),
+        (
+            r#"{"abi_version":"2.0.0","connector_id":"traverse.test","operation":"read","payload":{}}"#,
+            32,
+            0,
+            256,
+            64,
+        ),
+        (
+            r#"{"abi_version":"1.0.0","connector_id":"","operation":"read","payload":{}}"#,
+            32,
+            0,
+            256,
+            64,
+        ),
+        (
+            r#"{"abi_version":"1.0.0","connector_id":"traverse.test","operation":"","payload":{}}"#,
+            32,
+            0,
+            256,
+            64,
+        ),
+        (
+            r#"{"abi_version":"1.0.0","connector_id":"traverse.test","operation":"read","payload":{"path":"/private"}}"#,
+            32,
+            0,
+            256,
+            64,
+        ),
+        (
+            r#"{"abi_version":"1.0.0","connector_id":"traverse.test","operation":"read","payload":{"items":["https://example.test"]}}"#,
+            32,
+            0,
+            256,
+            64,
+        ),
+        (VALID_CONNECTOR_REQUEST, -1, 1, 256, 64),
+        (VALID_CONNECTOR_REQUEST, 65_535, 10, 256, 64),
+        (VALID_CONNECTOR_REQUEST, 32, valid_request_len, 256, 65_537),
+    ];
+
+    for (request, request_ptr, request_len, response_ptr, response_capacity) in invalid_requests {
+        let request_len = if request_len == 0 {
+            i32::try_from(request.len())
+                .map_err(|error| format!("request length conversion: {error}"))?
+        } else {
+            request_len
+        };
+        let wasm = connector_test_wasm(
+            request,
+            request_ptr,
+            request_len,
+            response_ptr,
+            response_capacity,
+        )?;
+        let output = executor
+            .run_bytes_with_mediated_connectors(
+                &wasm,
+                &json!({}),
+                "test",
+                connector_context(Arc::new(TestConnector), "1.0.0"),
+            )
+            .map_err(|error| format!("{error:?}"))?;
+        assert_eq!(output.value, json!(0));
+    }
+
+    Ok(())
+}
+
+#[test]
+fn wasm_connector_invoke_accepts_numeric_payload_values() -> Result<(), String> {
+    let numeric_payload_request = r#"{"abi_version":"1.0.0","connector_id":"traverse.test","operation":"read","payload":{"id":1}}"#;
+    let numeric_payload_request_len = i32::try_from(numeric_payload_request.len())
+        .map_err(|error| format!("request length conversion: {error}"))?;
+    let wasm = connector_test_wasm(
+        numeric_payload_request,
+        32,
+        numeric_payload_request_len,
+        256,
+        64,
+    )?;
+    let executor = WasmExecutor::new().map_err(|error| format!("{error:?}"))?;
+    let output = executor
+        .run_bytes_with_mediated_connectors(
+            &wasm,
+            &json!({}),
+            "test",
+            connector_context(Arc::new(TestConnector), "1.0.0"),
+        )
+        .map_err(|error| format!("{error:?}"))?;
+    assert_eq!(output.value, json!(0));
+    Ok(())
+}
+
+#[test]
+fn wasm_connector_invoke_denies_modules_without_memory() -> Result<(), String> {
+    let wasm_without_memory = wat::parse_str(
+        r#"
+        (module
+          (import "traverse_host" "connector_invoke" (func $invoke (param i32 i32 i32 i32) (result i32)))
+          (func $_start (export "_start")
+            i32.const 0 i32.const 0 i32.const 0 i32.const 0 call $invoke drop))
+        "#,
+    )
+    .map_err(|error| format!("WAT parse: {error}"))?;
+    let executor = WasmExecutor::new().map_err(|error| format!("{error:?}"))?;
+    let err = expect_err(
+        executor.run_bytes_with_mediated_connectors(
+            &wasm_without_memory,
+            &json!({}),
+            "test",
+            connector_context(Arc::new(TestConnector), "1.0.0"),
+        ),
+        "expected invalid stdout after connector_invoke without memory",
+    )?;
+    assert!(
+        matches!(err, ExecutorError::OutputDeserializationFailed(_)),
+        "expected OutputDeserializationFailed, got {err:?}"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn wasm_connector_invoke_records_unbound_and_undeclared_failures() -> Result<(), String> {
+    let valid_request_len = valid_connector_request_len()?;
+    let executor = WasmExecutor::new().map_err(|error| format!("{error:?}"))?;
+    let wasm = connector_test_wasm(VALID_CONNECTOR_REQUEST, 32, valid_request_len, 256, 64)?;
+    let unbound = executor
+        .run_bytes_with_capability(&wasm, &json!({}), "test", &[], ServiceType::Stateless)
+        .map_err(|error| format!("{error:?}"))?;
+    assert_eq!(
+        unbound.connector_invocation_evidence[0]
+            .failure_class
+            .as_deref(),
+        Some("unbound")
+    );
+
+    let undeclared_request = VALID_CONNECTOR_REQUEST.replace("traverse.test", "other.test");
+    let undeclared_request_len = i32::try_from(undeclared_request.len())
+        .map_err(|error| format!("request length conversion: {error}"))?;
+    let wasm = connector_test_wasm(&undeclared_request, 32, undeclared_request_len, 256, 64)?;
+    let undeclared = executor
+        .run_bytes_with_mediated_connectors(
+            &wasm,
+            &json!({}),
+            "test",
+            connector_context(Arc::new(TestConnector), "1.0.0"),
+        )
+        .map_err(|error| format!("{error:?}"))?;
+    assert_eq!(
+        undeclared.connector_invocation_evidence[0]
+            .failure_class
+            .as_deref(),
+        Some("undeclared")
+    );
+
+    let wasm = connector_test_wasm(VALID_CONNECTOR_REQUEST, 32, valid_request_len, 256, 64)?;
+    let declared_unbound = executor
+        .run_bytes_with_mediated_connectors(&wasm, &json!({}), "test", declared_connector_context())
+        .map_err(|error| format!("{error:?}"))?;
+    assert_eq!(
+        declared_unbound.connector_invocation_evidence[0]
+            .failure_class
+            .as_deref(),
+        Some("unbound")
+    );
+
+    Ok(())
+}
+
+#[test]
+fn wasm_connector_invoke_records_activated_connector_failures() -> Result<(), String> {
+    let valid_request_len = valid_connector_request_len()?;
+    let executor = WasmExecutor::new().map_err(|error| format!("{error:?}"))?;
+
+    for (connector, version, response_ptr, response_capacity, failure_class) in [
+        (
+            Arc::new(TestConnector) as Arc<dyn MediatedConnector>,
+            "2.0.0",
+            256,
+            64,
+            "incompatible",
+        ),
+        (
+            Arc::new(OutcomeConnector(ConnectorOutcome::Fails)) as Arc<dyn MediatedConnector>,
+            "1.0.0",
+            256,
+            64,
+            "execution_failed",
+        ),
+        (
+            Arc::new(OutcomeConnector(ConnectorOutcome::UnsafeOutput))
+                as Arc<dyn MediatedConnector>,
+            "1.0.0",
+            256,
+            64,
+            "unauthorized_output",
+        ),
+        (
+            Arc::new(OutcomeConnector(ConnectorOutcome::LargeOutput)) as Arc<dyn MediatedConnector>,
+            "1.0.0",
+            256,
+            1,
+            "bounded_io",
+        ),
+        (
+            Arc::new(TestConnector) as Arc<dyn MediatedConnector>,
+            "1.0.0",
+            65_535,
+            1_024,
+            "invalid_response_memory",
+        ),
+    ] {
+        let wasm = connector_test_wasm(
+            VALID_CONNECTOR_REQUEST,
+            32,
+            valid_request_len,
+            response_ptr,
+            response_capacity,
+        )?;
+        let output = executor
+            .run_bytes_with_mediated_connectors(
+                &wasm,
+                &json!({}),
+                "test",
+                connector_context(connector, version),
+            )
+            .map_err(|error| format!("{error:?}"))?;
+        assert_eq!(
+            output.connector_invocation_evidence[0]
+                .failure_class
+                .as_deref(),
+            Some(failure_class)
+        );
+    }
+    Ok(())
+}
+
 #[test]
 fn wasm_connector_invoke_requires_declaration_and_activation() -> Result<(), String> {
     let wasm_bytes = wat::parse_str(

--- a/crates/traverse-runtime/tests/router_tests.rs
+++ b/crates/traverse-runtime/tests/router_tests.rs
@@ -148,6 +148,7 @@ impl CapabilityExecutor for EventEmittingExecutor {
         Ok(ExecutorOutput {
             value: self.output.clone(),
             emitted_events: self.emitted_events.clone(),
+            connector_invocation_evidence: Vec::new(),
         })
     }
 }


### PR DESCRIPTION
## Summary

Implements the versioned, bounded `traverse_host::connector_invoke` mediation path for WASM guests.

The runtime accepts a host-owned activation context only for the explicit mediated execution entry point. It validates guest memory, request and response envelope versions, declared connector requirements, activated connector selection, semver compatibility, output bounds, and host-private data redaction before writing a result into guest memory.

## Security boundary

The default executor path remains deny-by-default. Guests receive neither host configuration nor ambient filesystem, network, environment, clock, or device access. The mediated handler rejects private configuration and ambient host identifiers in guest-visible requests and responses.

## Governing Spec

- `039-connector-plugin-architecture`
- `038-wasi-host-insulation`
- `098-capability-event-host-abi`
- `103-application-connector-binding`
- `104-mediated-connector-invocation`

## Project Item

- [#1056](https://github.com/traverse-framework/traverse/issues/1056)

## Validation

- `cargo test -p traverse-runtime`
- `cargo test -p traverse-contracts`

Closes #1056.
