### PR TITLE
fix(cli): clippy duration_suboptimal_units in grpc_event_transport.rs

### DIFF
--- a/crates/traverse-cli/src/grpc_event_transport.rs
+++ b/crates/traverse-cli/src/grpc_event_transport.rs
@@ -26,7 +26,7 @@ use proto::{Event, GovernanceMetadata, StreamEventsRequest};
 
 const STREAM_POLL_INTERVAL: Duration = Duration::from_millis(50);
 const MAX_CONCURRENT_STREAMS: usize = 64;
-const MAX_STREAM_DURATION: Duration = Duration::from_secs(300);
+const MAX_STREAM_DURATION: Duration = Duration::from_mins(5);
 
 pub(crate) struct GrpcServerConfig {
     pub(crate) bind_address: String,


### PR DESCRIPTION
## Summary

`crates/traverse-cli/src/grpc_event_transport.rs:29` declared `MAX_STREAM_DURATION` as `Duration::from_secs(300)`, which fails clippy's `duration_suboptimal_units` lint under the pinned 1.94.0 toolchain and currently blocks `cargo clippy --workspace --all-targets -- -D warnings` for anyone building on that toolchain. Switched to `Duration::from_mins(5)` (clippy's own suggested fix), matching the existing `Duration::from_mins(5)` usage in `crates/traverse-runtime/src/events/broker.rs:44`. Pure constant-construction equivalence (`Duration::from_mins(5) == Duration::from_secs(300)`), no behavior change.

Fixes #1076

## Governing Spec

- `097-websocket-grpc-event-transport`

## Project Item

- https://github.com/traverse-framework/traverse/issues/1076

## What Changed

- Contracts changed: none
- Runtime behavior changed: none (pure constant-construction equivalence)
- Compatibility impact: none
- ADR needed or linked: none

## Validation

- [x] Spec alignment checked
- [x] Contract alignment checked
- [x] Tests updated and passing (`cargo test -p traverse-cli-rs`, 390 passed)
- [x] Core coverage preserved
- [x] Required validation gates passing (`BASE_SHA=origin/main bash scripts/ci/local_preflight.sh --pr-body pr-body.md`, exit 0)

## Notes

None.
