### PR TITLE
feat(contracts): immutable capability risk metadata and manifest tightening

### DIFF
--- a/crates/traverse-cli/src/http_api.rs
+++ b/crates/traverse-cli/src/http_api.rs
@@ -7438,6 +7438,7 @@ mod tests {
             connector_requirements: Vec::new(),
             state_schema: None,
             use_cases: Vec::new(),
+            risk: traverse_contracts::default_risk_metadata(),
         }
     }
 

--- a/crates/traverse-cli/src/main.rs
+++ b/crates/traverse-cli/src/main.rs
@@ -4907,9 +4907,57 @@ fn validate_app_manifest_metadata_for_cli(
         {
             return Ok(Some(error));
         }
+
+        if let Some(error) =
+            validate_component_risk_policy_for_cli(&component_path, &component_manifest)
+        {
+            return Ok(Some(error));
+        }
     }
 
     Ok(None)
+}
+
+/// Spec 109 FR-005: a component manifest may declare `risk_policy` to narrow
+/// (never widen) the egress connectors its capability's immutable, contract-
+/// declared `risk` metadata allows. Silently skips the check when either the
+/// contract or an override is absent/unreadable — a missing/invalid contract
+/// reference is reported by other manifest validation, not this one.
+fn validate_component_risk_policy_for_cli(
+    component_path: &Path,
+    component_manifest: &Value,
+) -> Option<AppValidationError> {
+    let egress_allowed_connectors = component_manifest
+        .get("risk_policy")
+        .and_then(|policy| policy.get("egress_allowed_connectors"))
+        .and_then(Value::as_array)?;
+    let egress_allowed_connectors: Vec<String> = egress_allowed_connectors
+        .iter()
+        .filter_map(|value| value.as_str().map(str::to_string))
+        .collect();
+
+    let contract_path = component_manifest
+        .get("contract_path")
+        .and_then(Value::as_str)?;
+    let component_dir = component_path.parent().unwrap_or_else(|| Path::new(""));
+    let resolved_contract_path = component_dir.join(contract_path);
+    if !resolved_contract_path.is_file() {
+        return None;
+    }
+    let contract_json = fs::read_to_string(&resolved_contract_path).ok()?;
+    let contract = traverse_contracts::parse_contract(&contract_json).ok()?;
+
+    let policy = traverse_contracts::ManifestRiskPolicy {
+        egress_allowed_connectors: Some(egress_allowed_connectors),
+    };
+    let failure =
+        traverse_contracts::validate_manifest_risk_policy(&contract.risk, &policy).err()?;
+    let error = failure.errors.into_iter().next()?;
+    Some(AppValidationError {
+        code: "risk_policy_weakened".to_string(),
+        path: format!("{}:{}", component_path.display(), error.path),
+        message: error.message,
+    })
 }
 
 fn find_private_manifest_field(value: &Value, path: &str) -> Option<AppValidationError> {
@@ -6893,8 +6941,8 @@ mod tests {
     #![allow(clippy::expect_used)]
 
     use super::{
-        ArtifactRouter, CapabilityPublishRequest, CapabilityRegistry, CliError, Command,
-        DEFAULT_PUBLIC_REGISTRY_SOURCE, ExpeditionExampleExecutor, FetchedRegistryIndex,
+        AppValidationError, ArtifactRouter, CapabilityPublishRequest, CapabilityRegistry, CliError,
+        Command, DEFAULT_PUBLIC_REGISTRY_SOURCE, ExpeditionExampleExecutor, FetchedRegistryIndex,
         PublishCommandOutput, PublishProcessRunner, RealPublishProcessRunner, RegistryIndexFetcher,
         RegistrySyncError, Runtime, RuntimeResultStatus, SUPPORTED_HOST_ABI_VERSION,
         app_activate_at, app_activation_state_path, app_new_at, app_register_at,
@@ -6913,7 +6961,8 @@ mod tests {
         registry_sync_failure_json, reject_private_contract_scope, run_command, sha256_hex,
         surface_coverage_gap_messages, telemetry, uncovered_action_enum_values,
         unresolved_persona_refs, use_case_smoke_coverage_gaps,
-        use_case_smoke_coverage_gaps_for_package, validate_registry_path_segment,
+        use_case_smoke_coverage_gaps_for_package, validate_component_risk_policy_for_cli,
+        validate_registry_path_segment,
     };
     use crate::capability_packages::fnv1a64;
     use serde_json::Value;
@@ -10449,6 +10498,125 @@ mod tests {
 
     fn repo_root() -> PathBuf {
         PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..")
+    }
+
+    fn minimal_contract_json(egress_policy: traverse_contracts::EgressPolicy) -> Value {
+        let risk = traverse_contracts::RiskMetadata {
+            effect_class: traverse_contracts::EffectClass::ExternalEffect,
+            determinism_class: traverse_contracts::DeterminismClass::ExternallyVariable,
+            data_flow: traverse_contracts::DataFlowPolicy {
+                egress_policy,
+                ..Default::default()
+            },
+            reliability: traverse_contracts::ReliabilityMetadata {
+                idempotency_required: true,
+                retryable: false,
+                compensation_available: false,
+            },
+        };
+        serde_json::json!({
+            "kind": "capability_contract",
+            "schema_version": "1.0.0",
+            "id": "risk.policy.example",
+            "namespace": "risk.policy",
+            "name": "example",
+            "version": "0.1.0",
+            "lifecycle": "active",
+            "owner": {"team": "traverse-core", "contact": "enrico.piovesan10@gmail.com"},
+            "summary": "Send a validated payload to an external system for processing.",
+            "description": "Sends validated request data to an external connector for processing.",
+            "inputs": {"schema": {"type": "object"}},
+            "outputs": {"schema": {"type": "object"}},
+            "preconditions": [],
+            "postconditions": [],
+            "side_effects": [{"kind": "external_call", "description": "Calls an external system."}],
+            "emits": [],
+            "consumes": [],
+            "permissions": [],
+            "execution": {
+                "binary_format": "wasm",
+                "entrypoint": {"kind": "wasi-command", "command": "run"},
+                "preferred_targets": ["local"],
+                "constraints": {
+                    "host_api_access": "none",
+                    "network_access": "required",
+                    "filesystem_access": "none"
+                }
+            },
+            "policies": [],
+            "dependencies": [],
+            "provenance": {"source": "greenfield", "author": "enricopiovesan", "created_at": "2026-08-21T00:00:00Z"},
+            "evidence": [],
+            "risk": risk,
+        })
+    }
+
+    #[test]
+    fn component_risk_policy_allows_a_subset_of_the_contract_allowlist() {
+        let dir = unique_temp_dir();
+        let contract_path = dir.join("contract.json");
+        fs::write(
+            &contract_path,
+            serde_json::to_string(&minimal_contract_json(
+                traverse_contracts::EgressPolicy::AllowedConnectors(vec![
+                    "traverse.http".to_string(),
+                ]),
+            ))
+            .expect("contract json should serialize"),
+        )
+        .expect("contract json should write");
+
+        let component_manifest = serde_json::json!({
+            "contract_path": "contract.json",
+            "risk_policy": {"egress_allowed_connectors": ["traverse.http"]}
+        });
+        let component_path = dir.join("component.manifest.json");
+
+        let result = validate_component_risk_policy_for_cli(&component_path, &component_manifest);
+        assert_eq!(result, None);
+
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn component_risk_policy_rejects_a_connector_beyond_the_contract_allowlist() {
+        let dir = unique_temp_dir();
+        let contract_path = dir.join("contract.json");
+        fs::write(
+            &contract_path,
+            serde_json::to_string(&minimal_contract_json(
+                traverse_contracts::EgressPolicy::AllowedConnectors(vec![
+                    "traverse.http".to_string(),
+                ]),
+            ))
+            .expect("contract json should serialize"),
+        )
+        .expect("contract json should write");
+
+        let component_manifest = serde_json::json!({
+            "contract_path": "contract.json",
+            "risk_policy": {
+                "egress_allowed_connectors": ["traverse.http", "traverse.object-store"]
+            }
+        });
+        let component_path = dir.join("component.manifest.json");
+
+        let result = validate_component_risk_policy_for_cli(&component_path, &component_manifest);
+        assert_eq!(
+            result,
+            Some(AppValidationError {
+                code: "risk_policy_weakened".to_string(),
+                path: format!(
+                    "{}:$.risk_policy.egress_allowed_connectors",
+                    component_path.display()
+                ),
+                message: "manifest allows connector 'traverse.object-store' the contract's \
+                          egress policy does not permit"
+                    .to_string(),
+            })
+        );
+
+        let _ = fs::remove_dir_all(&dir);
     }
 
     fn unique_temp_dir() -> PathBuf {

--- a/crates/traverse-contracts/src/lib.rs
+++ b/crates/traverse-contracts/src/lib.rs
@@ -59,6 +59,202 @@ pub struct CapabilityContract {
     /// Executable surface examples (spec 102). Preserved through publish; not cleared by validate.
     #[serde(default)]
     pub use_cases: Vec<UseCase>,
+    /// Immutable capability risk classification (spec 109 FR-005). Contracts published
+    /// before this field existed default to the most conservative classification so
+    /// they are never silently treated as automatic-eligible.
+    #[serde(default = "default_risk_metadata")]
+    pub risk: RiskMetadata,
+}
+
+/// Portable, immutable capability authority metadata across four independent
+/// dimensions (ADR-0041). A capability's own contract is the only place these
+/// values may be declared; an application manifest may narrow how a capability
+/// is actually wired (for example connector selection) but can never override
+/// or weaken these classifications.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RiskMetadata {
+    pub effect_class: EffectClass,
+    pub determinism_class: DeterminismClass,
+    #[serde(default)]
+    pub data_flow: DataFlowPolicy,
+    pub reliability: ReliabilityMetadata,
+}
+
+/// What kind of effect invoking this capability has on the world.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum EffectClass {
+    /// Reads only; no observable effect on any state.
+    PureRead,
+    /// Writes to Traverse-owned state (`DataStore`, trace).
+    StateWrite,
+    /// Calls an external system that is not owned/reversible by Traverse.
+    ExternalEffect,
+    /// An external effect that cannot be undone or compensated.
+    IrreversibleEffect,
+}
+
+/// Whether repeated invocation with the same inputs is guaranteed to agree.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DeterminismClass {
+    Deterministic,
+    ExternallyVariable,
+    ModelDerived,
+}
+
+/// Field-level data classification and egress policy for this capability's
+/// declared inputs/outputs (spec 109 FR-005, FR-011). Schema compatibility
+/// alone never authorizes disclosure of a classified field.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DataFlowPolicy {
+    #[serde(default)]
+    pub accepted_data_classifications: Vec<FieldDataClassification>,
+    #[serde(default)]
+    pub produced_data_classifications: Vec<FieldDataClassification>,
+    #[serde(default = "default_egress_policy")]
+    pub egress_policy: EgressPolicy,
+}
+
+impl Default for DataFlowPolicy {
+    fn default() -> Self {
+        Self {
+            accepted_data_classifications: Vec::new(),
+            produced_data_classifications: Vec::new(),
+            egress_policy: default_egress_policy(),
+        }
+    }
+}
+
+/// Declares the classification of one field, addressed by a JSON Pointer
+/// (RFC 6901) into the capability's `inputs.schema` or `outputs.schema`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FieldDataClassification {
+    pub field_path: String,
+    pub classification: DataClassification,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DataClassification {
+    Public,
+    Internal,
+    Confidential,
+    Restricted,
+}
+
+/// Which connectors classified data produced/accepted by this capability may
+/// legally flow to. `Denied` means no external connector egress is permitted
+/// regardless of what connectors the capability is otherwise wired to.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum EgressPolicy {
+    Denied,
+    AllowedConnectors(Vec<String>),
+}
+
+fn default_egress_policy() -> EgressPolicy {
+    EgressPolicy::Denied
+}
+
+/// Reliability semantics a caller MUST honor when invoking this capability.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ReliabilityMetadata {
+    pub idempotency_required: bool,
+    pub retryable: bool,
+    pub compensation_available: bool,
+}
+
+/// Conservative migration default for contracts published before spec 109:
+/// the most restrictive classification on every dimension, so a capability
+/// never becomes silently automatic-eligible just because it predates risk
+/// metadata.
+#[must_use]
+pub fn default_risk_metadata() -> RiskMetadata {
+    RiskMetadata {
+        effect_class: EffectClass::IrreversibleEffect,
+        determinism_class: DeterminismClass::ModelDerived,
+        data_flow: DataFlowPolicy::default(),
+        reliability: ReliabilityMetadata {
+            idempotency_required: true,
+            retryable: false,
+            compensation_available: false,
+        },
+    }
+}
+
+/// Spec 109 FR-006: whether a proposal using only this capability's declared
+/// risk classes is eligible to run without an authorization token. Every
+/// caller that gates automatic execution MUST consume this single function
+/// rather than re-deriving the rule from individual fields.
+#[must_use]
+pub fn is_automatic_eligible(risk: &RiskMetadata) -> bool {
+    risk.effect_class == EffectClass::PureRead
+        && risk.determinism_class == DeterminismClass::Deterministic
+        && risk.data_flow.egress_policy == EgressPolicy::Denied
+        && !risk.reliability.idempotency_required
+}
+
+/// An application manifest's declared narrowing of a capability's egress
+/// surface (spec 109 FR-005: "a manifest may only tighten these
+/// requirements"). Every other risk dimension is an immutable fact about the
+/// capability's own behavior and has no manifest-side override.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct ManifestRiskPolicy {
+    /// When present, the manifest restricts egress to this connector id
+    /// subset. `Some(vec![])` tightens an `AllowedConnectors` capability down
+    /// to no egress for this deployment.
+    #[serde(default)]
+    pub egress_allowed_connectors: Option<Vec<String>>,
+}
+
+/// Validates that a manifest's declared risk policy only narrows the
+/// capability's immutable, contract-declared egress surface — it MUST NOT
+/// permit a connector the contract does not already allow.
+///
+/// # Errors
+///
+/// Returns [`ValidationFailure`] when the manifest policy would widen egress
+/// beyond what the capability's `RiskMetadata` allows.
+pub fn validate_manifest_risk_policy(
+    risk: &RiskMetadata,
+    policy: &ManifestRiskPolicy,
+) -> Result<(), ValidationFailure> {
+    let mut errors = Vec::new();
+
+    if let Some(declared) = &policy.egress_allowed_connectors {
+        match &risk.data_flow.egress_policy {
+            EgressPolicy::Denied => {
+                if !declared.is_empty() {
+                    errors.push(error(
+                        ValidationErrorCode::RiskPolicyWeakened,
+                        "$.risk_policy.egress_allowed_connectors",
+                        "manifest cannot allow egress for a capability whose contract denies all egress",
+                    ));
+                }
+            }
+            EgressPolicy::AllowedConnectors(allowed) => {
+                for connector_id in declared {
+                    if !allowed.contains(connector_id) {
+                        errors.push(error(
+                            ValidationErrorCode::RiskPolicyWeakened,
+                            "$.risk_policy.egress_allowed_connectors",
+                            &format!(
+                                "manifest allows connector '{connector_id}' the contract's \
+                                 egress policy does not permit"
+                            ),
+                        ));
+                    }
+                }
+            }
+        }
+    }
+
+    if errors.is_empty() {
+        Ok(())
+    } else {
+        Err(ValidationFailure { errors })
+    }
 }
 
 /// One authored use case that demonstrates a concrete input/output path for a capability.
