### PR TITLE
feat(contracts): add universal local connector contracts

### DIFF
--- a/contracts/connectors/traverse.fs.read/connector_contract.json
+++ b/contracts/connectors/traverse.fs.read/connector_contract.json
@@ -18,6 +18,60 @@
     },
     "additionalProperties": false
   },
+  "operation_envelopes": [
+    {
+      "operation_id": "read",
+      "request_schema": {
+        "type": "object",
+        "required": [
+          "resource_ref",
+          "idempotency_key"
+        ],
+        "properties": {
+          "resource_ref": {
+            "type": "string"
+          },
+          "max_bytes": {
+            "type": "integer"
+          },
+          "idempotency_key": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
+      "success_schema": {
+        "type": "object",
+        "required": [
+          "content_ref",
+          "content_digest",
+          "size",
+          "result_class"
+        ],
+        "properties": {
+          "content_ref": {
+            "type": "string"
+          },
+          "content_digest": {
+            "type": "string"
+          },
+          "size": {
+            "type": "integer"
+          },
+          "result_class": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
+      "failure_classes": [
+        "configuration",
+        "not_found",
+        "authorization",
+        "too_large"
+      ]
+    }
+  ],
   "supported_placement_targets": [
     "local",
     "cloud"

--- a/contracts/connectors/traverse.http/connector_contract.json
+++ b/contracts/connectors/traverse.http/connector_contract.json
@@ -18,6 +18,63 @@
     },
     "additionalProperties": false
   },
+  "operation_envelopes": [
+    {
+      "operation_id": "request",
+      "request_schema": {
+        "type": "object",
+        "required": [
+          "method",
+          "resource_ref",
+          "idempotency_key"
+        ],
+        "properties": {
+          "method": {
+            "type": "string"
+          },
+          "resource_ref": {
+            "type": "string"
+          },
+          "headers_ref": {
+            "type": "string"
+          },
+          "body_ref": {
+            "type": "string"
+          },
+          "idempotency_key": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
+      "success_schema": {
+        "type": "object",
+        "required": [
+          "status",
+          "body_ref",
+          "result_class"
+        ],
+        "properties": {
+          "status": {
+            "type": "integer"
+          },
+          "body_ref": {
+            "type": "string"
+          },
+          "result_class": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
+      "failure_classes": [
+        "configuration",
+        "transport",
+        "authorization",
+        "timeout"
+      ]
+    }
+  ],
   "supported_placement_targets": [
     "local",
     "cloud"

--- a/contracts/connectors/traverse.object-store/connector_contract.json
+++ b/contracts/connectors/traverse.object-store/connector_contract.json
@@ -1,18 +1,21 @@
 {
   "kind": "connector_contract",
   "schema_version": "1.0.0",
-  "connector_id": "traverse.env",
+  "connector_id": "traverse.object-store",
   "version": "1.0.0",
   "capabilities_provided": [
-    "traverse.env.read"
+    "traverse.object_store.put"
   ],
   "required_config_schema": {
     "type": "object",
     "required": [
-      "allowed_keys"
+      "authority_ref"
     ],
     "properties": {
-      "allowed_keys": {
+      "authority_ref": {
+        "type": "string"
+      },
+      "retention_classes": {
         "type": "array",
         "items": {
           "type": "string"
@@ -23,15 +26,22 @@
   },
   "operation_envelopes": [
     {
-      "operation_id": "read",
+      "operation_id": "put_immutable",
       "request_schema": {
         "type": "object",
         "required": [
-          "key_ref",
+          "content_ref",
+          "media_type",
           "idempotency_key"
         ],
         "properties": {
-          "key_ref": {
+          "content_ref": {
+            "type": "string"
+          },
+          "media_type": {
+            "type": "string"
+          },
+          "retention_class": {
             "type": "string"
           },
           "idempotency_key": {
@@ -43,12 +53,20 @@
       "success_schema": {
         "type": "object",
         "required": [
-          "value_ref",
+          "asset_ref",
+          "content_digest",
+          "size",
           "result_class"
         ],
         "properties": {
-          "value_ref": {
+          "asset_ref": {
             "type": "string"
+          },
+          "content_digest": {
+            "type": "string"
+          },
+          "size": {
+            "type": "integer"
           },
           "result_class": {
             "type": "string"
@@ -58,8 +76,9 @@
       },
       "failure_classes": [
         "configuration",
-        "not_found",
-        "authorization"
+        "authorization",
+        "quota",
+        "integrity"
       ]
     }
   ],

--- a/contracts/connectors/traverse.scheduler/connector_contract.json
+++ b/contracts/connectors/traverse.scheduler/connector_contract.json
@@ -1,18 +1,21 @@
 {
   "kind": "connector_contract",
   "schema_version": "1.0.0",
-  "connector_id": "traverse.env",
+  "connector_id": "traverse.scheduler",
   "version": "1.0.0",
   "capabilities_provided": [
-    "traverse.env.read"
+    "traverse.scheduler.schedule"
   ],
   "required_config_schema": {
     "type": "object",
     "required": [
-      "allowed_keys"
+      "authority_ref"
     ],
     "properties": {
-      "allowed_keys": {
+      "authority_ref": {
+        "type": "string"
+      },
+      "allowed_job_kinds": {
         "type": "array",
         "items": {
           "type": "string"
@@ -23,15 +26,26 @@
   },
   "operation_envelopes": [
     {
-      "operation_id": "read",
+      "operation_id": "schedule_invocation",
       "request_schema": {
         "type": "object",
         "required": [
-          "key_ref",
+          "job_kind",
+          "calendar_policy_ref",
+          "logical_deadline",
           "idempotency_key"
         ],
         "properties": {
-          "key_ref": {
+          "job_kind": {
+            "type": "string"
+          },
+          "calendar_policy_ref": {
+            "type": "string"
+          },
+          "logical_deadline": {
+            "type": "string"
+          },
+          "cancellation_ref": {
             "type": "string"
           },
           "idempotency_key": {
@@ -43,11 +57,15 @@
       "success_schema": {
         "type": "object",
         "required": [
-          "value_ref",
+          "invocation_ref",
+          "idempotency_key",
           "result_class"
         ],
         "properties": {
-          "value_ref": {
+          "invocation_ref": {
+            "type": "string"
+          },
+          "idempotency_key": {
             "type": "string"
           },
           "result_class": {
@@ -58,8 +76,9 @@
       },
       "failure_classes": [
         "configuration",
-        "not_found",
-        "authorization"
+        "authorization",
+        "deadline",
+        "quota"
       ]
     }
   ],

--- a/contracts/connectors/traverse.state-store/connector_contract.json
+++ b/contracts/connectors/traverse.state-store/connector_contract.json
@@ -1,38 +1,48 @@
 {
   "kind": "connector_contract",
   "schema_version": "1.0.0",
-  "connector_id": "traverse.env",
+  "connector_id": "traverse.state-store",
   "version": "1.0.0",
   "capabilities_provided": [
-    "traverse.env.read"
+    "traverse.state_store.append"
   ],
   "required_config_schema": {
     "type": "object",
     "required": [
-      "allowed_keys"
+      "authority_ref"
     ],
     "properties": {
-      "allowed_keys": {
-        "type": "array",
-        "items": {
-          "type": "string"
-        }
+      "authority_ref": {
+        "type": "string"
+      },
+      "record_type_namespace": {
+        "type": "string"
       }
     },
     "additionalProperties": false
   },
   "operation_envelopes": [
     {
-      "operation_id": "read",
+      "operation_id": "append_transition",
       "request_schema": {
         "type": "object",
         "required": [
-          "key_ref",
+          "record_refs",
+          "transition",
           "idempotency_key"
         ],
         "properties": {
-          "key_ref": {
-            "type": "string"
+          "record_refs": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "transition": {
+            "type": "object"
+          },
+          "expected_version": {
+            "type": "integer"
           },
           "idempotency_key": {
             "type": "string"
@@ -43,12 +53,20 @@
       "success_schema": {
         "type": "object",
         "required": [
-          "value_ref",
+          "result_ref",
+          "version",
+          "replay",
           "result_class"
         ],
         "properties": {
-          "value_ref": {
+          "result_ref": {
             "type": "string"
+          },
+          "version": {
+            "type": "integer"
+          },
+          "replay": {
+            "type": "boolean"
           },
           "result_class": {
             "type": "string"
@@ -58,8 +76,9 @@
       },
       "failure_classes": [
         "configuration",
-        "not_found",
-        "authorization"
+        "authorization",
+        "conflict",
+        "integrity"
       ]
     }
   ],

--- a/contracts/governance/ecca-capability-inventory.json
+++ b/contracts/governance/ecca-capability-inventory.json
@@ -120,8 +120,15 @@
   "excluded": [
     {
       "kind": "connector_contract",
-      "reason": "Connectors (traverse.http, traverse.fs.read, traverse.env) are resource adapters, not capabilities, per the constitution's capability-first boundary principle. They are out of scope for the ECCA existing-catalog migration in FR-020.",
-      "ids": ["traverse.http", "traverse.fs.read", "traverse.env"]
+      "reason": "Connectors (traverse.http, traverse.fs.read, traverse.env, traverse.object-store, traverse.state-store, traverse.scheduler) are resource adapters, not capabilities, per the constitution's capability-first boundary principle. They are out of scope for the ECCA existing-catalog migration in FR-020.",
+      "ids": [
+        "traverse.http",
+        "traverse.fs.read",
+        "traverse.env",
+        "traverse.object-store",
+        "traverse.state-store",
+        "traverse.scheduler"
+      ]
     }
   ]
 }

--- a/crates/traverse-contracts/src/lib.rs
+++ b/crates/traverse-contracts/src/lib.rs
@@ -80,8 +80,17 @@ pub struct ConnectorContract {
     pub version: String,
     pub capabilities_provided: Vec<String>,
     pub required_config_schema: Value,
+    pub operation_envelopes: Vec<ConnectorOperationEnvelope>,
     #[serde(default = "default_connector_targets")]
     pub supported_placement_targets: Vec<ExecutionTarget>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ConnectorOperationEnvelope {
+    pub operation_id: String,
+    pub request_schema: Value,
+    pub success_schema: Value,
+    pub failure_classes: Vec<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -122,6 +131,7 @@ pub trait ConnectorPlugin: Send + Sync {
 }
 
 #[must_use]
+#[allow(clippy::too_many_lines)]
 pub fn reference_connector_contracts() -> Vec<ConnectorContract> {
     vec![
         reference_connector_contract(
@@ -135,6 +145,32 @@ pub fn reference_connector_contracts() -> Vec<ConnectorContract> {
                 },
                 "additionalProperties": false
             }),
+            vec![connector_operation_envelope(
+                "request",
+                serde_json::json!({
+                    "type": "object",
+                    "required": ["method", "resource_ref", "idempotency_key"],
+                    "properties": {
+                        "method": {"type": "string"},
+                        "resource_ref": {"type": "string"},
+                        "headers_ref": {"type": "string"},
+                        "body_ref": {"type": "string"},
+                        "idempotency_key": {"type": "string"}
+                    },
+                    "additionalProperties": false
+                }),
+                serde_json::json!({
+                    "type": "object",
+                    "required": ["status", "body_ref", "result_class"],
+                    "properties": {
+                        "status": {"type": "integer"},
+                        "body_ref": {"type": "string"},
+                        "result_class": {"type": "string"}
+                    },
+                    "additionalProperties": false
+                }),
+                vec!["configuration", "transport", "authorization", "timeout"],
+            )],
         ),
         reference_connector_contract(
             "traverse.fs.read",
@@ -147,6 +183,31 @@ pub fn reference_connector_contracts() -> Vec<ConnectorContract> {
                 },
                 "additionalProperties": false
             }),
+            vec![connector_operation_envelope(
+                "read",
+                serde_json::json!({
+                    "type": "object",
+                    "required": ["resource_ref", "idempotency_key"],
+                    "properties": {
+                        "resource_ref": {"type": "string"},
+                        "max_bytes": {"type": "integer"},
+                        "idempotency_key": {"type": "string"}
+                    },
+                    "additionalProperties": false
+                }),
+                serde_json::json!({
+                    "type": "object",
+                    "required": ["content_ref", "content_digest", "size", "result_class"],
+                    "properties": {
+                        "content_ref": {"type": "string"},
+                        "content_digest": {"type": "string"},
+                        "size": {"type": "integer"},
+                        "result_class": {"type": "string"}
+                    },
+                    "additionalProperties": false
+                }),
+                vec!["configuration", "not_found", "authorization", "too_large"],
+            )],
         ),
         reference_connector_contract(
             "traverse.env",
@@ -162,6 +223,154 @@ pub fn reference_connector_contracts() -> Vec<ConnectorContract> {
                 },
                 "additionalProperties": false
             }),
+            vec![connector_operation_envelope(
+                "read",
+                serde_json::json!({
+                    "type": "object",
+                    "required": ["key_ref", "idempotency_key"],
+                    "properties": {
+                        "key_ref": {"type": "string"},
+                        "idempotency_key": {"type": "string"}
+                    },
+                    "additionalProperties": false
+                }),
+                serde_json::json!({
+                    "type": "object",
+                    "required": ["value_ref", "result_class"],
+                    "properties": {
+                        "value_ref": {"type": "string"},
+                        "result_class": {"type": "string"}
+                    },
+                    "additionalProperties": false
+                }),
+                vec!["configuration", "not_found", "authorization"],
+            )],
+        ),
+        reference_connector_contract(
+            "traverse.object-store",
+            vec!["traverse.object_store.put".to_string()],
+            serde_json::json!({
+                "type": "object",
+                "required": ["authority_ref"],
+                "properties": {
+                    "authority_ref": {"type": "string"},
+                    "retention_classes": {
+                        "type": "array",
+                        "items": {"type": "string"}
+                    }
+                },
+                "additionalProperties": false
+            }),
+            vec![connector_operation_envelope(
+                "put_immutable",
+                serde_json::json!({
+                    "type": "object",
+                    "required": ["content_ref", "media_type", "idempotency_key"],
+                    "properties": {
+                        "content_ref": {"type": "string"},
+                        "media_type": {"type": "string"},
+                        "retention_class": {"type": "string"},
+                        "idempotency_key": {"type": "string"}
+                    },
+                    "additionalProperties": false
+                }),
+                serde_json::json!({
+                    "type": "object",
+                    "required": ["asset_ref", "content_digest", "size", "result_class"],
+                    "properties": {
+                        "asset_ref": {"type": "string"},
+                        "content_digest": {"type": "string"},
+                        "size": {"type": "integer"},
+                        "result_class": {"type": "string"}
+                    },
+                    "additionalProperties": false
+                }),
+                vec!["configuration", "authorization", "quota", "integrity"],
+            )],
+        ),
+        reference_connector_contract(
+            "traverse.state-store",
+            vec!["traverse.state_store.append".to_string()],
+            serde_json::json!({
+                "type": "object",
+                "required": ["authority_ref"],
+                "properties": {
+                    "authority_ref": {"type": "string"},
+                    "record_type_namespace": {"type": "string"}
+                },
+                "additionalProperties": false
+            }),
+            vec![connector_operation_envelope(
+                "append_transition",
+                serde_json::json!({
+                    "type": "object",
+                    "required": ["record_refs", "transition", "idempotency_key"],
+                    "properties": {
+                        "record_refs": {
+                            "type": "array",
+                            "items": {"type": "string"}
+                        },
+                        "transition": {"type": "object"},
+                        "expected_version": {"type": "integer"},
+                        "idempotency_key": {"type": "string"}
+                    },
+                    "additionalProperties": false
+                }),
+                serde_json::json!({
+                    "type": "object",
+                    "required": ["result_ref", "version", "replay", "result_class"],
+                    "properties": {
+                        "result_ref": {"type": "string"},
+                        "version": {"type": "integer"},
+                        "replay": {"type": "boolean"},
+                        "result_class": {"type": "string"}
+                    },
+                    "additionalProperties": false
+                }),
+                vec!["configuration", "authorization", "conflict", "integrity"],
+            )],
+        ),
+        reference_connector_contract(
+            "traverse.scheduler",
+            vec!["traverse.scheduler.schedule".to_string()],
+            serde_json::json!({
+                "type": "object",
+                "required": ["authority_ref"],
+                "properties": {
+                    "authority_ref": {"type": "string"},
+                    "allowed_job_kinds": {
+                        "type": "array",
+                        "items": {"type": "string"}
+                    }
+                },
+                "additionalProperties": false
+            }),
+            vec![connector_operation_envelope(
+                "schedule_invocation",
+                serde_json::json!({
+                    "type": "object",
+                    "required": ["job_kind", "calendar_policy_ref", "logical_deadline", "idempotency_key"],
+                    "properties": {
+                        "job_kind": {"type": "string"},
+                        "calendar_policy_ref": {"type": "string"},
+                        "logical_deadline": {"type": "string"},
+                        "cancellation_ref": {"type": "string"},
+                        "idempotency_key": {"type": "string"}
+                    },
+                    "additionalProperties": false
+                }),
+                serde_json::json!({
+                    "type": "object",
+                    "required": ["invocation_ref", "idempotency_key", "result_class"],
+                    "properties": {
+                        "invocation_ref": {"type": "string"},
+                        "idempotency_key": {"type": "string"},
+                        "result_class": {"type": "string"}
+                    },
+                    "additionalProperties": false
+                }),
+                vec!["configuration", "authorization", "deadline", "quota"],
+            )],
         ),
     ]
 }
@@ -170,6 +379,7 @@ fn reference_connector_contract(
     connector_id: &str,
     capabilities_provided: Vec<String>,
     required_config_schema: Value,
+    operation_envelopes: Vec<ConnectorOperationEnvelope>,
 ) -> ConnectorContract {
     ConnectorContract {
         kind: CONNECTOR_CONTRACT_KIND.to_string(),
@@ -178,7 +388,25 @@ fn reference_connector_contract(
         version: "1.0.0".to_string(),
         capabilities_provided,
         required_config_schema,
+        operation_envelopes,
         supported_placement_targets: default_connector_targets(),
+    }
+}
+
+fn connector_operation_envelope(
+    operation_id: &str,
+    request_schema: Value,
+    success_schema: Value,
+    failure_classes: Vec<&str>,
+) -> ConnectorOperationEnvelope {
+    ConnectorOperationEnvelope {
+        operation_id: operation_id.to_string(),
+        request_schema,
+        success_schema,
+        failure_classes: failure_classes
+            .into_iter()
+            .map(std::string::ToString::to_string)
+            .collect(),
     }
 }
 
@@ -718,6 +946,7 @@ pub fn validate_connector_contract(
         "$.required_config_schema",
         &mut errors,
     );
+    validate_connector_operation_envelopes(&contract.operation_envelopes, &mut errors);
     if contract.supported_placement_targets.is_empty() {
         errors.push(error(
             ValidationErrorCode::MissingRequiredField,
@@ -743,6 +972,66 @@ pub fn validate_connector_contract(
     }
 
     Ok(contract)
+}
+
+fn validate_connector_operation_envelopes(
+    operation_envelopes: &[ConnectorOperationEnvelope],
+    errors: &mut Vec<ValidationError>,
+) {
+    if operation_envelopes.is_empty() {
+        errors.push(error(
+            ValidationErrorCode::MissingRequiredField,
+            "$.operation_envelopes",
+            "operation_envelopes must contain at least one operation",
+        ));
+        return;
+    }
+
+    let mut seen = HashSet::new();
+    for (index, envelope) in operation_envelopes.iter().enumerate() {
+        let operation_id_path = format!("$.operation_envelopes[{index}].operation_id");
+        validate_non_empty(&envelope.operation_id, &operation_id_path, errors);
+        if !seen.insert(envelope.operation_id.clone()) {
+            errors.push(error(
+                ValidationErrorCode::DuplicateItem,
+                &operation_id_path,
+                "operation_id values must be unique",
+            ));
+        }
+
+        validate_schema_value(
+            &envelope.request_schema,
+            &format!("$.operation_envelopes[{index}].request_schema"),
+            errors,
+        );
+        validate_schema_value(
+            &envelope.success_schema,
+            &format!("$.operation_envelopes[{index}].success_schema"),
+            errors,
+        );
+
+        let failure_classes_path = format!("$.operation_envelopes[{index}].failure_classes");
+        if envelope.failure_classes.is_empty() {
+            errors.push(error(
+                ValidationErrorCode::MissingRequiredField,
+                &failure_classes_path,
+                "failure_classes must contain at least one stable failure class",
+            ));
+        }
+        validate_unique_strings(
+            &envelope.failure_classes,
+            &failure_classes_path,
+            "failure_classes must be unique",
+            errors,
+        );
+        for (failure_index, failure_class) in envelope.failure_classes.iter().enumerate() {
+            validate_non_empty(
+                failure_class,
+                &format!("$.operation_envelopes[{index}].failure_classes[{failure_index}]"),
+                errors,
+            );
+        }
+    }
 }
 
 /// Validates a parsed event contract against the governed `v0.1` rules.

--- a/crates/traverse-contracts/tests/validation.rs
+++ b/crates/traverse-contracts/tests/validation.rs
@@ -96,7 +96,48 @@ fn parses_and_validates_connector_contract() -> Result<(), String> {
         vec!["traverse.http.outbound".to_string()]
     );
     assert!(validated.required_config_schema.is_object());
+    assert_eq!(validated.operation_envelopes[0].operation_id, "request");
     Ok(())
+}
+
+#[test]
+fn reference_connector_registry_includes_universal_local_connectors() {
+    let contracts = reference_connector_contracts();
+    let connector_ids: Vec<_> = contracts
+        .iter()
+        .map(|connector| connector.connector_id.as_str())
+        .collect();
+
+    for connector_id in [
+        "traverse.object-store",
+        "traverse.state-store",
+        "traverse.scheduler",
+    ] {
+        assert!(
+            connector_ids.contains(&connector_id),
+            "missing reference connector {connector_id}"
+        );
+    }
+
+    let operation_ids: Vec<_> = contracts
+        .iter()
+        .filter(|connector| {
+            matches!(
+                connector.connector_id.as_str(),
+                "traverse.object-store" | "traverse.state-store" | "traverse.scheduler"
+            )
+        })
+        .flat_map(|connector| {
+            connector
+                .operation_envelopes
+                .iter()
+                .map(|envelope| envelope.operation_id.as_str())
+        })
+        .collect();
+
+    assert!(operation_ids.contains(&"put_immutable"));
+    assert!(operation_ids.contains(&"append_transition"));
+    assert!(operation_ids.contains(&"schedule_invocation"));
 }
 
 #[test]
@@ -117,6 +158,7 @@ fn rejects_invalid_connector_contract_shape() -> Result<(), String> {
     contract.version = "nope".to_string();
     contract.capabilities_provided.clear();
     contract.required_config_schema = serde_json::json!("not-object");
+    contract.operation_envelopes.clear();
     contract.supported_placement_targets = vec![ExecutionTarget::Local, ExecutionTarget::Local];
 
     let errors: Vec<_> = expect_validation_failure(validate_connector_contract(contract))
@@ -140,6 +182,75 @@ fn rejects_invalid_connector_contract_shape() -> Result<(), String> {
     assert!(failure.errors.iter().any(|error| {
         error.code == ValidationErrorCode::DuplicateItem
             && error.path == "$.supported_placement_targets"
+    }));
+    assert!(failure.errors.iter().any(|error| {
+        error.code == ValidationErrorCode::MissingRequiredField
+            && error.path == "$.operation_envelopes"
+    }));
+    Ok(())
+}
+
+#[test]
+fn rejects_invalid_connector_operation_envelopes() -> Result<(), String> {
+    let mut contract = reference_connector_contracts()
+        .into_iter()
+        .find(|connector| connector.connector_id == "traverse.object-store")
+        .ok_or_else(|| "reference connector should exist".to_string())?;
+    let mut duplicate = contract.operation_envelopes[0].clone();
+    duplicate.operation_id = String::new();
+    contract.operation_envelopes[0].operation_id = String::new();
+    contract.operation_envelopes[0].request_schema = serde_json::json!("not-object");
+    contract.operation_envelopes[0].success_schema = serde_json::json!("not-object");
+    contract.operation_envelopes[0].failure_classes = vec![
+        "configuration".to_string(),
+        "configuration".to_string(),
+        String::new(),
+    ];
+    contract.operation_envelopes.push(duplicate);
+
+    let errors: Vec<_> = expect_validation_failure(validate_connector_contract(contract))
+        .into_iter()
+        .collect();
+    let failure = &errors[0];
+
+    assert!(failure.errors.iter().any(|error| {
+        error.code == ValidationErrorCode::MissingRequiredField
+            && error.path == "$.operation_envelopes[0].operation_id"
+    }));
+    assert!(failure.errors.iter().any(|error| {
+        error.code == ValidationErrorCode::InvalidFormat
+            && error.path == "$.operation_envelopes[0].request_schema"
+    }));
+    assert!(failure.errors.iter().any(|error| {
+        error.code == ValidationErrorCode::InvalidFormat
+            && error.path == "$.operation_envelopes[0].success_schema"
+    }));
+    assert!(failure.errors.iter().any(|error| {
+        error.code == ValidationErrorCode::DuplicateItem
+            && error.path == "$.operation_envelopes[0].failure_classes"
+    }));
+    assert!(failure.errors.iter().any(|error| {
+        error.code == ValidationErrorCode::MissingRequiredField
+            && error.path == "$.operation_envelopes[0].failure_classes[2]"
+    }));
+    Ok(())
+}
+
+#[test]
+fn rejects_connector_operation_without_failure_classes() -> Result<(), String> {
+    let mut contract = reference_connector_contracts()
+        .into_iter()
+        .find(|connector| connector.connector_id == "traverse.scheduler")
+        .ok_or_else(|| "reference connector should exist".to_string())?;
+    contract.operation_envelopes[0].failure_classes.clear();
+
+    let errors: Vec<_> = expect_validation_failure(validate_connector_contract(contract))
+        .into_iter()
+        .collect();
+
+    assert!(errors[0].errors.iter().any(|error| {
+        error.code == ValidationErrorCode::MissingRequiredField
+            && error.path == "$.operation_envelopes[0].failure_classes"
     }));
     Ok(())
 }
@@ -1023,6 +1134,9 @@ fn validates_checked_in_reference_connector_contracts() -> Result<(), String> {
         "contracts/connectors/traverse.http/connector_contract.json",
         "contracts/connectors/traverse.fs.read/connector_contract.json",
         "contracts/connectors/traverse.env/connector_contract.json",
+        "contracts/connectors/traverse.object-store/connector_contract.json",
+        "contracts/connectors/traverse.state-store/connector_contract.json",
+        "contracts/connectors/traverse.scheduler/connector_contract.json",
     ] {
         let path = repo_root.join(relative_path);
         let contents = fs::read_to_string(&path)


### PR DESCRIPTION
## Summary
- Add universal local connector contracts for object storage, state storage, and scheduling.
- Extend connector contracts with validated operation envelopes covering request schemas, success schemas, and stable failure classes.
- Register and validate the universal connector IDs alongside existing reference connectors.

## Governing Spec
- `039-connector-plugin-architecture`
- `014-service-type-taxonomy`
- `056-capability-publish`
- `103-application-connector-binding`
- `104-mediated-connector-invocation`
- `534-ecca-event-products`

## Project Item
- Closes #1080

## Definition of Done
- [x] New connector contracts are checked in under `contracts/connectors/`.
- [x] Reference connector registry exposes the new connector IDs.
- [x] Validation rejects malformed connector schemas, semver, placement targets, and operation envelopes.

## Validation
- `cargo test -p traverse-contracts`
- `cargo clippy -p traverse-contracts --all-targets -- -D warnings`
- `BASE_SHA=$(git rev-parse origin/main) bash scripts/ci/spec_alignment_check.sh /private/tmp/pr-1080-body.md`
- `bash scripts/ci/coverage_gate.sh`
