### PR TITLE
feat(mcp): expose standalone package discovery posture

### DIFF
--- a/crates/traverse-cli/src/main.rs
+++ b/crates/traverse-cli/src/main.rs
@@ -5025,12 +5025,31 @@ fn discover_capabilities(manifest_path: &Path, json_output: bool) -> Result<Stri
         let json_entries: Vec<serde_json::Value> = entries
             .iter()
             .map(|entry| {
+                let resolved = registered.capability_registry.find_exact(
+                    LookupScope::PreferPrivate,
+                    &entry.id,
+                    &entry.version,
+                );
+                let package_mode = resolved
+                    .as_ref()
+                    .map_or("unknown", |capability| {
+                        capability_discovery_package_mode(&capability.artifact)
+                    });
+                let advisory_compositions = resolved.as_ref().map_or_else(Vec::new, |capability| {
+                    capability_discovery_advisory_compositions(
+                        capability.artifact.workflow_ref.as_ref(),
+                    )
+                });
                 serde_json::json!({
                     "id": entry.id,
                     "version": entry.version,
                     "scope": format!("{:?}", entry.scope).to_lowercase(),
                     "lifecycle": format!("{:?}", entry.lifecycle).to_lowercase(),
                     "implementation_kind": format!("{:?}", entry.implementation_kind).to_lowercase(),
+                    "package_mode": package_mode,
+                    "advisory_compositions": advisory_compositions,
+                    "activation_eligibility": "unknown",
+                    "activation_eligibility_reason": "requires_host_activation_resolution",
                     "summary": entry.summary,
                     "tags": entry.tags,
                 })
@@ -5045,6 +5064,27 @@ fn discover_capabilities(manifest_path: &Path, json_output: bool) -> Result<Stri
             .collect();
         Ok(lines.join("\n"))
     }
+}
+
+fn capability_discovery_package_mode(artifact: &CapabilityArtifactRecord) -> &'static str {
+    if artifact.workflow_ref.is_some() {
+        "workflow_composed"
+    } else {
+        "standalone"
+    }
+}
+
+fn capability_discovery_advisory_compositions(
+    workflow_ref: Option<&WorkflowReference>,
+) -> Vec<String> {
+    workflow_ref
+        .map(|reference| {
+            vec![format!(
+                "{}@{}",
+                reference.workflow_id, reference.workflow_version
+            )]
+        })
+        .unwrap_or_default()
 }
 
 fn inspect_capability_package(manifest_path: &Path) -> Result<String, CliError> {
@@ -6860,9 +6900,9 @@ mod tests {
         app_activate_at, app_activation_state_path, app_new_at, app_register_at,
         app_registration_state_path, app_validate, app_validate_at,
         canonical_expedition_bundle_path, capability_new_at, capability_publish_at, component_new,
-        curl_text, enforce_contract_surface_coverage, enforce_persona_refs_resolve,
-        ensure_clean_registry_checkout, execute_capability_package, execute_expedition,
-        execute_traverse_starter_process, execute_traverse_starter_summarize,
+        curl_text, discover_capabilities, enforce_contract_surface_coverage,
+        enforce_persona_refs_resolve, ensure_clean_registry_checkout, execute_capability_package,
+        execute_expedition, execute_traverse_starter_process, execute_traverse_starter_summarize,
         execute_traverse_starter_validate, format_capability_package_execution_summary,
         help_expedition_execute, help_serve, inspect_bundle, inspect_capability,
         inspect_capability_package, inspect_event, inspect_trace, latest_index_release_asset,
@@ -9493,6 +9533,38 @@ mod tests {
         assert!(output.contains("registered_events: 5"));
         assert!(output.contains("registered_workflows: 1"));
         assert!(output.contains("expedition.planning.plan-expedition@1.0.0 (workflow)"));
+    }
+
+    #[test]
+    fn capability_discover_json_distinguishes_package_mode_from_activation_eligibility() {
+        let manifest_path =
+            repo_root().join("examples/traverse-starter/registry-bundle/manifest.json");
+        let output = discover_capabilities(&manifest_path, true)
+            .expect("capability discovery should render JSON");
+        let entries: Vec<Value> =
+            serde_json::from_str(&output).expect("discovery output should be JSON");
+        let process = entries
+            .iter()
+            .find(|entry| entry["id"] == "traverse-starter.process")
+            .expect("process capability should be discovered");
+        let pipeline = entries
+            .iter()
+            .find(|entry| entry["id"] == "traverse-starter.pipeline")
+            .expect("pipeline capability should be discovered");
+
+        assert_eq!(process["package_mode"], "standalone");
+        assert_eq!(process["advisory_compositions"], serde_json::json!([]));
+        assert_eq!(process["activation_eligibility"], "unknown");
+        assert_eq!(
+            process["activation_eligibility_reason"],
+            "requires_host_activation_resolution"
+        );
+        assert_eq!(pipeline["package_mode"], "workflow_composed");
+        assert_eq!(
+            pipeline["advisory_compositions"],
+            serde_json::json!(["traverse-starter.pipeline@1.0.0"])
+        );
+        assert_eq!(pipeline["activation_eligibility"], "unknown");
     }
 
     #[test]

--- a/crates/traverse-mcp/src/lib.rs
+++ b/crates/traverse-mcp/src/lib.rs
@@ -13,8 +13,9 @@ pub use stdio_server::*;
 
 use std::collections::HashMap;
 use traverse_registry::{
-    CapabilityRegistry, DiscoveryQuery, EventRegistry, LookupScope, ModelResolutionEvidence,
-    RegistryScope, ResolvedCapability, ResolvedEvent, ResolvedWorkflow, WorkflowRegistry,
+    CapabilityArtifactRecord, CapabilityRegistry, DiscoveryQuery, EventRegistry, LookupScope,
+    ModelResolutionEvidence, RegistryScope, ResolvedCapability, ResolvedEvent, ResolvedWorkflow,
+    WorkflowReference, WorkflowRegistry,
 };
 use traverse_runtime::{
     LocalExecutor, Runtime, RuntimeErrorCode, RuntimeExecutionOutcome, RuntimeRequest,
@@ -35,12 +36,23 @@ pub fn discover_capabilities(registry: &CapabilityRegistry) -> serde_json::Value
     let summaries: Vec<serde_json::Value> = entries
         .into_iter()
         .map(|e| {
+            let resolved = registry.find_exact(LookupScope::PreferPrivate, &e.id, &e.version);
+            let package_mode = resolved
+                .as_ref()
+                .map_or("unknown", |cap| capability_package_mode(&cap.artifact));
+            let advisory_compositions = resolved.as_ref().map_or_else(Vec::new, |cap| {
+                advisory_compositions(cap.artifact.workflow_ref.as_ref())
+            });
             serde_json::json!({
                 "id": e.id,
                 "version": e.version,
                 "lifecycle": lifecycle_name(&e.lifecycle),
                 "summary": e.summary,
                 "tags": e.tags,
+                "package_mode": package_mode,
+                "advisory_compositions": advisory_compositions,
+                "activation_eligibility": activation_eligibility_unknown(),
+                "activation_eligibility_reason": activation_eligibility_reason(),
             })
         })
         .collect();
@@ -166,6 +178,21 @@ where
             .discover(map_lookup_scope(lookup_scope), query)
             .into_iter()
             .map(|entry| McpArtifactSummary {
+                package_mode: self
+                    .capability_registry
+                    .find_exact(map_lookup_scope(lookup_scope), &entry.id, &entry.version)
+                    .as_ref()
+                    .map_or("unknown", |cap| capability_package_mode(&cap.artifact))
+                    .to_string(),
+                advisory_compositions: self
+                    .capability_registry
+                    .find_exact(map_lookup_scope(lookup_scope), &entry.id, &entry.version)
+                    .as_ref()
+                    .map_or_else(Vec::new, |cap| {
+                        advisory_compositions(cap.artifact.workflow_ref.as_ref())
+                    }),
+                activation_eligibility: activation_eligibility_unknown().to_string(),
+                activation_eligibility_reason: activation_eligibility_reason().to_string(),
                 artifact_kind: McpArtifactKind::Capability,
                 scope: map_registry_scope(entry.scope),
                 id: entry.id,
@@ -189,6 +216,10 @@ where
                 scope: map_registry_scope(entry.scope),
                 id: entry.id,
                 version: entry.version,
+                package_mode: "not_applicable".to_string(),
+                advisory_compositions: Vec::new(),
+                activation_eligibility: "not_applicable".to_string(),
+                activation_eligibility_reason: "not_executable_capability_package".to_string(),
                 lifecycle: lifecycle_name(&entry.lifecycle).to_string(),
                 summary: entry.summary,
                 owner_team: None,
@@ -208,6 +239,10 @@ where
                 scope: map_registry_scope(entry.scope),
                 id: entry.id,
                 version: entry.version,
+                package_mode: "not_applicable".to_string(),
+                advisory_compositions: Vec::new(),
+                activation_eligibility: "not_applicable".to_string(),
+                activation_eligibility_reason: "not_executable_capability_package".to_string(),
                 lifecycle: lifecycle_name(&entry.lifecycle).to_string(),
                 summary: entry.summary,
                 owner_team: Some(entry.owner.team),
@@ -368,6 +403,10 @@ pub struct McpArtifactSummary {
     pub scope: McpRegistryScope,
     pub id: String,
     pub version: String,
+    pub package_mode: String,
+    pub advisory_compositions: Vec<String>,
+    pub activation_eligibility: String,
+    pub activation_eligibility_reason: String,
     pub lifecycle: String,
     pub summary: String,
     pub owner_team: Option<String>,
@@ -498,6 +537,33 @@ fn map_lookup_scope(scope: McpLookupScope) -> LookupScope {
     }
 }
 
+fn capability_package_mode(artifact: &CapabilityArtifactRecord) -> &'static str {
+    if artifact.workflow_ref.is_some() {
+        "workflow_composed"
+    } else {
+        "standalone"
+    }
+}
+
+fn advisory_compositions(workflow_ref: Option<&WorkflowReference>) -> Vec<String> {
+    workflow_ref
+        .map(|reference| {
+            vec![format!(
+                "{}@{}",
+                reference.workflow_id, reference.workflow_version
+            )]
+        })
+        .unwrap_or_default()
+}
+
+fn activation_eligibility_unknown() -> &'static str {
+    "unknown"
+}
+
+fn activation_eligibility_reason() -> &'static str {
+    "requires_host_activation_resolution"
+}
+
 fn map_registry_scope(scope: RegistryScope) -> McpRegistryScope {
     match scope {
         RegistryScope::Public => McpRegistryScope::Public,
@@ -562,7 +628,7 @@ mod tests {
         EventRegistration, ModelCandidateEvaluation, ModelCandidateReadiness,
         ModelCandidateRejectionCode, ModelResolutionEvidence, ModelResolutionPhase,
         RegistryProvenance, SelectedModelCandidate, SourceKind, SourceReference,
-        WorkflowDefinition, WorkflowNode, WorkflowNodeInput, WorkflowNodeOutput,
+        WorkflowDefinition, WorkflowNode, WorkflowNodeInput, WorkflowNodeOutput, WorkflowReference,
         WorkflowRegistration,
     };
     use traverse_runtime::{
@@ -590,10 +656,82 @@ mod tests {
 
         assert_eq!(capabilities.len(), 1);
         assert_eq!(capabilities[0].artifact_kind, McpArtifactKind::Capability);
+        assert_eq!(capabilities[0].package_mode, "standalone");
+        assert_eq!(capabilities[0].advisory_compositions, Vec::<String>::new());
+        assert_eq!(capabilities[0].activation_eligibility, "unknown");
+        assert_eq!(
+            capabilities[0].activation_eligibility_reason,
+            "requires_host_activation_resolution"
+        );
         assert_eq!(events.len(), 1);
         assert_eq!(events[0].artifact_kind, McpArtifactKind::Event);
+        assert_eq!(events[0].activation_eligibility, "not_applicable");
         assert_eq!(workflows.len(), 1);
         assert_eq!(workflows[0].artifact_kind, McpArtifactKind::Workflow);
+        assert_eq!(workflows[0].activation_eligibility, "not_applicable");
+    }
+
+    #[test]
+    fn capability_discovery_marks_workflow_compositions_advisory_and_not_activation_eligible() {
+        let mut capability_registry = CapabilityRegistry::new();
+        let mut artifact = capability_artifact_record();
+        artifact.implementation_kind = traverse_registry::ImplementationKind::Workflow;
+        artifact.binary = None;
+        artifact.digests.binary_digest = None;
+        artifact.workflow_ref = Some(WorkflowReference {
+            workflow_id: "content.comments.publish-comment".to_string(),
+            workflow_version: "1.0.0".to_string(),
+        });
+        capability_registry
+            .register(CapabilityRegistration {
+                scope: RegistryScope::Private,
+                contract: capability_contract(),
+                contract_path:
+                    "registry/private/content.comments.create-comment-draft/1.0.0/contract.json"
+                        .to_string(),
+                artifact,
+                registered_at: "2026-03-30T00:00:00Z".to_string(),
+                tags: vec!["comments".to_string()],
+                composability: ComposabilityMetadata {
+                    kind: CompositionKind::Composite,
+                    patterns: vec![CompositionPattern::Sequential],
+                    provides: vec!["draft".to_string()],
+                    requires: Vec::new(),
+                },
+                governing_spec: "005-capability-registry".to_string(),
+                validator_version: "validator".to_string(),
+            })
+            .expect("workflow-referenced capability should register");
+        let event_registry = EventRegistry::new();
+        let workflow_registry = WorkflowRegistry::new();
+        let runtime = runtime_fixture(&capability_registry, &workflow_registry);
+        let mcp = TraverseMcp::new(
+            &capability_registry,
+            &event_registry,
+            &workflow_registry,
+            &runtime,
+        );
+
+        let json = super::discover_capabilities(&capability_registry);
+        assert_eq!(json[0]["package_mode"], "workflow_composed");
+        assert_eq!(
+            json[0]["advisory_compositions"],
+            serde_json::json!(["content.comments.publish-comment@1.0.0"])
+        );
+        assert_eq!(json[0]["activation_eligibility"], "unknown");
+        assert_eq!(
+            json[0]["activation_eligibility_reason"],
+            "requires_host_activation_resolution"
+        );
+
+        let discovered =
+            mcp.discover_capabilities(McpLookupScope::PreferPrivate, &DiscoveryQuery::default());
+        assert_eq!(discovered[0].package_mode, "workflow_composed");
+        assert_eq!(
+            discovered[0].advisory_compositions,
+            vec!["content.comments.publish-comment@1.0.0"]
+        );
+        assert_eq!(discovered[0].activation_eligibility, "unknown");
     }
 
     #[test]
@@ -1345,6 +1483,13 @@ mod tests {
         assert!(entry.get("version").is_some(), "entry must have version");
         assert!(entry.get("summary").is_some(), "entry must have summary");
         assert!(entry.get("tags").is_some(), "entry must have tags");
+        assert_eq!(entry["package_mode"], "standalone");
+        assert_eq!(entry["advisory_compositions"], serde_json::json!([]));
+        assert_eq!(entry["activation_eligibility"], "unknown");
+        assert_eq!(
+            entry["activation_eligibility_reason"],
+            "requires_host_activation_resolution"
+        );
     }
 
     #[test]

--- a/crates/traverse-mcp/src/tools/capabilities.rs
+++ b/crates/traverse-mcp/src/tools/capabilities.rs
@@ -4,7 +4,9 @@
 
 use serde::{Deserialize, Serialize};
 use traverse_contracts::{ExecutionTarget, ServiceType};
-use traverse_registry::{CapabilityRegistry, DiscoveryQuery, LookupScope};
+use traverse_registry::{
+    CapabilityArtifactRecord, CapabilityRegistry, DiscoveryQuery, LookupScope, WorkflowReference,
+};
 
 use crate::{McpError, McpErrorCode};
 
@@ -31,6 +33,14 @@ pub struct CapabilitySummary {
     pub permitted_targets: Vec<ExecutionTarget>,
     /// Short human-readable description.
     pub description: String,
+    /// Whether the executable package is standalone or carries advisory workflow composition metadata.
+    pub package_mode: String,
+    /// Advisory known workflow compositions; never used as execution authority.
+    pub advisory_compositions: Vec<String>,
+    /// Host activation eligibility is unknown from registry discovery alone.
+    pub activation_eligibility: String,
+    /// Stable reason explaining why eligibility requires activation evidence.
+    pub activation_eligibility_reason: String,
 }
 
 /// List all capabilities, optionally filtered by `service_type` or `permitted_targets`.
@@ -69,8 +79,31 @@ pub fn list_capabilities(
             service_type: cap.contract.service_type.clone(),
             permitted_targets: cap.contract.permitted_targets.clone(),
             description: cap.contract.description.clone(),
+            package_mode: capability_package_mode(&cap.artifact).to_string(),
+            advisory_compositions: advisory_compositions(cap.artifact.workflow_ref.as_ref()),
+            activation_eligibility: "unknown".to_string(),
+            activation_eligibility_reason: "requires_host_activation_resolution".to_string(),
         })
         .collect()
+}
+
+fn capability_package_mode(artifact: &CapabilityArtifactRecord) -> &'static str {
+    if artifact.workflow_ref.is_some() {
+        "workflow_composed"
+    } else {
+        "standalone"
+    }
+}
+
+fn advisory_compositions(workflow_ref: Option<&WorkflowReference>) -> Vec<String> {
+    workflow_ref
+        .map(|reference| {
+            vec![format!(
+                "{}@{}",
+                reference.workflow_id, reference.workflow_version
+            )]
+        })
+        .unwrap_or_default()
 }
 
 /// Return the full contract JSON for a capability identified by `capability_id`.

--- a/crates/traverse-mcp/tests/mcp_tests.rs
+++ b/crates/traverse-mcp/tests/mcp_tests.rs
@@ -21,7 +21,7 @@ use traverse_registry::{
     ArtifactDigests, BinaryFormat, BinaryReference, CapabilityArtifactRecord,
     CapabilityRegistration, CapabilityRegistry, ComposabilityMetadata, CompositionKind,
     CompositionPattern, ImplementationKind, RegistryProvenance, RegistryScope, SourceKind,
-    SourceReference,
+    SourceReference, WorkflowReference,
 };
 use traverse_runtime::{
     events::{
@@ -174,6 +174,18 @@ fn capability_artifact_record(id: &str) -> CapabilityArtifactRecord {
     }
 }
 
+fn workflow_composed_capability_artifact_record(id: &str) -> CapabilityArtifactRecord {
+    let mut artifact = capability_artifact_record(id);
+    artifact.implementation_kind = ImplementationKind::Workflow;
+    artifact.binary = None;
+    artifact.digests.binary_digest = None;
+    artifact.workflow_ref = Some(WorkflowReference {
+        workflow_id: "content.comments.publish-comment".to_string(),
+        workflow_version: "1.0.0".to_string(),
+    });
+    artifact
+}
+
 fn composability() -> ComposabilityMetadata {
     ComposabilityMetadata {
         kind: CompositionKind::Atomic,
@@ -218,6 +230,31 @@ fn capability_registry_with_two_capabilities() -> Result<CapabilityRegistry, Str
         })
         .map_err(|e| format!("{e:?}"))?;
 
+    Ok(registry)
+}
+
+fn workflow_composed_capability_registry() -> Result<CapabilityRegistry, String> {
+    let mut registry = CapabilityRegistry::new();
+    let contract = capability_contract();
+    let id = contract.id.clone();
+    registry
+        .register(CapabilityRegistration {
+            scope: RegistryScope::Public,
+            contract,
+            contract_path: format!("registry/public/{id}/1.0.0/contract.json"),
+            artifact: workflow_composed_capability_artifact_record(&id),
+            registered_at: "2026-04-09T00:00:00Z".to_string(),
+            tags: vec!["comments".to_string()],
+            composability: ComposabilityMetadata {
+                kind: CompositionKind::Composite,
+                patterns: vec![CompositionPattern::Sequential],
+                provides: vec!["draft".to_string()],
+                requires: Vec::new(),
+            },
+            governing_spec: "005-capability-registry".to_string(),
+            validator_version: "v1".to_string(),
+        })
+        .map_err(|e| format!("{e:?}"))?;
     Ok(registry)
 }
 
@@ -327,6 +364,31 @@ fn list_capabilities_returns_expected_fields() -> Result<(), String> {
     assert_eq!(s.name, "create-comment-draft");
     assert!(!s.description.is_empty());
     assert!(!s.permitted_targets.is_empty());
+    assert_eq!(s.package_mode, "standalone");
+    assert!(s.advisory_compositions.is_empty());
+    assert_eq!(s.activation_eligibility, "unknown");
+    assert_eq!(
+        s.activation_eligibility_reason,
+        "requires_host_activation_resolution"
+    );
+    Ok(())
+}
+
+#[test]
+fn list_capabilities_marks_workflow_compositions_advisory() -> Result<(), String> {
+    let registry = workflow_composed_capability_registry()?;
+    let summaries = list_capabilities(&registry, None);
+    assert_eq!(summaries.len(), 1);
+    assert_eq!(summaries[0].package_mode, "workflow_composed");
+    assert_eq!(
+        summaries[0].advisory_compositions,
+        vec!["content.comments.publish-comment@1.0.0"]
+    );
+    assert_eq!(summaries[0].activation_eligibility, "unknown");
+    assert_eq!(
+        summaries[0].activation_eligibility_reason,
+        "requires_host_activation_resolution"
+    );
     Ok(())
 }
 

--- a/docs/architecture-execution-models.md
+++ b/docs/architecture-execution-models.md
@@ -24,7 +24,7 @@ CLI request → PlacementRouter → WasmExecutor → WASM binary (stdin/stdout) 
 
 ### 2. MCP Surface (Agent/LLM Discovery and Invocation)
 
-**What**: The `traverse-mcp` crate exposes a Model Context Protocol server over stdio. It provides tools that LLMs and AI agents can call to discover registered capabilities, inspect their contracts, and execute them — without knowing the CLI.
+**What**: The `traverse-mcp` crate exposes a Model Context Protocol server over stdio plus a Rust library surface. It provides tools that LLMs and AI agents can call to discover registered capabilities, inspect their contracts, and execute them — without knowing the CLI.
 
 **MCP tools exposed**:
 | Tool | Description |
@@ -48,7 +48,13 @@ LLM tool call → MCP stdio server → traverse-mcp → traverse-runtime → Was
 
 **Entry point**: [`docs/mcp-stdio-server.md`](mcp-stdio-server.md)
 
-**Important**: In v0.1, `traverse-mcp` is a stdio binary server. Agents cannot link it as a library — they must communicate via the MCP wire protocol. See [#310](https://github.com/traverse-framework/traverse/issues/310) for the planned library API.
+**Important**: Capability discovery is contract/package discovery, not host activation. Discovery may report whether a package is standalone or carries advisory workflow composition metadata, but it must not claim the package is activation-eligible without host activation-resolution evidence.
+
+### Direct Invocation vs Application Activation
+
+Standalone capability packages can be inspected and executed directly through `capability-package execute`, MCP `execute_capability`, or the `traverse-mcp` library API when the caller supplies a valid runtime request. Direct invocation uses the registered capability contract and executable artifact metadata.
+
+Governed application activation is a separate host step. `traverse-cli app activate` resolves application-required contracts to host-installed executable artifacts and records immutable activation evidence. That evidence is the only place discovery consumers should treat a package as activation-eligible for an application. Advisory composition metadata such as known workflow references is useful context, but it does not grant authority, select artifacts, or prove host availability.
 
 ---
 


### PR DESCRIPTION
## Summary

- Expose package posture in CLI and MCP capability discovery so standalone executable capability packages are visible as standalone.
- Surface workflow composition references as advisory discovery metadata, not as activation eligibility or artifact selection authority.
- Document the boundary between direct package invocation and governed application activation.

## Governing Spec

- `015-capability-discovery-mcp`
- `042-mcp-library-surface`
- `065-sigstore-bundle-verification`
- `070-runtime-event-sink-boundary`
- `105-standalone-capability-packages`
- `106-activation-artifact-resolution`

## Project Item

Closes #1061.

## Definition of Done

- Capability discovery reports standalone packages without requiring `known_compositions`.
- Workflow-composed package metadata is exposed only as advisory composition context.
- Discovery responses do not claim host activation eligibility without activation-resolution evidence.
- CLI JSON discovery, MCP tool summaries, MCP library summaries, and documentation stay aligned.

## Validation

- `cargo test -p traverse-mcp`
- `cargo test -p traverse-cli-rs capability_discover -- --nocapture`
- `cargo clippy -p traverse-mcp --all-targets -- -D warnings`
- `cargo clippy -p traverse-cli-rs --all-targets -- -D warnings`
- `BASE_SHA=origin/main bash scripts/ci/spec_alignment_check.sh /private/tmp/pr-1061-body.md`
- `bash scripts/ci/coverage_gate.sh`
