### PR TITLE
test(runtime): cover mediated connector fixtures

### DIFF
--- a/crates/traverse-cli/src/main.rs
+++ b/crates/traverse-cli/src/main.rs
@@ -8313,6 +8313,165 @@ mod tests {
     }
 
     #[test]
+    fn app_activate_persists_universal_connector_evidence_without_private_config_values() {
+        let state_root = unique_temp_dir();
+        let fixture_root = unique_temp_dir();
+        let manifest_path = write_app_validate_fixture(
+            &fixture_root,
+            "sha256:470e430bb7e53d2b4d37af50186511a1f7f9ae903bc4f1524755f2a97014ef90",
+            "sha256:470e430bb7e53d2b4d37af50186511a1f7f9ae903bc4f1524755f2a97014ef90",
+            None,
+        );
+        add_universal_connector_bindings(&manifest_path);
+        let host_activation_path = fixture_root.join("host-activation.json");
+        fs::write(
+            &host_activation_path,
+            universal_host_activation_json(&serde_json::json!([
+                {
+                    "connector_id": "traverse.object-store",
+                    "installed_version": "1.0.0",
+                    "placement_target": "local",
+                    "config": {
+                        "authority_ref": "bucket-prod-private-name",
+                        "retention_classes": ["standard"]
+                    }
+                },
+                {
+                    "connector_id": "traverse.state-store",
+                    "installed_version": "1.0.0",
+                    "placement_target": "local",
+                    "config": {
+                        "authority_ref": "postgres://private-state-store",
+                        "record_type_namespace": "fixture"
+                    }
+                },
+                {
+                    "connector_id": "traverse.scheduler",
+                    "installed_version": "1.0.0",
+                    "placement_target": "local",
+                    "config": {
+                        "authority_ref": "scheduler-device-42",
+                        "allowed_job_kinds": ["fixture-job"]
+                    }
+                }
+            ])),
+        )
+        .expect("host activation fixture should write");
+
+        let output = app_activate_at(
+            &state_root,
+            &manifest_path,
+            "local",
+            &host_activation_path,
+            true,
+        )
+        .expect("universal connector activation should succeed");
+        let json: Value = serde_json::from_str(&output).expect("activation output must be JSON");
+        let state_path =
+            app_activation_state_path(&state_root, "local", "expedition.readiness", "1.0.0");
+        let persisted: Value = serde_json::from_str(
+            &fs::read_to_string(&state_path).expect("activation evidence must persist"),
+        )
+        .expect("persisted activation must be JSON");
+
+        assert_eq!(json["status"], "activated");
+        assert_eq!(json["connectors"].as_array().map(Vec::len), Some(3));
+        assert_eq!(
+            json["connectors"][0]["connector_id"],
+            "traverse.object-store"
+        );
+        assert_eq!(json["connectors"][1]["connector_id"], "traverse.scheduler");
+        assert_eq!(
+            json["connectors"][2]["connector_id"],
+            "traverse.state-store"
+        );
+        assert_eq!(
+            json["connectors"][0]["config_keys_present"],
+            serde_json::json!(["authority_ref", "retention_classes"])
+        );
+        assert_eq!(json, persisted);
+        for private_value in [
+            "bucket-prod-private-name",
+            "postgres://private-state-store",
+            "scheduler-device-42",
+        ] {
+            assert!(
+                !output.contains(private_value),
+                "activation evidence leaked host-private value {private_value}"
+            );
+        }
+    }
+
+    #[test]
+    fn app_activate_rejects_unconfigured_universal_connector_without_leaking_value() {
+        let state_root = unique_temp_dir();
+        let fixture_root = unique_temp_dir();
+        let manifest_path = write_app_validate_fixture(
+            &fixture_root,
+            "sha256:470e430bb7e53d2b4d37af50186511a1f7f9ae903bc4f1524755f2a97014ef90",
+            "sha256:470e430bb7e53d2b4d37af50186511a1f7f9ae903bc4f1524755f2a97014ef90",
+            None,
+        );
+        add_universal_connector_bindings(&manifest_path);
+        let host_activation_path = fixture_root.join("host-activation.json");
+        fs::write(
+            &host_activation_path,
+            universal_host_activation_json(&serde_json::json!([
+                {
+                    "connector_id": "traverse.object-store",
+                    "installed_version": "1.0.0",
+                    "placement_target": "local",
+                    "config": {
+                        "retention_classes": ["standard"],
+                        "private_value": "bucket-prod-private-name"
+                    }
+                },
+                {
+                    "connector_id": "traverse.state-store",
+                    "installed_version": "1.0.0",
+                    "placement_target": "local",
+                    "config": {
+                        "authority_ref": "state-authority",
+                        "record_type_namespace": "fixture"
+                    }
+                },
+                {
+                    "connector_id": "traverse.scheduler",
+                    "installed_version": "1.0.0",
+                    "placement_target": "local",
+                    "config": {
+                        "authority_ref": "scheduler-authority",
+                        "allowed_job_kinds": ["fixture-job"]
+                    }
+                }
+            ])),
+        )
+        .expect("host activation fixture should write");
+
+        let output = app_activate_at(
+            &state_root,
+            &manifest_path,
+            "local",
+            &host_activation_path,
+            true,
+        )
+        .expect("activation denial should render JSON evidence");
+        let json: Value = serde_json::from_str(&output).expect("activation output must be JSON");
+
+        assert_eq!(json["status"], "activation_failed");
+        assert_eq!(json["errors"][0]["code"], "connector_unconfigured");
+        assert_eq!(
+            json["errors"][0]["path"],
+            "$.connector_bindings[traverse.object-store]"
+        );
+        assert!(
+            !output.contains("bucket-prod-private-name"),
+            "activation failure leaked host-private value"
+        );
+        assert!(!state_root.join(".traverse").exists());
+    }
+
+    #[test]
     #[allow(clippy::too_many_lines)] // Exercises the complete synced-reference registration flow.
     fn synced_registry_reference_validates_registers_and_reuses_verified_cache() {
         let state_root = unique_temp_dir();
@@ -10453,6 +10612,55 @@ mod tests {
         )
         .expect("app manifest must write");
         manifest_path
+    }
+
+    fn add_universal_connector_bindings(manifest_path: &Path) {
+        let mut manifest: Value = serde_json::from_str(
+            &fs::read_to_string(manifest_path).expect("app manifest should read"),
+        )
+        .expect("app manifest should parse");
+        manifest["connector_bindings"] = serde_json::json!([
+            {
+                "connector_id": "traverse.object-store",
+                "version_range": "^1.0.0",
+                "config_ref": "object-store.default"
+            },
+            {
+                "connector_id": "traverse.state-store",
+                "version_range": "^1.0.0",
+                "config_ref": "state-store.default"
+            },
+            {
+                "connector_id": "traverse.scheduler",
+                "version_range": "^1.0.0",
+                "config_ref": "scheduler.default"
+            }
+        ]);
+        fs::write(
+            manifest_path,
+            serde_json::to_string_pretty(&manifest).expect("app manifest should serialize"),
+        )
+        .expect("app manifest should write");
+    }
+
+    fn universal_host_activation_json(connectors: &Value) -> String {
+        serde_json::to_string_pretty(&serde_json::json!({
+            "connectors": connectors,
+            "artifacts": [{
+                "contract_reference": "expedition.planning.validate-team-readiness@1.0.0",
+                "placement_target": "local",
+                "candidates": [{
+                    "package_id": "fixture.team-readiness",
+                    "package_version": "1.0.0",
+                    "digest": "sha256:470e430bb7e53d2b4d37af50186511a1f7f9ae903bc4f1524755f2a97014ef90",
+                    "abi": "wasi-preview1",
+                    "lifecycle": "active",
+                    "placement": ["local"],
+                    "execution_constraints": "fixture"
+                }]
+            }]
+        }))
+        .expect("host activation fixture should serialize")
     }
 
     fn app_state_machine_fixture() -> Value {

--- a/crates/traverse-runtime/tests/executor_tests.rs
+++ b/crates/traverse-runtime/tests/executor_tests.rs
@@ -1,8 +1,9 @@
 use serde_json::json;
 use sha2::{Digest, Sha256};
+use std::collections::{BTreeMap, BTreeSet};
 use std::fmt::Write as _;
-use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
 use traverse_contracts::{ConnectorRequirement, EventReference, ServiceType};
 use traverse_runtime::executor::{
     ActivatedConnector, ArtifactType, CapabilityExecutor, ConnectorInvokeRequest,
@@ -592,6 +593,32 @@ fn connector_test_wasm(
     .map_err(|error| format!("WAT parse: {error}"))
 }
 
+fn connector_response_wasm(
+    request: &str,
+    request_ptr: i32,
+    request_len: i32,
+    response_ptr: i32,
+    response_capacity: i32,
+) -> Result<Vec<u8>, String> {
+    let escaped_request = request.replace('\\', "\\\\").replace('"', "\\\"");
+    wat::parse_str(format!(
+        r#"
+        (module
+          (import "wasi_snapshot_preview1" "fd_write" (func $write (param i32 i32 i32 i32) (result i32)))
+          (import "traverse_host" "connector_invoke" (func $invoke (param i32 i32 i32 i32) (result i32)))
+          (memory (export "memory") 1)
+          (data (i32.const 32) "{escaped_request}")
+          (func $_start (export "_start") (local $len i32)
+            i32.const {request_ptr} i32.const {request_len} i32.const {response_ptr} i32.const {response_capacity} call $invoke local.set $len
+            i32.const 4 i32.const {response_ptr} i32.store
+            i32.const 8 local.get $len i32.store
+            i32.const 1 i32.const 4 i32.const 1 i32.const 12 call $write drop)
+        )
+        "#
+    ))
+    .map_err(|error| format!("WAT parse: {error}"))
+}
+
 fn connector_context(
     connector: Arc<dyn MediatedConnector>,
     version: &str,
@@ -619,11 +646,212 @@ fn declared_connector_context() -> MediatedConnectorContext {
     }
 }
 
+fn universal_connector_context(
+    connector_id: &str,
+    connector: Arc<dyn MediatedConnector>,
+    version: &str,
+) -> MediatedConnectorContext {
+    MediatedConnectorContext {
+        declared_requirements: vec![ConnectorRequirement {
+            connector_id: connector_id.to_string(),
+            version: "^1.0.0".to_string(),
+        }],
+        activated_connectors: vec![ActivatedConnector {
+            connector_id: connector_id.to_string(),
+            version: version.to_string(),
+            implementation: connector,
+        }],
+    }
+}
+
 const VALID_CONNECTOR_REQUEST: &str = r#"{"abi_version":"1.0.0","connector_id":"traverse.test","operation":"read","payload":{"id":"x"}}"#;
 
 fn valid_connector_request_len() -> Result<i32, String> {
     i32::try_from(VALID_CONNECTOR_REQUEST.len())
         .map_err(|error| format!("request length conversion: {error}"))
+}
+
+fn connector_request(connector_id: &str, operation: &str, payload: &serde_json::Value) -> String {
+    json!({
+        "abi_version": SUPPORTED_HOST_ABI_VERSION,
+        "connector_id": connector_id,
+        "operation": operation,
+        "payload": payload
+    })
+    .to_string()
+}
+
+fn invoke_connector_fixture(
+    connector_id: &str,
+    operation: &str,
+    payload: &serde_json::Value,
+    connector: Arc<dyn MediatedConnector>,
+) -> Result<ExecutorOutput, String> {
+    let request = connector_request(connector_id, operation, payload);
+    let request_len = i32::try_from(request.len())
+        .map_err(|error| format!("request length conversion: {error}"))?;
+    let wasm = connector_response_wasm(&request, 32, request_len, 256, 2048)?;
+    let executor = WasmExecutor::new().map_err(|error| format!("{error:?}"))?;
+    executor
+        .run_bytes_with_mediated_connectors(
+            &wasm,
+            &json!({}),
+            "universal-connector-fixture",
+            universal_connector_context(connector_id, connector, "1.0.0"),
+        )
+        .map_err(|error| format!("{error:?}"))
+}
+
+fn assert_no_private_connector_details(output: &ExecutorOutput) {
+    let rendered = format!(
+        "{:?} {}",
+        output.connector_invocation_evidence, output.value
+    );
+    for forbidden in [
+        "/var/private/traverse",
+        "bucket-prod",
+        "postgres://",
+        "scheduler-device-42",
+        "credential",
+        "secret-token",
+        "https://provider.internal",
+    ] {
+        assert!(
+            !rendered.contains(forbidden),
+            "connector output/evidence leaked {forbidden}: {rendered}"
+        );
+    }
+}
+
+struct ObjectStoreFixtureConnector {
+    max_bytes: u64,
+}
+
+impl MediatedConnector for ObjectStoreFixtureConnector {
+    fn invoke(&self, request: &ConnectorInvokeRequest) -> Result<ConnectorInvokeResponse, String> {
+        let size = request.payload["size"].as_u64().unwrap_or(u64::MAX);
+        let digest = request.payload["content_digest"]
+            .as_str()
+            .unwrap_or_default();
+        let result_class = if size > self.max_bytes {
+            "too_large"
+        } else if digest != "sha256:fixture-content" {
+            "integrity"
+        } else {
+            "stored"
+        };
+        Ok(ConnectorInvokeResponse {
+            abi_version: SUPPORTED_HOST_ABI_VERSION.to_string(),
+            result_class: result_class.to_string(),
+            payload: json!({
+                "asset_ref": "asset:fixture-content",
+                "content_digest": digest,
+                "size": size,
+                "result_class": result_class
+            }),
+        })
+    }
+}
+
+#[derive(Default)]
+struct StateStoreFixtureConnector {
+    state: Mutex<StateStoreFixtureState>,
+}
+
+#[derive(Default)]
+struct StateStoreFixtureState {
+    version: u64,
+    seen_idempotency: BTreeMap<String, u64>,
+}
+
+impl MediatedConnector for StateStoreFixtureConnector {
+    fn invoke(&self, request: &ConnectorInvokeRequest) -> Result<ConnectorInvokeResponse, String> {
+        let idempotency_key = request.payload["idempotency_key"]
+            .as_str()
+            .unwrap_or_default()
+            .to_string();
+        let expected_version = request.payload["expected_version"].as_u64();
+        let mut state = self
+            .state
+            .lock()
+            .map_err(|_| "state fixture lock poisoned".to_string())?;
+        if let Some(version) = state.seen_idempotency.get(&idempotency_key) {
+            return Ok(ConnectorInvokeResponse {
+                abi_version: SUPPORTED_HOST_ABI_VERSION.to_string(),
+                result_class: "replay".to_string(),
+                payload: json!({
+                    "result_ref": "state:fixture-transition",
+                    "version": version,
+                    "replay": true,
+                    "result_class": "replay"
+                }),
+            });
+        }
+        if expected_version.is_some_and(|version| version != state.version) {
+            return Ok(ConnectorInvokeResponse {
+                abi_version: SUPPORTED_HOST_ABI_VERSION.to_string(),
+                result_class: "conflict".to_string(),
+                payload: json!({
+                    "result_ref": "state:fixture-transition",
+                    "version": state.version,
+                    "replay": false,
+                    "result_class": "conflict"
+                }),
+            });
+        }
+        state.version += 1;
+        let version = state.version;
+        state.seen_idempotency.insert(idempotency_key, version);
+        Ok(ConnectorInvokeResponse {
+            abi_version: SUPPORTED_HOST_ABI_VERSION.to_string(),
+            result_class: "appended".to_string(),
+            payload: json!({
+                "result_ref": "state:fixture-transition",
+                "version": version,
+                "replay": false,
+                "result_class": "appended"
+            }),
+        })
+    }
+}
+
+#[derive(Default)]
+struct SchedulerFixtureConnector {
+    scheduled: Mutex<BTreeSet<String>>,
+}
+
+impl MediatedConnector for SchedulerFixtureConnector {
+    fn invoke(&self, request: &ConnectorInvokeRequest) -> Result<ConnectorInvokeResponse, String> {
+        let deadline = request.payload["logical_deadline"]
+            .as_str()
+            .unwrap_or_default();
+        let idempotency_key = request.payload["idempotency_key"]
+            .as_str()
+            .unwrap_or_default()
+            .to_string();
+        let result_class = if deadline < "2026-08-18T00:00:00Z" {
+            "late"
+        } else {
+            let mut scheduled = self
+                .scheduled
+                .lock()
+                .map_err(|_| "scheduler fixture lock poisoned".to_string())?;
+            if scheduled.insert(idempotency_key.clone()) {
+                "scheduled"
+            } else {
+                "duplicate"
+            }
+        };
+        Ok(ConnectorInvokeResponse {
+            abi_version: SUPPORTED_HOST_ABI_VERSION.to_string(),
+            result_class: result_class.to_string(),
+            payload: json!({
+                "invocation_ref": "schedule:fixture-invocation",
+                "idempotency_key": idempotency_key,
+                "result_class": result_class
+            }),
+        })
+    }
 }
 
 #[test]
@@ -921,6 +1149,290 @@ fn wasm_connector_invoke_requires_declaration_and_activation() -> Result<(), Str
         "success"
     );
     assert_eq!(output.connector_invocation_evidence[0].failure_class, None);
+    Ok(())
+}
+
+#[test]
+fn universal_connector_fixtures_invoke_through_mediated_abi() -> Result<(), String> {
+    struct UniversalConnectorCase {
+        connector_id: &'static str,
+        operation: &'static str,
+        payload: serde_json::Value,
+        connector: Arc<dyn MediatedConnector>,
+        result_class: &'static str,
+    }
+
+    let cases = vec![
+        UniversalConnectorCase {
+            connector_id: "traverse.object-store",
+            operation: "put_immutable",
+            payload: json!({
+                "content_ref": "content:fixture",
+                "content_digest": "sha256:fixture-content",
+                "size": 12,
+                "idempotency_key": "object-ok"
+            }),
+            connector: Arc::new(ObjectStoreFixtureConnector { max_bytes: 64 }),
+            result_class: "stored",
+        },
+        UniversalConnectorCase {
+            connector_id: "traverse.state-store",
+            operation: "append_transition",
+            payload: json!({
+                "record_refs": ["record:fixture"],
+                "transition": {"kind": "fixture"},
+                "expected_version": 0,
+                "idempotency_key": "state-ok"
+            }),
+            connector: Arc::new(StateStoreFixtureConnector::default()),
+            result_class: "appended",
+        },
+        UniversalConnectorCase {
+            connector_id: "traverse.scheduler",
+            operation: "schedule_invocation",
+            payload: json!({
+                "job_kind": "fixture-job",
+                "calendar_policy_ref": "calendar:fixture",
+                "logical_deadline": "2026-08-19T00:00:00Z",
+                "idempotency_key": "schedule-ok"
+            }),
+            connector: Arc::new(SchedulerFixtureConnector::default()),
+            result_class: "scheduled",
+        },
+    ];
+
+    for case in cases {
+        let output = invoke_connector_fixture(
+            case.connector_id,
+            case.operation,
+            &case.payload,
+            case.connector,
+        )?;
+        assert_eq!(output.value["result_class"], case.result_class);
+        assert_eq!(
+            output.connector_invocation_evidence[0].connector_id,
+            case.connector_id
+        );
+        assert_eq!(
+            output.connector_invocation_evidence[0]
+                .resolved_version
+                .as_deref(),
+            Some("1.0.0")
+        );
+        assert_eq!(
+            output.connector_invocation_evidence[0].result_class,
+            case.result_class
+        );
+        assert_eq!(output.connector_invocation_evidence[0].failure_class, None);
+        assert_no_private_connector_details(&output);
+    }
+
+    Ok(())
+}
+
+#[test]
+fn object_store_fixture_enforces_digest_and_byte_bounds() -> Result<(), String> {
+    let connector = Arc::new(ObjectStoreFixtureConnector { max_bytes: 16 });
+    let oversized = invoke_connector_fixture(
+        "traverse.object-store",
+        "put_immutable",
+        &json!({
+            "content_ref": "content:too-large",
+            "content_digest": "sha256:fixture-content",
+            "size": 17,
+            "idempotency_key": "object-too-large"
+        }),
+        connector.clone(),
+    )?;
+    assert_eq!(oversized.value["result_class"], "too_large");
+    assert_eq!(
+        oversized.connector_invocation_evidence[0].result_class,
+        "too_large"
+    );
+    assert_no_private_connector_details(&oversized);
+
+    let bad_digest = invoke_connector_fixture(
+        "traverse.object-store",
+        "put_immutable",
+        &json!({
+            "content_ref": "content:bad-digest",
+            "content_digest": "sha256:wrong",
+            "size": 12,
+            "idempotency_key": "object-bad-digest"
+        }),
+        connector,
+    )?;
+    assert_eq!(bad_digest.value["result_class"], "integrity");
+    assert_eq!(
+        bad_digest.connector_invocation_evidence[0].result_class,
+        "integrity"
+    );
+    assert_no_private_connector_details(&bad_digest);
+    Ok(())
+}
+
+#[test]
+fn state_store_fixture_replays_duplicate_and_reports_stale_conflict() -> Result<(), String> {
+    let connector = Arc::new(StateStoreFixtureConnector::default());
+    let initial = invoke_connector_fixture(
+        "traverse.state-store",
+        "append_transition",
+        &json!({
+            "record_refs": ["record:fixture"],
+            "transition": {"kind": "started"},
+            "expected_version": 0,
+            "idempotency_key": "state-idempotent"
+        }),
+        connector.clone(),
+    )?;
+    assert_eq!(initial.value["result_class"], "appended");
+    assert_eq!(initial.value["payload"]["version"], 1);
+
+    let replay = invoke_connector_fixture(
+        "traverse.state-store",
+        "append_transition",
+        &json!({
+            "record_refs": ["record:fixture"],
+            "transition": {"kind": "started"},
+            "expected_version": 0,
+            "idempotency_key": "state-idempotent"
+        }),
+        connector.clone(),
+    )?;
+    assert_eq!(replay.value["result_class"], "replay");
+    assert_eq!(replay.value["payload"]["replay"], true);
+
+    let stale = invoke_connector_fixture(
+        "traverse.state-store",
+        "append_transition",
+        &json!({
+            "record_refs": ["record:fixture"],
+            "transition": {"kind": "stale"},
+            "expected_version": 0,
+            "idempotency_key": "state-stale"
+        }),
+        connector,
+    )?;
+    assert_eq!(stale.value["result_class"], "conflict");
+    assert_eq!(stale.value["payload"]["version"], 1);
+
+    assert_no_private_connector_details(&initial);
+    assert_no_private_connector_details(&replay);
+    assert_no_private_connector_details(&stale);
+    Ok(())
+}
+
+#[test]
+fn scheduler_fixture_reports_duplicate_and_late_requests() -> Result<(), String> {
+    let connector = Arc::new(SchedulerFixtureConnector::default());
+    let scheduled = invoke_connector_fixture(
+        "traverse.scheduler",
+        "schedule_invocation",
+        &json!({
+            "job_kind": "fixture-job",
+            "calendar_policy_ref": "calendar:fixture",
+            "logical_deadline": "2026-08-19T00:00:00Z",
+            "idempotency_key": "schedule-idempotent"
+        }),
+        connector.clone(),
+    )?;
+    assert_eq!(scheduled.value["result_class"], "scheduled");
+
+    let duplicate = invoke_connector_fixture(
+        "traverse.scheduler",
+        "schedule_invocation",
+        &json!({
+            "job_kind": "fixture-job",
+            "calendar_policy_ref": "calendar:fixture",
+            "logical_deadline": "2026-08-19T00:00:00Z",
+            "idempotency_key": "schedule-idempotent"
+        }),
+        connector.clone(),
+    )?;
+    assert_eq!(duplicate.value["result_class"], "duplicate");
+
+    let late = invoke_connector_fixture(
+        "traverse.scheduler",
+        "schedule_invocation",
+        &json!({
+            "job_kind": "fixture-job",
+            "calendar_policy_ref": "calendar:fixture",
+            "logical_deadline": "2026-08-17T23:59:59Z",
+            "idempotency_key": "schedule-late"
+        }),
+        connector,
+    )?;
+    assert_eq!(late.value["result_class"], "late");
+
+    assert_no_private_connector_details(&scheduled);
+    assert_no_private_connector_details(&duplicate);
+    assert_no_private_connector_details(&late);
+    Ok(())
+}
+
+#[test]
+fn universal_connector_authorization_failures_are_non_secret() -> Result<(), String> {
+    let request = connector_request(
+        "traverse.object-store",
+        "put_immutable",
+        &json!({
+            "content_ref": "content:fixture",
+            "content_digest": "sha256:fixture-content",
+            "size": 12,
+            "idempotency_key": "object-authz"
+        }),
+    );
+    let request_len = i32::try_from(request.len())
+        .map_err(|error| format!("request length conversion: {error}"))?;
+    let wasm = connector_test_wasm(&request, 32, request_len, 256, 2048)?;
+    let executor = WasmExecutor::new().map_err(|error| format!("{error:?}"))?;
+
+    let undeclared = executor
+        .run_bytes_with_mediated_connectors(
+            &wasm,
+            &json!({}),
+            "universal-connector-authz",
+            MediatedConnectorContext {
+                declared_requirements: vec![ConnectorRequirement {
+                    connector_id: "traverse.scheduler".to_string(),
+                    version: "^1.0.0".to_string(),
+                }],
+                activated_connectors: vec![ActivatedConnector {
+                    connector_id: "traverse.object-store".to_string(),
+                    version: "1.0.0".to_string(),
+                    implementation: Arc::new(ObjectStoreFixtureConnector { max_bytes: 64 }),
+                }],
+            },
+        )
+        .map_err(|error| format!("{error:?}"))?;
+    assert_eq!(
+        undeclared.connector_invocation_evidence[0]
+            .failure_class
+            .as_deref(),
+        Some("undeclared")
+    );
+    assert_no_private_connector_details(&undeclared);
+
+    let incompatible = executor
+        .run_bytes_with_mediated_connectors(
+            &wasm,
+            &json!({}),
+            "universal-connector-authz",
+            universal_connector_context(
+                "traverse.object-store",
+                Arc::new(ObjectStoreFixtureConnector { max_bytes: 64 }),
+                "2.0.0",
+            ),
+        )
+        .map_err(|error| format!("{error:?}"))?;
+    assert_eq!(
+        incompatible.connector_invocation_evidence[0]
+            .failure_class
+            .as_deref(),
+        Some("incompatible")
+    );
+    assert_no_private_connector_details(&incompatible);
+
     Ok(())
 }
 


