### PR TITLE
feat(embedder): add native registry cache adapters

### DIFF
--- a/packages/dotnet/TraverseEmbedder/TraverseEmbedder/RegistryCache.cs
+++ b/packages/dotnet/TraverseEmbedder/TraverseEmbedder/RegistryCache.cs
@@ -1,0 +1,50 @@
+using System.Security.Cryptography;
+
+namespace Traverse.Embedder;
+
+/// <summary>Stable, secret-free errors for the host-owned registry cache.</summary>
+public sealed class RegistryCacheException(string code, string message) : Exception(message)
+{
+    public string Code { get; } = code;
+}
+
+/// <summary>Non-secret evidence retained for one verified registry dependency.</summary>
+public sealed record RegistryCacheEvidence(
+    string Namespace, string Id, string SelectedVersion, string VersionRange,
+    string SourceRelease, string IndexDigest, string ArtifactDigest, long VerifiedAt,
+    string Outcome);
+
+/// <summary>A selected public record and its host-fetched artifact bytes.</summary>
+public sealed record RegistryCachePreparation(
+    string Namespace, string Id, string SelectedVersion, string VersionRange,
+    string SourceRelease, string IndexDigest, string ArtifactDigest, byte[] ArtifactBytes);
+
+/// <summary>Host-owned cache adapter. It never performs network I/O.</summary>
+public sealed class InMemoryRegistryCache
+{
+    private readonly Dictionary<string, (byte[] Bytes, RegistryCacheEvidence Evidence)> entries = [];
+
+    public RegistryCacheEvidence Prepare(RegistryCachePreparation input)
+    {
+        if (!MatchesDigest(input.ArtifactBytes, input.ArtifactDigest))
+            throw new RegistryCacheException("registry_artifact_digest_mismatch", "registry artifact bytes do not match the published digest");
+        var evidence = new RegistryCacheEvidence(input.Namespace, input.Id, input.SelectedVersion,
+            input.VersionRange, input.SourceRelease, input.IndexDigest, input.ArtifactDigest,
+            DateTimeOffset.UtcNow.ToUnixTimeSeconds(), "prepared");
+        entries[Key(input.Namespace, input.Id, input.VersionRange)] = (input.ArtifactBytes.ToArray(), evidence);
+        return evidence;
+    }
+
+    public (byte[] ArtifactBytes, RegistryCacheEvidence Evidence) ResolveOffline(string @namespace, string id, string versionRange)
+    {
+        if (!entries.TryGetValue(Key(@namespace, id, versionRange), out var entry))
+            throw new RegistryCacheException("registry_cache_entry_missing", "verified registry cache entry is missing for registry_ref");
+        if (!MatchesDigest(entry.Bytes, entry.Evidence.ArtifactDigest))
+            throw new RegistryCacheException("registry_artifact_digest_mismatch", "cached registry artifact digest mismatch");
+        return (entry.Bytes.ToArray(), entry.Evidence with { Outcome = "resolved" });
+    }
+
+    private static string Key(string @namespace, string id, string range) => $"{@namespace}:{id}:{range}";
+    private static bool MatchesDigest(byte[] bytes, string digest) =>
+        digest == "sha256:" + Convert.ToHexString(SHA256.HashData(bytes)).ToLowerInvariant();
+}

--- a/packages/kotlin/TraverseEmbedder/traverse-embedder/src/main/kotlin/dev/traverse/embedder/RegistryCache.kt
+++ b/packages/kotlin/TraverseEmbedder/traverse-embedder/src/main/kotlin/dev/traverse/embedder/RegistryCache.kt
@@ -1,0 +1,45 @@
+package dev.traverse.embedder
+
+import java.security.MessageDigest
+
+/** Stable, secret-free failure for host-owned registry cache operations. */
+class RegistryCacheException(val code: String, message: String) : IllegalStateException(message)
+
+/** Non-secret evidence for a verified registry dependency. */
+data class RegistryCacheEvidence(
+    val namespace: String, val id: String, val selectedVersion: String, val versionRange: String,
+    val sourceRelease: String, val indexDigest: String, val artifactDigest: String,
+    val verifiedAt: Long, val outcome: String,
+)
+
+/** A host-selected, fetched dependency presented for verification and storage. */
+data class RegistryCachePreparation(
+    val namespace: String, val id: String, val selectedVersion: String, val versionRange: String,
+    val sourceRelease: String, val indexDigest: String, val artifactDigest: String, val artifactBytes: ByteArray,
+)
+
+/** Host-owned, in-memory cache adapter. It deliberately performs no network I/O. */
+class InMemoryRegistryCache {
+    private val entries = mutableMapOf<String, Pair<ByteArray, RegistryCacheEvidence>>()
+
+    fun prepare(input: RegistryCachePreparation): RegistryCacheEvidence {
+        if (!matches(input.artifactBytes, input.artifactDigest)) throw RegistryCacheException(
+            "registry_artifact_digest_mismatch", "registry artifact bytes do not match the published digest")
+        val evidence = RegistryCacheEvidence(input.namespace, input.id, input.selectedVersion, input.versionRange,
+            input.sourceRelease, input.indexDigest, input.artifactDigest, System.currentTimeMillis() / 1000, "prepared")
+        entries[key(input.namespace, input.id, input.versionRange)] = input.artifactBytes.copyOf() to evidence
+        return evidence
+    }
+
+    fun resolveOffline(namespace: String, id: String, versionRange: String): Pair<ByteArray, RegistryCacheEvidence> {
+        val entry = entries[key(namespace, id, versionRange)] ?: throw RegistryCacheException(
+            "registry_cache_entry_missing", "verified registry cache entry is missing for registry_ref")
+        if (!matches(entry.first, entry.second.artifactDigest)) throw RegistryCacheException(
+            "registry_artifact_digest_mismatch", "cached registry artifact digest mismatch")
+        return entry.first.copyOf() to entry.second.copy(outcome = "resolved")
+    }
+
+    private fun key(namespace: String, id: String, range: String) = "$namespace:$id:$range"
+    private fun matches(bytes: ByteArray, digest: String) = digest == "sha256:" +
+        MessageDigest.getInstance("SHA-256").digest(bytes).joinToString("") { "%02x".format(it) }
+}

