### PR TITLE
spec: declarative workflow planner (P0 of governed runtime workflow composition)

### DIFF
--- a/docs/adr/0043-declarative-workflow-planning-boundary.md
+++ b/docs/adr/0043-declarative-workflow-planning-boundary.md
@@ -1,0 +1,57 @@
+# ADR-0043: Plan Workflows as a Deterministic, Data-Dependency-Only Reader, Never an Auto-Chooser
+
+- Status: Accepted
+- Governing specs: `108-governed-runtime-workflow-composition`, `113-declarative-workflow-planning`
+- Related issues: #865, #1089, #1098
+
+## Context
+
+`109-runtime-workflow-proposals` (P1) deliberately excluded "planner
+implementation" from its scope, leaving open how a concrete, submittable
+proposal actually gets generated in the first place. A live website demo
+(traverse-framework.com/discover.html) exposed this gap concretely: without
+real declared data-dependency metadata or a real planner, composing a
+plausible workflow from live registry data required a client-side
+namespace/verb-name heuristic — a guess, not something grounded in the
+contracts themselves.
+
+## Decision
+
+The planner reads only declared `consumes`/`emits` contract metadata; it
+never infers a chain from capability names, namespaces, or any other
+signal, and never operates on a capability with no declared linkage. When
+more than one capability could satisfy a need, the planner enumerates every
+resulting complete candidate plan rather than choosing one — ambiguity
+resolution is a caller/reviewer decision, never a runtime one, consistent
+with ADR-0041 treating the planner-adjacent surface as untrusted and this
+runtime's everywhere-else stance against silent inference. Search is
+bounded by fixed, small, non-configurable limits in v1. Field-level
+JSON-path mappings are proposed but always marked unconfirmed until
+reviewed — the planner produces a draft, not an authority. The planner is a
+new phase (P0) of the `108` north star rather than a standalone spec, since
+`109` already named this exact gap as its own boundary.
+
+## Consequences
+
+A planner call against today's registry (per registry#305: `consumes`/
+`emits` populated on roughly 1 of 116 published capability versions) will
+mostly return zero candidates. That is treated as correct, honest behavior
+— not a bug to route around with a heuristic — and makes this spec's real
+unblock condition explicit: registry#305's backfill, not more runtime code.
+`traverse#1098`'s original framing (which implied the review/execution/
+trust architecture was still undecided) is superseded by this narrower
+reading; `108`–`112` already own that.
+
+## Alternatives considered
+
+- Fall back to a namespace/verb heuristic when `consumes`/`emits` is empty
+  (matching the discover.html demo): rejected — mixing a real, data-grounded
+  candidate with a guessed one on the same governed proposal surface blurs
+  exactly the honesty line this org has held elsewhere (registry
+  decision-log entry 61).
+- Auto-resolve ambiguity via a scoring heuristic (coverage %, version
+  recency): rejected — a silent automatic pick is the kind of unreviewed
+  runtime decision `109`'s explicit-mapping requirement exists to prevent.
+- Accept natural-language goals and interpret them in-runtime: rejected —
+  reintroduces exactly the hosted-model dependency `109` FR-001 and
+  ADR-0041 explicitly excluded.

--- a/docs/decision-log.md
+++ b/docs/decision-log.md
@@ -2166,3 +2166,69 @@ Decision 57 / Spec 102 v1.0.0 gated only `inputs.schema.properties.action.enum`.
 - Implementation tracked by traverse `#1040` and registry `#215`.
 - Honesty patch-bumps for stripped Loop caps follow once the gate lands.
 