### PR DESCRIPTION
## Summary

- Adds mediated end-to-end runtime fixtures for the universal `traverse.object-store`, `traverse.state-store`, and `traverse.scheduler` connectors.
- Covers happy-path `traverse_host::connector_invoke` output capture plus fixture-level failure classes for oversized object writes, digest mismatch, stale state versions, duplicate idempotency keys, duplicate schedules, late schedules, undeclared connectors, and incompatible activated versions.
- Adds CLI app activation fixtures proving universal connector activation evidence records only public connector metadata and config key names, while rejecting missing required host config without persisting state or leaking host-private values.
- Implements acceptance coverage for ADR-0039 via its approved governing specs.

## Governing Spec

- `039-connector-plugin-architecture`
- `103-application-connector-binding`
- `104-mediated-connector-invocation`

## Project Item

Closes #1079.

## Definition of Done

- Object-store fixture enforces content digest and byte bounds and returns opaque `asset:` refs.
- State-store fixture returns idempotent replay for duplicate idempotency keys and stable conflict for stale expected versions.
- Scheduler fixture returns deterministic duplicate and late request failures.
- CLI activation fixtures cover happy and failure path behavior without leaking private connector config values.
- Guest-visible output and public connector evidence are asserted not to expose representative local paths, bucket names, provider endpoints, device IDs, credentials, or raw private config.

## Validation

- `cargo test -p traverse-runtime --test executor_tests`
- `cargo test -p traverse-cli-rs universal_connector -- --nocapture`
- `cargo clippy -p traverse-runtime --test executor_tests -- -D warnings`
- `cargo clippy -p traverse-cli-rs --all-targets -- -D warnings`
- `BASE_SHA=origin/main bash scripts/ci/spec_alignment_check.sh <PR body>`

Note: local full `bash scripts/ci/coverage_gate.sh` reached the required gate, but local elevated coverage reruns were blocked by the Codex usage limiter in this environment; GitHub Actions will run it in a clean environment.
