### PR TITLE
feat(cli,runtime): bump traverse-registry to 0.15.0, wire resolve usage-telemetry hook

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2693,9 +2693,9 @@ dependencies = [
 
 [[package]]
 name = "traverse-registry"
-version = "0.14.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "193735d5b0f1cf10edfe7a61f9247e4bb8d718a93a8945cec139cf4e39e5f7f7"
+checksum = "5006c40e012370afec3427a7fcb164c9285bdc0f6469003b859cc086ecd9f001"
 dependencies = [
  "semver",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ version = "0.9.1"
 
 [workspace.dependencies]
 traverse-contracts = { path = "crates/traverse-contracts", version = "0.9.1" }
-traverse-registry = { version = "=0.14.0" }
+traverse-registry = { version = "=0.15.0" }
 traverse-runtime = { path = "crates/traverse-runtime", version = "0.9.1" }
 
 # The published registry crate pins the current contracts release.  During

--- a/crates/traverse-cli/src/app_runtime_events.rs
+++ b/crates/traverse-cli/src/app_runtime_events.rs
@@ -141,7 +141,10 @@ pub(crate) fn runtime_with_app_event_broker<E: LocalExecutor + Clone>(
     Ok(Runtime::new(registry, executor)
         .with_workflow_registry(workflow_registry)
         .with_security_config(security)
-        .with_event_broker(broker))
+        .with_event_broker(broker)
+        .with_usage_telemetry_sink(std::sync::Arc::from(
+            crate::telemetry::wire_usage_telemetry_sink(),
+        )))
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/crates/traverse-cli/src/http_api.rs
+++ b/crates/traverse-cli/src/http_api.rs
@@ -3040,6 +3040,9 @@ fn load_workspace_app_runtime<E: LocalExecutor + Clone>(
         env!("CARGO_PKG_VERSION"),
     ) {
         Ok(runtime) => {
+            let runtime = runtime.with_usage_telemetry_sink(std::sync::Arc::from(
+                crate::telemetry::wire_usage_telemetry_sink(),
+            ));
             let machines = load_workspace_app_state_machines(workspace_root, &runtime);
             ws.app_list_context_fields = machines
                 .iter()

--- a/crates/traverse-cli/src/main.rs
+++ b/crates/traverse-cli/src/main.rs
@@ -5062,12 +5062,14 @@ fn execute_capability_package(
     registry
         .register(package.capability_registration())
         .map_err(|f| CliError::RegistrationConflict(render_registry_failure(f)))?;
+    let sink: std::sync::Arc<dyn traverse_contracts::UsageTelemetrySink> =
+        std::sync::Arc::from(telemetry::wire_usage_telemetry_sink());
     let runtime = Runtime::new(
         registry,
         ArtifactRouter::new().map_err(|error| CliError::ExecutionFailed(error.message))?,
     )
-    .with_security_config(traverse_runtime::security::RuntimeSecurityConfig::development());
-    let sink = telemetry::wire_usage_telemetry_sink();
+    .with_security_config(traverse_runtime::security::RuntimeSecurityConfig::development())
+    .with_usage_telemetry_sink(sink.clone());
     let outcome = telemetry::execute_with_telemetry(&runtime, request, sink.as_ref());
 
     if outcome.result.status == RuntimeResultStatus::Error {

--- a/crates/traverse-runtime/src/lib.rs
+++ b/crates/traverse-runtime/src/lib.rs
@@ -40,15 +40,16 @@ use std::path::Path;
 use std::sync::{Arc, Mutex};
 use trace::TraceStore;
 use traverse_contracts::{
-    EventReference, ExecutionTarget, HostApiAccess, Lifecycle, NetworkAccess, ServiceType,
-    ViolationRecord,
+    EventReference, ExecutionTarget, HostApiAccess, Lifecycle, NetworkAccess,
+    NoOpUsageTelemetrySink, ServiceType, UsageTelemetrySink, ViolationRecord,
 };
 use traverse_registry::{
     CapabilityRegistration, CapabilityRegistry, DiscoveryQuery, ImplementationKind, LookupScope,
     ModelResolutionEvidence, RegistrationOutcome, RegistryFailure, RegistryScope, ResolutionError,
-    ResolvedCapability, WorkflowFailure, WorkflowRegistration, WorkflowRegistrationOutcome,
-    WorkflowRegistry, WorkspaceAppStateFailure, WorkspaceApplicationRegistration,
-    load_workspace_application_registries, resolve_dependencies, resolve_version_range,
+    ResolveTelemetry, ResolvedCapability, WorkflowFailure, WorkflowRegistration,
+    WorkflowRegistrationOutcome, WorkflowRegistry, WorkspaceAppStateFailure,
+    WorkspaceApplicationRegistration, load_workspace_application_registries, resolve_dependencies,
+    resolve_version_range,
 };
 use uuid::Uuid;
 
@@ -81,6 +82,7 @@ pub struct Runtime<E> {
     event_sink: Arc<dyn RuntimeEventSink>,
     trace_store: Arc<Mutex<TraceStore>>,
     event_broker: Arc<dyn EventBroker>,
+    usage_telemetry_sink: Arc<dyn UsageTelemetrySink>,
 }
 
 impl<E: Clone> Clone for Runtime<E> {
@@ -95,6 +97,7 @@ impl<E: Clone> Clone for Runtime<E> {
             event_sink: Arc::clone(&self.event_sink),
             trace_store: Arc::clone(&self.trace_store),
             event_broker: Arc::clone(&self.event_broker),
+            usage_telemetry_sink: Arc::clone(&self.usage_telemetry_sink),
         }
     }
 }
@@ -111,6 +114,7 @@ impl<E: fmt::Debug> fmt::Debug for Runtime<E> {
             .field("event_sink", &self.event_sink)
             .field("trace_store", &self.trace_store)
             .field("event_broker", &"Arc<dyn EventBroker>")
+            .field("usage_telemetry_sink", &"Arc<dyn UsageTelemetrySink>")
             .finish()
     }
 }
@@ -128,6 +132,7 @@ impl<E> Runtime<E> {
             event_sink: Arc::new(NoopRuntimeEventSink),
             trace_store: Arc::new(Mutex::new(TraceStore::new())),
             event_broker: default_event_broker(),
+            usage_telemetry_sink: Arc::new(NoOpUsageTelemetrySink),
         }
     }
 
@@ -194,6 +199,18 @@ impl<E> Runtime<E> {
     #[must_use]
     pub fn with_event_broker(mut self, event_broker: Arc<dyn EventBroker>) -> Self {
         self.event_broker = event_broker;
+        self
+    }
+
+    /// Injects the [`UsageTelemetrySink`] used to record a `resolve` event
+    /// (spec `015-runtime-usage-telemetry-resolve-hook`) whenever
+    /// [`collect_candidates`](Self::collect_candidates) resolves a
+    /// capability through a semver range. Defaults to
+    /// [`NoOpUsageTelemetrySink`], so no caller takes on a network or
+    /// configuration dependency merely by constructing a [`Runtime`].
+    #[must_use]
+    pub fn with_usage_telemetry_sink(mut self, sink: Arc<dyn UsageTelemetrySink>) -> Self {
+        self.usage_telemetry_sink = sink;
         self
     }
 
@@ -1311,11 +1328,16 @@ where
         ) && non_empty(capability_id)
             && non_empty(range_str)
         {
+            let resolved_at = Utc::now().to_rfc3339();
             return match resolve_version_range(
                 &self.registry,
                 capability_id,
                 range_str,
                 lookup_scope,
+                Some(ResolveTelemetry {
+                    sink: self.usage_telemetry_sink.as_ref(),
+                    resolved_at: &resolved_at,
+                }),
             ) {
                 Ok(resolved) => {
                     let entry_lookup = match resolved.scope {

--- a/crates/traverse-runtime/tests/runtime.rs
+++ b/crates/traverse-runtime/tests/runtime.rs
@@ -1,9 +1,11 @@
 use serde_json::{Value, json};
+use std::sync::{Arc, Mutex};
 use traverse_contracts::{
     BinaryFormat as ContractBinaryFormat, Condition, DependencyReference, Entrypoint,
     EntrypointKind, EventReference, Execution, ExecutionConstraints, ExecutionTarget,
     FilesystemAccess, HostApiAccess, IdReference, Lifecycle, NetworkAccess, Owner, Provenance,
-    ProvenanceSource, SchemaContainer, SideEffect, SideEffectKind,
+    ProvenanceSource, SchemaContainer, SideEffect, SideEffectKind, UsageEvent, UsageEventKind,
+    UsageTelemetrySink,
 };
 use traverse_registry::{
     ArtifactDigests, BinaryFormat, BinaryReference, CapabilityArtifactRecord,
@@ -656,6 +658,88 @@ fn executes_capability_resolved_via_semver_range() {
         Some(json!({"draft_id": "draft-001"}))
     );
     assert_eq!(outcome.trace.selection.status, SelectionStatus::Selected);
+}
+
+#[derive(Default)]
+struct SpyUsageTelemetrySink {
+    events: Arc<Mutex<Vec<UsageEvent>>>,
+}
+
+impl UsageTelemetrySink for SpyUsageTelemetrySink {
+    fn record(&self, event: UsageEvent) {
+        self.events
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .push(event);
+    }
+}
+
+#[test]
+fn semver_range_resolution_records_a_resolve_usage_telemetry_event() {
+    // Spec 015-runtime-usage-telemetry-resolve-hook / issue #930: a
+    // capability_id + version_range request resolved through
+    // `resolve_version_range` must fire exactly one `resolve` event through
+    // whatever `UsageTelemetrySink` the `Runtime` was configured with.
+    let sink = SpyUsageTelemetrySink::default();
+    let events = Arc::clone(&sink.events);
+    let runtime = Runtime::new(
+        registry_with(vec![registration(
+            RegistryScope::Private,
+            "content.comments.create-comment-draft",
+            "1.2.0",
+            Lifecycle::Active,
+        )]),
+        EchoExecutor,
+    )
+    .with_security_config(RuntimeSecurityConfig::development())
+    .with_usage_telemetry_sink(Arc::new(sink));
+    let mut request = base_request_exact();
+    request.intent.capability_version = None;
+    request.intent.version_range = Some("^1.0.0".to_string());
+
+    let outcome = runtime.execute(request);
+
+    assert_eq!(outcome.result.status, RuntimeResultStatus::Completed);
+    let recorded = events
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    assert_eq!(recorded.len(), 1);
+    assert_eq!(recorded[0].kind, UsageEventKind::Resolve);
+    assert_eq!(
+        recorded[0].capability_ref,
+        "content.comments.create-comment-draft@1.2.0"
+    );
+}
+
+#[test]
+fn exact_version_lookup_does_not_record_a_resolve_usage_telemetry_event() {
+    // The resolve hook only instruments the semver-range resolution path
+    // (spec 015 FR-006 scope) — an exact capability_id + capability_version
+    // lookup never calls `resolve_version_range` and must not fire a
+    // `resolve` event.
+    let sink = SpyUsageTelemetrySink::default();
+    let events = Arc::clone(&sink.events);
+    let runtime = Runtime::new(
+        registry_with(vec![registration(
+            RegistryScope::Private,
+            "content.comments.create-comment-draft",
+            "1.0.0",
+            Lifecycle::Active,
+        )]),
+        EchoExecutor,
+    )
+    .with_security_config(RuntimeSecurityConfig::development())
+    .with_usage_telemetry_sink(Arc::new(sink));
+
+    let outcome = runtime.execute(base_request_exact());
+
+    assert_eq!(outcome.result.status, RuntimeResultStatus::Completed);
+    assert!(
+        events
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .is_empty()
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Bumps `traverse-cli`'s pinned `traverse-registry` dependency to `0.15.0`,
which publishes the resolve-hook from `traverse-framework/registry`'s
Spec 015 (registry PR #270/#271): `resolve_version_range` now accepts an
optional `ResolveTelemetry<'a> { sink: &'a dyn UsageTelemetrySink,
resolved_at: &'a str }` and, on a successful resolution, invokes the sink
exactly once with a `resolve` usage-telemetry event carrying
`{capability_id}@{version}`.

The only call site of `resolve_version_range` in this repo is inside
`Runtime::collect_candidates` (`crates/traverse-runtime/src/lib.rs`), used
when a request supplies `capability_id` + `version_range` (a semver range)
rather than an exact version. `Runtime` gets a new
`usage_telemetry_sink: Arc<dyn UsageTelemetrySink>` field and
`with_usage_telemetry_sink` builder (defaulting to
`NoOpUsageTelemetrySink`, consistent with every other `Arc<dyn Trait>`
field on `Runtime`), and the resolve call site now passes
`Some(ResolveTelemetry { sink: self.usage_telemetry_sink.as_ref(),
resolved_at: &Utc::now().to_rfc3339() })`.

`traverse-cli` wires the real sink (from spec 088's existing
`telemetry::wire_usage_telemetry_sink()`) at both production
`Runtime`-construction points: `runtime_with_app_event_broker`
(`app_runtime_events.rs`, used for a fresh/empty workspace's `serve`
runtime) and `load_workspace_app_runtime` (`http_api.rs`, used when
loading durable workspace app state) — so `serve`'s execution handlers and
`capability-package execute` (via `execute_capability_package` in
`main.rs`) both observe `resolve` events end-to-end when telemetry is
enabled and a request resolves through a semver range.

## Governing Spec

- `088-runtime-usage-telemetry`
- `006-runtime-request-execution`
- `051-registry-extraction`

`088-runtime-usage-telemetry` (already approved, PR #926) governs
`crates/traverse-cli/` broadly and is this ticket's primary spec — it's
the same port trait (`UsageTelemetrySink`, `UsageEventKind::Resolve`) this
change wires into a second call site. `006-runtime-request-execution`
covers the `crates/traverse-runtime/src/lib.rs`/`tests/runtime.rs` changes
(the `Runtime` builder addition and the `resolve_version_range` call
site). The resolve-hook's own behavioral spec
(`015-runtime-usage-telemetry-resolve-hook`) is registered in
`traverse-framework/registry`'s governance, not this repo's — this PR only
consumes that published behavior via the version bump. `051-registry-extraction`
covers the root `Cargo.toml` pin bump itself.

## Project Item

Issue #930

## Validation

- `cargo test --workspace` — all suites green (390 traverse-cli-rs tests,
  39 traverse-runtime integration tests including 2 new: a semver-range
  resolution firing exactly one `resolve` event through a spy sink with
  the correct `capability_id@version`, and an exact-version lookup firing
  none)
- `cargo clippy --workspace --all-targets -- -D warnings` (1.94.0
  toolchain, matching CI's pin) — clean on every file this PR touches
- `cargo fmt --all --check` — clean
- `bash scripts/ci/coverage_gate.sh` — passed;
  `traverse-runtime: 100.00% (19526/19526 lines)`,
  `traverse-contracts: 100.00%`, `traverse-cli-rs: 87.03%` (≥ 87% floor),
  `traverse-embedder: 100.00%`, `traverse-mcp: 98.89%`,
  `traverse-swift-host: 84.03%`
- `BASE_SHA=origin/main bash scripts/ci/local_preflight.sh --pr-body <file>` — pending