+
+## Decision 59: Declarative Workflow Planner (P0) — Data-Dependency-Only, Fail-Closed, Bounded
+
+- **Date**: 2026-08-22
+- **Status**: Accepted; Spec 113 Approved 2026-08-22
+- **Governing spec**: `113-declarative-workflow-planning` (P0 of `108-governed-runtime-workflow-composition`), ADR-0043
+- **Related issues**: `#1098`; registry `#304`, `#305`; related `#865`, `#1089`–`#1094`
+- **Origin**: Investigation into why a live demo at traverse-framework.com/discover.html only simulates workflow composition instead of doing it for real (traverse `#1097`, `#1098`, `#1100`; registry `#304`, `#305`), which surfaced that `109`'s own scope explicitly excluded "planner implementation" — the actual remaining gap was narrower and different than first filed.
+
+### Context
+
+`109-runtime-workflow-proposals` (P1) governs how a *submitted* proposal is
+validated, authorized, and executed, and is Approved and shipping. It
+explicitly named "planner implementation" as out of scope. Nothing in this
+repo generates the content of a proposal from declared capability metadata
+— composing a multi-step workflow has only ever been possible by hand
+(`workflow.json`) or via the explicit `WorkflowBuilder` API (`#309`/`#367`),
+where the caller already knows and names the exact chain.
+
+### Decision
+
+Ship a first-party, deterministic planner in `traverse-runtime`, governed as
+phase P0 of the existing `108` north star (not a standalone spec, since
+`109` already named this exact boundary):
+
+1. Accepts a structured target only — no natural-language goal
+   interpretation, no hosted-model dependency.
+2. Plans only from capabilities with real, declared `consumes`/`emits`
+   linkage; no namespace/verb-name fallback when that data is missing.
+3. Never auto-resolves ambiguity between multiple viable capabilities —
+   enumerates every complete candidate plan and hands the choice to the
+   caller/reviewer.
+4. Bounds search to a small, fixed, non-configurable limit in v1 (5
+   candidate plans, 8 nodes deep).
+5. Proposes best-effort field-level JSON-path mappings per edge, always
+   flagged `mapping_unconfirmed` until a human/reviewer clears it.
+6. Is exposed as a new public MCP tool alongside the existing P1 tools, and
+   produces plans structurally submittable to the P1 surface as-is once
+   reviewed — the planner itself never submits or executes anything.
+
+### Alternatives Considered
+
+- Namespace/verb-name heuristic fallback when `consumes`/`emits` is empty
+  (what the discover.html demo already does client-side) — rejected for
+  the governed planner: mixing a real, data-grounded candidate with a
+  guessed one on the same proposal surface undermines exactly the honesty
+  line this org holds elsewhere (registry decision-log entry 61).
+- Auto-pick via a scoring heuristic (coverage %, version recency) —
+  rejected; a silent automatic pick is the unreviewed runtime decision
+  `109`'s explicit-mapping requirement exists to prevent.
+- Standalone new spec instead of a phase of `108` — rejected; `109`
+  explicitly deferred this exact scope to a later phase, and a parallel
+  spec covering the same feature invites drift (cf. Decision 58's "do not
+  create a parallel coverage law").
+- Accept and interpret natural-language goals in-runtime — rejected;
+  reintroduces the hosted-model dependency `109` FR-001 and ADR-0041
+  explicitly excluded.
+
+### Outcome
+
+Spec `113` drafted and Approved same-day; ADR-0043 recorded. `traverse#1098`
+retitled and rescoped to match (see issue history for the two prior
+corrections). Real unblock condition made explicit: this planner will
+return almost no candidates until registry `#305` backfills real
+`consumes`/`emits` data — that dependency is recorded as a formal
+`blocked by` relationship on `#1098`, not just prose.

--- a/specs/113-declarative-workflow-planning/spec.md
+++ b/specs/113-declarative-workflow-planning/spec.md
@@ -1,0 +1,83 @@
+# Declarative Workflow Planning — P0 of Governed Runtime Workflow Composition
+
+**Status**: Approved
+**Canonical governing ID**: `113-declarative-workflow-planning`
+**Version**: 0.1.0
+**Implements phase**: P0 of `108-governed-runtime-workflow-composition` (precedes the P1 proposal-submission surface)
+**Input**: Decision 59 (`docs/decision-log.md`); traverse #1098; registry #305.
+
+## Purpose
+
+Define a deterministic planner that, given a structured target and the
+declared `consumes`/`emits` metadata of published capabilities, derives one
+or more complete candidate workflow proposals — each already shaped to
+satisfy `109-runtime-workflow-proposals` FR-002/FR-004/FR-011 (explicit
+capability IDs/versions, explicit edges, explicit field-level JSON-path
+mappings) — for a caller to review and submit through the existing P1 MCP
+surface. This spec governs what generates a proposal's *content*; it does
+not change how proposals are validated, authorized, or executed, which
+remain entirely owned by `109`–`112`.
+
+## Requirements
+
+- **FR-001**: The planner MUST accept a structured target (a declared event
+  type or capability ID the caller needs produced) and a starting fact set.
+  It MUST NOT accept or interpret open-ended natural-language goals, and
+  MUST NOT require or embed a hosted language model, matching FR-001 of
+  spec `109`.
+- **FR-002**: The planner MUST derive candidate chains only from capabilities
+  whose contract declares non-empty `consumes`/`emits` linkage to the target
+  and to each other. A capability with no declared linkage MUST NOT be
+  selected, even if its name or namespace suggests a plausible fit.
+- **FR-003**: When more than one published capability's declared `emits`
+  could satisfy the same downstream `consumes` need, the planner MUST NOT
+  pick one automatically. It MUST enumerate each resulting complete
+  candidate plan separately and return the full set to the caller.
+- **FR-004**: The planner MUST bound its search: at most 5 complete
+  candidate plans, each at most 8 nodes deep, per planning call. A call
+  that would exceed either bound MUST return the bounded subset it found
+  plus a stable `plan_search_truncated` indicator, never fail silently or
+  search unbounded.
+- **FR-005**: Each returned candidate plan MUST include a best-effort,
+  per-edge field-level JSON-path mapping derived from the source
+  capability's `outputs.schema` and the target capability's `inputs.schema`.
+  A candidate plan MUST be flagged `mapping_unconfirmed` until a human or
+  caller-side reviewer approves it; this flag MUST NOT be cleared by the
+  planner itself.
+- **FR-006**: A candidate plan MUST be structurally submittable as-is to the
+  `109-runtime-workflow-proposals` MCP surface (identical capability-id/
+  version, edge, and mapping shape) once its `mapping_unconfirmed` flag is
+  cleared by review. The planner MUST NOT submit or execute a plan itself.
+- **FR-007**: The planner MUST be exposed as a public MCP tool alongside the
+  existing P1 proposal tools (e.g. `workflow.plan`), discoverable without
+  special credentials, per FR-001 of spec `109`.
+- **FR-008**: Planning MUST be a pure, read-only operation over the current
+  registry/manifest snapshot. It MUST NOT mutate the registry, the workflow
+  catalog, or any manifest, and MUST NOT persist a candidate plan as a
+  reusable workflow.
+
+## Acceptance scenarios
+
+1. A caller requests a plan targeting an event only one published capability
+   chain can produce; the planner returns exactly one candidate plan with
+   field mappings flagged `mapping_unconfirmed`.
+2. A caller requests a plan where two published capabilities both emit a
+   compatible event for the same downstream need; the planner returns two
+   complete candidate plans, one per choice, rather than picking one.
+3. A caller requests a plan for a target no published capability declares
+   `emits` linkage to; the planner returns zero candidates rather than
+   falling back to a name/namespace guess.
+4. A candidate plan's field mapping is reviewed and corrected by a human
+   before submission; the corrected mapping, not the planner's original
+   guess, is what gets submitted to and validated by the P1 surface.
+5. A goal whose valid chain space exceeds the bound returns the bounded
+   subset plus `plan_search_truncated: true`, never an unbounded result or
+   a silent failure.
+
+## Out of scope
+
+Natural-language goal interpretation, embedding a hosted planner model,
+automatic proposal submission or execution, ambiguity auto-resolution,
+unbounded plan search, registry or workflow-catalog mutation, and any
+change to how `109`–`112` validate, authorize, or execute a submitted
+proposal.

--- a/specs/governance/approved-specs.json
+++ b/specs/governance/approved-specs.json
@@ -1425,9 +1425,11 @@
         "specs/110-bounded-parallel-workflow-scheduling/",
         "specs/111-durable-dynamic-orchestration/",
         "specs/112-governed-workflow-promotion/",
+        "specs/113-declarative-workflow-planning/",
         "docs/adr/0041-governed-runtime-workflow-proposal-authority.md",
         "docs/adr/0042-phased-dynamic-orchestration-evolution.md",
-        "docs/decision-log.md"
+        "docs/decision-log.md",
+        "docs/adr/0043-declarative-workflow-planning-boundary.md"
       ]
     },
     {
@@ -1480,6 +1482,19 @@
         "crates/traverse-cli/",
         "crates/traverse-mcp/",
         "specs/112-governed-workflow-promotion/"
+      ]
+    },
+    {
+      "id": "113-declarative-workflow-planning",
+      "version": "1.0.0",
+      "status": "approved",
+      "immutable": true,
+      "path": "specs/113-declarative-workflow-planning/spec.md",
+      "governs": [
+        "crates/traverse-runtime/",
+        "crates/traverse-contracts/",
+        "crates/traverse-mcp/",
+        "specs/113-declarative-workflow-planning/"
       ]
     }
   ]