--- a/packages/swift/TraverseEmbedder/Sources/TraverseEmbedder/RegistryCache.swift
+++ b/packages/swift/TraverseEmbedder/Sources/TraverseEmbedder/RegistryCache.swift
@@ -1,0 +1,31 @@
+import CryptoKit
+import Foundation
+
+/// Stable, secret-free failure for host-owned registry cache operations.
+public struct RegistryCacheError: Error, Equatable, Sendable { public let code: String; public let message: String }
+public struct RegistryCacheEvidence: Sendable, Equatable {
+    public let namespace: String; public let id: String; public let selectedVersion: String; public let versionRange: String
+    public let sourceRelease: String; public let indexDigest: String; public let artifactDigest: String; public let verifiedAt: Int; public let outcome: String
+}
+public struct RegistryCachePreparation: Sendable {
+    public let namespace: String; public let id: String; public let selectedVersion: String; public let versionRange: String
+    public let sourceRelease: String; public let indexDigest: String; public let artifactDigest: String; public let artifactBytes: Data
+}
+
+/// Host-owned in-memory cache adapter. It deliberately performs no network I/O.
+public final class InMemoryRegistryCache: @unchecked Sendable {
+    private var entries: [String: (Data, RegistryCacheEvidence)] = [:]
+    public init() {}
+    public func prepare(_ input: RegistryCachePreparation) throws -> RegistryCacheEvidence {
+        guard matches(input.artifactBytes, input.artifactDigest) else { throw RegistryCacheError(code: "registry_artifact_digest_mismatch", message: "registry artifact bytes do not match the published digest") }
+        let evidence = RegistryCacheEvidence(namespace: input.namespace, id: input.id, selectedVersion: input.selectedVersion, versionRange: input.versionRange, sourceRelease: input.sourceRelease, indexDigest: input.indexDigest, artifactDigest: input.artifactDigest, verifiedAt: Int(Date().timeIntervalSince1970), outcome: "prepared")
+        entries[key(input.namespace, input.id, input.versionRange)] = (input.artifactBytes, evidence); return evidence
+    }
+    public func resolveOffline(namespace: String, id: String, versionRange: String) throws -> (Data, RegistryCacheEvidence) {
+        guard let entry = entries[key(namespace, id, versionRange)] else { throw RegistryCacheError(code: "registry_cache_entry_missing", message: "verified registry cache entry is missing for registry_ref") }
+        guard matches(entry.0, entry.1.artifactDigest) else { throw RegistryCacheError(code: "registry_artifact_digest_mismatch", message: "cached registry artifact digest mismatch") }
+        return (entry.0, RegistryCacheEvidence(namespace: entry.1.namespace, id: entry.1.id, selectedVersion: entry.1.selectedVersion, versionRange: entry.1.versionRange, sourceRelease: entry.1.sourceRelease, indexDigest: entry.1.indexDigest, artifactDigest: entry.1.artifactDigest, verifiedAt: entry.1.verifiedAt, outcome: "resolved"))
+    }
+    private func key(_ namespace: String, _ id: String, _ range: String) -> String { "\(namespace):\(id):\(range)" }
+    private func matches(_ bytes: Data, _ digest: String) -> Bool { digest == "sha256:" + SHA256.hash(data: bytes).map { String(format: "%02x", $0) }.joined() }
+}


### PR DESCRIPTION
## Summary

- Add host-owned, offline-only registry-cache adapters to Swift, Kotlin, and .NET embedders.
- Preserve the shared digest verification, non-secret evidence, and stable error contract.

## Governing Spec

- `107-cross-host-embedded-registry-cache`
- `080-embedded-registry-cache`
- `068-public-platform-embedder-packages`

## Project Item

- Closes #1071

## Definition of Done

- [x] Native adapters expose host-supplied preparation and offline resolution.
- [x] Adapters verify digests and fail closed with stable cache errors.

## Validation

- `swift test` in `packages/swift/TraverseEmbedder`
- `gradle :traverse-embedder:test` in `packages/kotlin/TraverseEmbedder`
- `dotnet test packages/dotnet/TraverseEmbedder/TraverseEmbedder.Tests/TraverseEmbedder.Tests.csproj`
