### PR TITLE
feat(mcp): distinguish discovery from activation

### DIFF
--- a/crates/traverse-mcp/src/lib.rs
+++ b/crates/traverse-mcp/src/lib.rs
@@ -41,6 +41,9 @@ pub fn discover_capabilities(registry: &CapabilityRegistry) -> serde_json::Value
                 "lifecycle": lifecycle_name(&e.lifecycle),
                 "summary": e.summary,
                 "tags": e.tags,
+                "implementation_kind": format!("{:?}", e.implementation_kind),
+                "artifact_ref": e.artifact_ref,
+                "activation_eligibility": "host_activation_required",
             })
         })
         .collect();
@@ -175,6 +178,9 @@ where
                 owner_team: Some(entry.owner.team),
                 tags: entry.tags,
                 provenance_summary: None,
+                implementation_kind: Some(format!("{:?}", entry.implementation_kind)),
+                artifact_ref: Some(entry.artifact_ref),
+                activation_eligibility: "host_activation_required".to_string(),
             })
             .collect()
     }
@@ -194,6 +200,9 @@ where
                 owner_team: None,
                 tags: entry.tags,
                 provenance_summary: Some(format!("{:?}", entry.classification)),
+                implementation_kind: None,
+                artifact_ref: None,
+                activation_eligibility: "not_applicable".to_string(),
             })
             .collect()
     }
@@ -217,6 +226,9 @@ where
                     entry.start_node,
                     entry.terminal_nodes.join(",")
                 )),
+                implementation_kind: None,
+                artifact_ref: None,
+                activation_eligibility: "not_applicable".to_string(),
             })
             .collect()
     }
@@ -373,6 +385,12 @@ pub struct McpArtifactSummary {
     pub owner_team: Option<String>,
     pub tags: Vec<String>,
     pub provenance_summary: Option<String>,
+    /// Portable implementation metadata; it does not assert host eligibility.
+    pub implementation_kind: Option<String>,
+    /// Registry artifact identity for discoverable executable packages.
+    pub artifact_ref: Option<String>,
+    /// Discovery intentionally reports host-specific eligibility truthfully.
+    pub activation_eligibility: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -1342,6 +1360,8 @@ mod tests {
             entry["id"].as_str(),
             Some("content.comments.create-comment-draft")
         );
+        assert_eq!(entry["activation_eligibility"], "host_activation_required");
+        assert!(entry["artifact_ref"].is_string());
         assert!(entry.get("version").is_some(), "entry must have version");
         assert!(entry.get("summary").is_some(), "entry must have summary");
         assert!(entry.get("tags").is_some(), "entry must have tags");

--- a/docs/mcp-stdio-server.md
+++ b/docs/mcp-stdio-server.md
@@ -13,6 +13,11 @@ It is intentionally narrow:
 - it exposes discovery, description, validation, execution, and execution-report rendering through one stdio command surface
 - it is documented and runnable locally
 
+Discovery reports portable contract and executable-package metadata only. A
+discoverable standalone package is not thereby eligible to execute on the
+current host: activation remains host-specific and must resolve the package
+against that host's verified artifacts, placement, bindings, and configuration.
+
 ## Supported Bootstrap Path
 
 The supported developer bootstrap path for the dedicated MCP server is:


### PR DESCRIPTION
## Summary

- Expose standalone executable-package metadata through MCP capability discovery.
- Mark activation eligibility truthfully as host-specific and document the boundary.

## Governing Spec

- `105-standalone-capability-packages`
- `106-activation-artifact-resolution`
- `086-mode-a-registry-mcp`

## Project Item

- Closes #1061

## Definition of Done

- [x] Discovery includes portable package metadata without asserting host eligibility.
- [x] MCP documentation distinguishes discovery from activation.

## Validation

- `cargo fmt --check`
- `cargo test -p traverse-mcp discover_capabilities`