@@ -790,6 +986,9 @@ pub enum ValidationErrorCode {
     MissingEventTrigger,
     InvalidConnectorContract,
     InvalidConnectorRequirement,
+    /// A manifest-declared risk policy would widen egress beyond what the
+    /// capability's immutable `RiskMetadata` allows.
+    RiskPolicyWeakened,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -882,6 +1081,7 @@ pub fn validate_contract(
     validate_evidence(&contract.evidence, &mut errors);
     validate_boundary(&contract, &mut errors);
     validate_placement_constraints(&contract, &mut errors);
+    validate_risk_metadata(&contract.risk, &mut errors);
     validate_published_record(&contract, context.existing_published, &mut errors);
 
     if !errors.is_empty() {
@@ -1642,6 +1842,38 @@ fn validate_placement_constraints(
             path: "$.event_trigger".to_string(),
             severity: ErrorSeverity::Error,
         });
+    }
+}
+
+fn validate_risk_metadata(risk: &RiskMetadata, errors: &mut Vec<ValidationError>) {
+    validate_field_classifications(
+        &risk.data_flow.accepted_data_classifications,
+        "$.risk.data_flow.accepted_data_classifications",
+        errors,
+    );
+    validate_field_classifications(
+        &risk.data_flow.produced_data_classifications,
+        "$.risk.data_flow.produced_data_classifications",
+        errors,
+    );
+}
+
+fn validate_field_classifications(
+    classifications: &[FieldDataClassification],
+    path: &str,
+    errors: &mut Vec<ValidationError>,
+) {
+    let mut seen = HashSet::new();
+    for (index, item) in classifications.iter().enumerate() {
+        let field_path = format!("{path}[{index}].field_path");
+        validate_non_empty(&item.field_path, &field_path, errors);
+        if !seen.insert(item.field_path.clone()) {
+            errors.push(error(
+                ValidationErrorCode::DuplicateItem,
+                &field_path,
+                "field_path values must be unique",
+            ));
+        }
     }
 }
 