### PR DESCRIPTION
## Summary

Governs P0 of #1089's north star — the "planner implementation" spec 109
explicitly named as its own boundary. Adds:

- `specs/113-declarative-workflow-planning/spec.md` (Approved)
- `docs/adr/0043-declarative-workflow-planning-boundary.md`
- Decision 59 in `docs/decision-log.md`
- Registers spec 113 in `specs/governance/approved-specs.json`, and adds it
  to spec 108's own `governs` list alongside 109-112.

## Governing Spec

- `108-governed-runtime-workflow-composition`
- `113-declarative-workflow-planning`
- `004-spec-alignment-gate`

## Project Item

- Issue: traverse-framework/Traverse#1098 (implementation ticket, to be
  rescoped to match this spec's narrower framing once merged)
- No Project 1 card created by this PR — left for whoever picks up
  implementation, since this PR is spec-only, no code.

## Decision record

Brainstormed live and decided by the owner (traverse#1098's comment history
+ Decision 59): fail-closed ambiguity (enumerate complete candidate plans,
never auto-pick), data-dependency-only (no namespace/verb fallback), bounded
search, planner-proposed-but-reviewer-confirmed field mappings, new public
MCP tool, phase of the existing 108 program rather than a standalone spec.

## Validation

Documentation-only change (spec, ADR, decision log, governance registry) —
no code, no crate touched.

- `bash scripts/ci/spec_alignment_check.sh` — run locally against this
  PR's own body, passed.
- `python3 -c "import json; json.load(open('specs/governance/approved-specs.json'))"`
  — confirms the registry edit is valid JSON.
- Manually diffed the new `113` entry and the `108` governs-list addition
  against the existing `109`-`112` entries for shape parity.

## Related

#1098 (implementation ticket, to be rescoped), registry#304, registry#305
(this spec's real unblock condition — see ADR-0043 Consequences), #865,
#1089-#1094.