--- a/crates/traverse-contracts/tests/validation.rs
+++ b/crates/traverse-contracts/tests/validation.rs
@@ -2,16 +2,20 @@ use std::{fs, path::Path};
 
 use traverse_contracts::{
     BinaryFormat, CapabilityContract, CapabilityReference, Condition, ConnectorRequirement,
-    DependencyArtifactType, DependencyReference, Entrypoint, EntrypointKind, EventClassification,
+    DataClassification, DataFlowPolicy, DependencyArtifactType, DependencyReference,
+    DeterminismClass, EffectClass, EgressPolicy, Entrypoint, EntrypointKind, EventClassification,
     EventContract, EventPayload, EventProvenance, EventProvenanceSource, EventReference, EventType,
     EventValidationContext, EventValidationEvidence, EvidenceStatus, EvidenceType, Execution,
-    ExecutionConstraints, ExecutionTarget, FilesystemAccess, HostApiAccess, IdReference, Lifecycle,
-    NetworkAccess, Owner, PayloadCompatibility, ProducedValidationEvidence, Provenance,
-    ProvenanceSource, PublishedContractRecord, PublishedEventRecord, SchemaContainer, ServiceType,
-    SideEffect, SideEffectKind, ValidationContext, ValidationErrorCode, ValidationEvidence,
-    ValidationFailure, ValidationResult, governed_content_digest, governed_event_content_digest,
-    parse_connector_contract, parse_contract, parse_event_contract, reference_connector_contracts,
-    validate_connector_contract, validate_contract, validate_event_contract,
+    ExecutionConstraints, ExecutionTarget, FieldDataClassification, FilesystemAccess,
+    HostApiAccess, IdReference, Lifecycle, ManifestRiskPolicy, NetworkAccess, Owner,
+    PayloadCompatibility, ProducedValidationEvidence, Provenance, ProvenanceSource,
+    PublishedContractRecord, PublishedEventRecord, ReliabilityMetadata, RiskMetadata,
+    SchemaContainer, ServiceType, SideEffect, SideEffectKind, ValidationContext,
+    ValidationErrorCode, ValidationEvidence, ValidationFailure, ValidationResult,
+    default_risk_metadata, governed_content_digest, governed_event_content_digest,
+    is_automatic_eligible, parse_connector_contract, parse_contract, parse_event_contract,
+    reference_connector_contracts, validate_connector_contract, validate_contract,
+    validate_event_contract, validate_manifest_risk_policy,
 };
 
 const GOVERNING_SPEC: &str = "002-capability-contracts@0.1.0";
@@ -827,6 +831,16 @@ fn valid_contract() -> CapabilityContract {
         connector_requirements: Vec::new(),
         state_schema: None,
         use_cases: Vec::new(),
+        risk: RiskMetadata {
+            effect_class: EffectClass::StateWrite,
+            determinism_class: DeterminismClass::Deterministic,
+            data_flow: DataFlowPolicy::default(),
+            reliability: ReliabilityMetadata {
+                idempotency_required: false,
+                retryable: true,
+                compensation_available: false,
+            },
+        },
     }
 }
 
@@ -851,6 +865,224 @@ fn stateless_contract_defaults_parse_from_json_without_new_fields() -> Result<()
         "permitted_targets defaults to all targets"
     );
     assert_eq!(parsed.event_trigger, None);
+    Ok(())
+}
+
+#[test]
+fn contract_without_risk_field_migrates_to_the_most_conservative_classification()
+-> Result<(), String> {
+    // Contracts published before spec 109 have no `risk` field at all. They must
+    // still parse, and must default to the strictest classification so they are
+    // never silently treated as automatic-eligible.
+    let mut v: serde_json::Value =
+        serde_json::from_str(&serde_json::to_string(&valid_contract()).map_err(|e| e.to_string())?)
+            .map_err(|e| e.to_string())?;
+    if let Some(m) = v.as_object_mut() {
+        m.remove("risk");
+    }
+    let json = serde_json::to_string(&v).map_err(|e| e.to_string())?;
+
+    let parsed = parse_contract(&json).map_err(|e| format!("{e:?}"))?;
+    assert_eq!(parsed.risk, default_risk_metadata());
+    assert_eq!(parsed.risk.effect_class, EffectClass::IrreversibleEffect);
+    assert_eq!(
+        parsed.risk.determinism_class,
+        DeterminismClass::ModelDerived
+    );
+    assert_eq!(parsed.risk.data_flow.egress_policy, EgressPolicy::Denied);
+    assert!(!is_automatic_eligible(&parsed.risk));
+    Ok(())
+}
+
+#[test]
+fn risk_metadata_round_trips_through_json() -> Result<(), String> {
+    let mut contract = valid_contract();
+    contract.risk = RiskMetadata {
+        effect_class: EffectClass::PureRead,
+        determinism_class: DeterminismClass::Deterministic,
+        data_flow: DataFlowPolicy {
+            accepted_data_classifications: vec![FieldDataClassification {
+                field_path: "/subject".to_string(),
+                classification: DataClassification::Internal,
+            }],
+            produced_data_classifications: vec![FieldDataClassification {
+                field_path: "/draft_id".to_string(),
+                classification: DataClassification::Public,
+            }],
+            egress_policy: EgressPolicy::Denied,
+        },
+        reliability: ReliabilityMetadata {
+            idempotency_required: false,
+            retryable: true,
+            compensation_available: false,
+        },
+    };
+
+    let json = serde_json::to_string(&contract).map_err(|e| e.to_string())?;
+    let parsed = parse_contract(&json).map_err(|e| format!("{e:?}"))?;
+    assert_eq!(parsed.risk, contract.risk);
+    assert!(is_automatic_eligible(&parsed.risk));
+    Ok(())
+}
+
+#[test]
+fn is_automatic_eligible_is_false_when_any_dimension_disqualifies() {
+    let base = RiskMetadata {
+        effect_class: EffectClass::PureRead,
+        determinism_class: DeterminismClass::Deterministic,
+        data_flow: DataFlowPolicy::default(),
+        reliability: ReliabilityMetadata {
+            idempotency_required: false,
+            retryable: true,
+            compensation_available: false,
+        },
+    };
+    assert!(is_automatic_eligible(&base));
+
+    let mut state_write = base.clone();
+    state_write.effect_class = EffectClass::StateWrite;
+    assert!(!is_automatic_eligible(&state_write));
+
+    let mut externally_variable = base.clone();
+    externally_variable.determinism_class = DeterminismClass::ExternallyVariable;
+    assert!(!is_automatic_eligible(&externally_variable));
+
+    let mut allows_egress = base.clone();
+    allows_egress.data_flow.egress_policy = EgressPolicy::AllowedConnectors(vec![]);
+    assert!(!is_automatic_eligible(&allows_egress));
+
+    let mut requires_idempotency = base;
+    requires_idempotency.reliability.idempotency_required = true;
+    assert!(!is_automatic_eligible(&requires_idempotency));
+}
+
+#[test]
+fn rejects_duplicate_and_empty_field_data_classification_paths() -> Result<(), String> {
+    let mut contract = valid_contract();
+    contract.risk.data_flow.accepted_data_classifications = vec![
+        FieldDataClassification {
+            field_path: "/subject".to_string(),
+            classification: DataClassification::Internal,
+        },
+        FieldDataClassification {
+            field_path: "/subject".to_string(),
+            classification: DataClassification::Confidential,
+        },
+        FieldDataClassification {
+            field_path: String::new(),
+            classification: DataClassification::Public,
+        },
+    ];
+
+    let failure = expect_validation_failure(validate_contract(
+        contract,
+        &ValidationContext {
+            governing_spec: GOVERNING_SPEC,
+            validator_version: VALIDATOR_VERSION,
+            existing_published: None,
+        },
+    ))?;
+
+    let codes: Vec<_> = failure.errors.iter().map(|e| &e.code).collect();
+    assert!(
+        codes.contains(&&ValidationErrorCode::DuplicateItem),
+        "expected DuplicateItem for repeated field_path, got {codes:?}"
+    );
+    assert!(
+        codes.contains(&&ValidationErrorCode::MissingRequiredField),
+        "expected MissingRequiredField for empty field_path, got {codes:?}"
+    );
+    Ok(())
+}
+
+#[test]
+fn validate_manifest_risk_policy_allows_tightening_to_a_subset() -> Result<(), String> {
+    let risk = RiskMetadata {
+        effect_class: EffectClass::ExternalEffect,
+        determinism_class: DeterminismClass::ExternallyVariable,
+        data_flow: DataFlowPolicy {
+            egress_policy: EgressPolicy::AllowedConnectors(vec![
+                "traverse.http".to_string(),
+                "traverse.object-store".to_string(),
+            ]),
+            ..DataFlowPolicy::default()
+        },
+        reliability: ReliabilityMetadata {
+            idempotency_required: true,
+            retryable: false,
+            compensation_available: false,
+        },
+    };
+
+    let narrower = ManifestRiskPolicy {
+        egress_allowed_connectors: Some(vec!["traverse.http".to_string()]),
+    };
+    validate_manifest_risk_policy(&risk, &narrower).map_err(|e| format!("{e:?}"))?;
+
+    let tightened_to_nothing = ManifestRiskPolicy {
+        egress_allowed_connectors: Some(vec![]),
+    };
+    validate_manifest_risk_policy(&risk, &tightened_to_nothing).map_err(|e| format!("{e:?}"))?;
+
+    let unset = ManifestRiskPolicy::default();
+    validate_manifest_risk_policy(&risk, &unset).map_err(|e| format!("{e:?}"))?;
+    Ok(())
+}
+
+#[test]
+fn validate_manifest_risk_policy_rejects_a_connector_beyond_the_contract_allowlist()
+-> Result<(), String> {
+    let risk = RiskMetadata {
+        effect_class: EffectClass::ExternalEffect,
+        determinism_class: DeterminismClass::ExternallyVariable,
+        data_flow: DataFlowPolicy {
+            egress_policy: EgressPolicy::AllowedConnectors(vec!["traverse.http".to_string()]),
+            ..DataFlowPolicy::default()
+        },
+        reliability: ReliabilityMetadata {
+            idempotency_required: true,
+            retryable: false,
+            compensation_available: false,
+        },
+    };
+
+    let widened = ManifestRiskPolicy {
+        egress_allowed_connectors: Some(vec![
+            "traverse.http".to_string(),
+            "traverse.object-store".to_string(),
+        ]),
+    };
+
+    let failure = expect_validation_failure(validate_manifest_risk_policy(&risk, &widened))?;
+    assert!(
+        failure
+            .errors
+            .iter()
+            .any(|e| e.code == ValidationErrorCode::RiskPolicyWeakened),
+        "expected RiskPolicyWeakened, got {:?}",
+        failure.errors
+    );
+    Ok(())
+}
+
+#[test]
+fn validate_manifest_risk_policy_rejects_any_egress_when_contract_denies_all() -> Result<(), String>
+{
+    let risk = default_risk_metadata();
+    assert_eq!(risk.data_flow.egress_policy, EgressPolicy::Denied);
+
+    let attempted_override = ManifestRiskPolicy {
+        egress_allowed_connectors: Some(vec!["traverse.http".to_string()]),
+    };
+
+    let failure =
+        expect_validation_failure(validate_manifest_risk_policy(&risk, &attempted_override))?;
+    assert!(
+        failure
+            .errors
+            .iter()
+            .any(|e| e.code == ValidationErrorCode::RiskPolicyWeakened)
+    );
     Ok(())
 }
 

--- a/crates/traverse-mcp/src/lib.rs
+++ b/crates/traverse-mcp/src/lib.rs
@@ -1245,6 +1245,7 @@ mod tests {
             connector_requirements: Vec::new(),
             state_schema: None,
             use_cases: Vec::new(),
+            risk: traverse_contracts::default_risk_metadata(),
         }
     }
 

--- a/crates/traverse-mcp/src/tools/capabilities.rs
+++ b/crates/traverse-mcp/src/tools/capabilities.rs
@@ -3,7 +3,10 @@
 //! Governed by spec 015-capability-discovery-mcp
 
 use serde::{Deserialize, Serialize};
-use traverse_contracts::{ExecutionTarget, ServiceType};
+use traverse_contracts::{
+    DeterminismClass, EffectClass, EgressPolicy, ExecutionTarget, ReliabilityMetadata, ServiceType,
+    is_automatic_eligible,
+};
 use traverse_registry::{
     CapabilityArtifactRecord, CapabilityRegistry, DiscoveryQuery, LookupScope, WorkflowReference,
 };
@@ -41,6 +44,18 @@ pub struct CapabilitySummary {
     pub activation_eligibility: String,
     /// Stable reason explaining why eligibility requires activation evidence.
     pub activation_eligibility_reason: String,
+    /// Immutable effect classification (spec 109 FR-005).
+    pub effect_class: EffectClass,
+    /// Immutable determinism classification (spec 109 FR-005).
+    pub determinism_class: DeterminismClass,
+    /// Declared egress surface — connector ids only, never private connector
+    /// configuration or secrets.
+    pub egress_policy: EgressPolicy,
+    /// Declared reliability semantics (spec 109 FR-005).
+    pub reliability: ReliabilityMetadata,
+    /// Spec 109 FR-006: whether a proposal using only this capability's
+    /// declared risk classes may run without an authorization token.
+    pub automatic_eligible: bool,
 }
 
 /// List all capabilities, optionally filtered by `service_type` or `permitted_targets`.
@@ -83,6 +98,11 @@ pub fn list_capabilities(
             advisory_compositions: advisory_compositions(cap.artifact.workflow_ref.as_ref()),
             activation_eligibility: "unknown".to_string(),
             activation_eligibility_reason: "requires_host_activation_resolution".to_string(),
+            effect_class: cap.contract.risk.effect_class,
+            determinism_class: cap.contract.risk.determinism_class,
+            egress_policy: cap.contract.risk.data_flow.egress_policy.clone(),
+            reliability: cap.contract.risk.reliability,
+            automatic_eligible: is_automatic_eligible(&cap.contract.risk),
         })
         .collect()
 }

--- a/crates/traverse-mcp/tests/mcp_tests.rs
+++ b/crates/traverse-mcp/tests/mcp_tests.rs
@@ -129,6 +129,7 @@ fn capability_contract() -> traverse_contracts::CapabilityContract {
         connector_requirements: Vec::new(),
         state_schema: None,
         use_cases: Vec::new(),
+        risk: traverse_contracts::default_risk_metadata(),
     }
 }
 
@@ -371,6 +372,20 @@ fn list_capabilities_returns_expected_fields() -> Result<(), String> {
         s.activation_eligibility_reason,
         "requires_host_activation_resolution"
     );
+    // The fixture contract predates spec 109 and declares no `risk` field, so
+    // discovery must expose the conservative migration default rather than
+    // silently treating it as automatic-eligible.
+    assert_eq!(
+        s.effect_class,
+        traverse_contracts::EffectClass::IrreversibleEffect
+    );
+    assert_eq!(
+        s.determinism_class,
+        traverse_contracts::DeterminismClass::ModelDerived
+    );
+    assert_eq!(s.egress_policy, traverse_contracts::EgressPolicy::Denied);
+    assert!(s.reliability.idempotency_required);
+    assert!(!s.automatic_eligible);
     Ok(())
 }
 

--- a/crates/traverse-runtime/src/data_store.rs
+++ b/crates/traverse-runtime/src/data_store.rs
@@ -2385,6 +2385,7 @@ mod tests {
             connector_requirements: Vec::new(),
             state_schema,
             use_cases: Vec::new(),
+            risk: traverse_contracts::default_risk_metadata(),
         }
     }
 }

--- a/crates/traverse-runtime/src/lib.rs
+++ b/crates/traverse-runtime/src/lib.rs
@@ -5532,6 +5532,7 @@ mod tests {
             connector_requirements: Vec::new(),
             state_schema: None,
             use_cases: Vec::new(),
+            risk: traverse_contracts::default_risk_metadata(),
         }
     }
 

--- a/crates/traverse-runtime/src/security.rs
+++ b/crates/traverse-runtime/src/security.rs
@@ -535,6 +535,7 @@ mod tests {
             connector_requirements: Vec::new(),
             state_schema: None,
             use_cases: Vec::new(),
+            risk: traverse_contracts::default_risk_metadata(),
         };
         let record = CapabilityRegistryRecord {
             scope: RegistryScope::Private,

--- a/crates/traverse-runtime/src/workflows.rs
+++ b/crates/traverse-runtime/src/workflows.rs
@@ -3551,6 +3551,7 @@ mod tests {
             connector_requirements: Vec::new(),
             state_schema: None,
             use_cases: Vec::new(),
+            risk: traverse_contracts::default_risk_metadata(),
         }
     }
 

--- a/crates/traverse-runtime/tests/expedition_wasm_tests.rs
+++ b/crates/traverse-runtime/tests/expedition_wasm_tests.rs
@@ -150,6 +150,7 @@ fn expedition_contract() -> CapabilityContract {
         connector_requirements: Vec::new(),
         state_schema: None,
         use_cases: Vec::new(),
+        risk: traverse_contracts::default_risk_metadata(),
     }
 }
 

--- a/crates/traverse-runtime/tests/placement_router_live_wiring.rs
+++ b/crates/traverse-runtime/tests/placement_router_live_wiring.rs
@@ -277,6 +277,7 @@ fn base_contract(
         connector_requirements: Vec::new(),
         state_schema: None,
         use_cases: Vec::new(),
+        risk: traverse_contracts::default_risk_metadata(),
     }
 }
 

--- a/crates/traverse-runtime/tests/placement_tests.rs
+++ b/crates/traverse-runtime/tests/placement_tests.rs
@@ -89,6 +89,7 @@ fn base_contract() -> CapabilityContract {
         connector_requirements: Vec::new(),
         state_schema: None,
         use_cases: Vec::new(),
+        risk: traverse_contracts::default_risk_metadata(),
     }
 }
 

--- a/crates/traverse-runtime/tests/router_tests.rs
+++ b/crates/traverse-runtime/tests/router_tests.rs
@@ -105,6 +105,7 @@ fn base_contract(service_type: ServiceType) -> CapabilityContract {
         connector_requirements: Vec::new(),
         state_schema: None,
         use_cases: Vec::new(),
+        risk: traverse_contracts::default_risk_metadata(),
     }
 }
 

--- a/crates/traverse-runtime/tests/runtime.rs
+++ b/crates/traverse-runtime/tests/runtime.rs
@@ -1191,6 +1191,7 @@ fn capability_contract(
         connector_requirements: Vec::new(),
         state_schema: None,
         use_cases: Vec::new(),
+        risk: traverse_contracts::default_risk_metadata(),
     }
 }
 
@@ -1523,6 +1524,7 @@ fn simple_registration(scope: RegistryScope, id: &str, version: &str) -> Capabil
         connector_requirements: Vec::new(),
         state_schema: None,
         use_cases: Vec::new(),
+        risk: traverse_contracts::default_risk_metadata(),
     };
     CapabilityRegistration {
         scope,

--- a/crates/traverse-runtime/tests/thread_pool_integration.rs
+++ b/crates/traverse-runtime/tests/thread_pool_integration.rs
@@ -113,6 +113,7 @@ fn test_contract() -> CapabilityContract {
         connector_requirements: Vec::new(),
         state_schema: None,
         use_cases: Vec::new(),
+        risk: traverse_contracts::default_risk_metadata(),
     }
 }
 

--- a/docs/capability-contract-authoring-guide.md
+++ b/docs/capability-contract-authoring-guide.md
@@ -390,6 +390,82 @@ Use `"stateful"` only for capabilities that explicitly manage a persistent resou
 
 ---
 
+## `risk` Reference (spec 109)
+
+Every contract carries an immutable `risk` classification across four
+independent dimensions (spec `109-runtime-workflow-proposals` FR-005, ADR-0041).
+A single field never implies another dimension — declare each one deliberately.
+
+```json
+"risk": {
+  "effect_class": "pure_read",
+  "determinism_class": "deterministic",
+  "data_flow": {
+    "accepted_data_classifications": [
+      { "field_path": "/comment_text", "classification": "internal" }
+    ],
+    "produced_data_classifications": [
+      { "field_path": "/draft_id", "classification": "public" }
+    ],
+    "egress_policy": "denied"
+  },
+  "reliability": {
+    "idempotency_required": false,
+    "retryable": true,
+    "compensation_available": false
+  }
+}
+```
+
+| Dimension | Values | Meaning |
+|---|---|---|
+| `effect_class` | `pure_read`, `state_write`, `external_effect`, `irreversible_effect` | What kind of effect invoking this capability has on the world. |
+| `determinism_class` | `deterministic`, `externally_variable`, `model_derived` | Whether repeated invocation with the same inputs is guaranteed to agree. |
+| `data_flow` | `accepted_data_classifications`, `produced_data_classifications` (JSON-Pointer `field_path` + `classification`: `public`/`internal`/`confidential`/`restricted`), `egress_policy` (`"denied"` or `{"allowed_connectors": [...]}`) | Field-level data classification and which connectors classified data may flow to. Schema compatibility alone never authorizes disclosure. |
+| `reliability` | `idempotency_required`, `retryable`, `compensation_available` (booleans) | Reliability semantics a caller must honor. |
+
+**Migration behavior.** Contracts published before spec 109 have no `risk`
+field at all. `traverse-contracts` treats a missing `risk` as present but set
+to the most conservative value on every dimension
+(`irreversible_effect`/`model_derived`/all egress denied/idempotency
+required) — see `traverse_contracts::default_risk_metadata()`. A pre-109
+contract is therefore never silently treated as safe to run without
+authorization; author it explicitly once you know the capability's real
+classification. Because the field is additive with a safe default, adding
+`risk` to an existing contract is a backward-compatible change under this
+repo's [compatibility policy](compatibility-policy.md), the same as
+`service_type` or `permitted_targets` before it. Within one contract version,
+`risk` is covered by the existing immutable-publish digest check — it cannot
+change without republishing under a new version.
+
+**Automatic-eligible gate.** `traverse_contracts::is_automatic_eligible(&risk)`
+is the single, canonical decision of whether a proposal built only from this
+capability's declared risk classes may run without an approval token (spec 109
+FR-006). Every caller that gates automatic execution — including the future
+P1 proposal runtime (issue #1090) — must consume this function rather than
+re-deriving the rule from individual fields.
+
+**Manifest tightening, never weakening.** An application manifest may narrow
+a component's egress surface below what its contract allows, but can never
+grant egress the contract's `risk` forbids. Declare the narrower set on the
+component manifest:
+
+```json
+"risk_policy": {
+  "egress_allowed_connectors": ["traverse.http"]
+}
+```
+
+`traverse-cli` validates this at `app register`/`app validate` time via
+`traverse_contracts::validate_manifest_risk_policy`: an `egress_allowed_connectors`
+entry not present in the contract's `egress_policy` allowlist (or any entry at
+all when the contract's `egress_policy` is `"denied"`) fails with the stable
+`risk_policy_weakened` code. `effect_class`, `determinism_class`, and
+`reliability` are immutable facts about the capability's own behavior — a
+manifest has no override for them at all.
+
+---
+
 ## Validate Before Registering (#298)
 
 Before opening a PR or registering a contract, run the spec-alignment gate against your contract:


### PR DESCRIPTION
## Summary

Implements #1091: immutable capability risk metadata and manifest tightening,
per spec `109-runtime-workflow-proposals` FR-005/FR-006 and ADR-0041.

- `traverse-contracts`: adds `RiskMetadata` (effect class, determinism class,
  field-level data-flow/egress policy, reliability semantics) to
  `CapabilityContract`, with a conservative migration default
  (`default_risk_metadata()`) for contracts published before spec 109 so none
  are silently treated as automatic-eligible. Adds `is_automatic_eligible()`
  as the single canonical FR-006 decision point, and
  `validate_manifest_risk_policy()` enforcing that a manifest may only narrow
  (never widen) a capability's declared egress connector allowlist.
- `traverse-cli`: `app register`/`app validate` reject a component manifest
  `risk_policy.egress_allowed_connectors` override that would widen egress
  beyond the capability contract's declared `risk.data_flow.egress_policy`,
  with the stable `risk_policy_weakened` error code.
- `traverse-mcp`: capability discovery (`list_capabilities`) exposes the
  redacted risk classification (connector ids only, never secrets/private
  config) alongside `automatic_eligible`; `get_capability` already returns
  the full contract, so `risk` is exposed there automatically.
- Docs: new `risk` reference section in
  `docs/capability-contract-authoring-guide.md` covering the four dimensions,
  migration/compatibility behavior, and the manifest tightening convention.

Closes #1091

## Governing Spec

- `109-runtime-workflow-proposals`
- `102-contract-surface-coverage`

## Project Item

Project 1 item for #1091: `PVTI_lADOEbiBt84Bbyp1zg3fR5k` (In Progress).

## Validation

- `cargo test --workspace` — all suites pass (traverse-contracts 44 tests
  incl. new risk/tightening coverage; traverse-cli 396 incl. new
  `risk_policy_weakened` coverage; traverse-mcp incl. updated discovery
  assertions; traverse-runtime full suite unaffected).
- `cargo clippy --workspace --all-targets` — clean.
- `cargo fmt --check` — clean.
- `BASE_SHA=origin/main bash scripts/ci/local_preflight.sh --pr-body <file>`
- `bash scripts/ci/pr_body_check.sh <file>`
- `bash scripts/ci/spec_alignment_check.sh` — clean against this PR body.
