### PR TITLE
docs(governance): ADR-0044 + Decision 60 — single-capability browser execution via execute_entrypoint

### DIFF
--- a/docs/adr/0044-single-capability-execution-via-mcp-not-embedder.md
+++ b/docs/adr/0044-single-capability-execution-via-mcp-not-embedder.md
@@ -1,0 +1,80 @@
+# ADR-0044: Single-Capability Browser Execution Goes Through `execute_entrypoint`, Not an Extended BundleEmbedder
+
+- Status: Accepted
+- Governing specs: `023-browser-hosted-mcp-consumer-model`; related `006-runtime-request-execution`, `010-runtime-state-machine`, `068-public-platform-embedder-packages`
+- Related issues: #1100, #1097, #1098, #865
+
+## Context
+
+`#1100` found that running an arbitrary, live-fetched registry capability
+directly in a browser requires assembling a `manifest.json` (`agent_package`,
+with an FNV-1a `expected_digest`) and a `runtime-request.json` before
+anything executes — real, enforced ceremony, not optional metadata — and
+that `catalog.json` doesn't expose a ready digest to build one from today.
+The natural-seeming fix was to extend `BundleEmbedder`
+(`traverse-embedder-web`, spec `068`) or add a browser-side helper to
+compute the digest and synthesize a manifest client-side.
+
+`traverse-mcp` already exposes an `execute_entrypoint` tool that performs
+exactly this manifest/digest/binary resolution server-side and returns a
+public trace summary. The ceremony `#1100` was proposing to duplicate in
+the browser is already solved once — just not on a path a browser-hosted
+client can reach outside of `stdio`.
+
+## Decision
+
+Do not extend `BundleEmbedder` to construct manifests or digests
+client-side. Single-capability execution from a browser-hosted client goes
+through the existing `execute_entrypoint` MCP tool, called over whatever
+non-stdio transport `023` already defines for browser-hosted consumers
+(FR-006) — the manifest/digest/binary-resolution ceremony stays
+server-side, where it already lives, instead of being duplicated in the
+browser. `BundleEmbedder` keeps its existing, narrower job: executing a
+pre-vetted, already-reviewed application bundle (spec `044`) shipped with
+the app itself, not fetching and running arbitrary live registry content
+chosen at runtime. Once `#1098`'s planner (spec `113`) and `109`'s P1
+lifecycle produce a submittable, approved multi-step proposal, the same
+reasoning applies: execution runs through P1's existing MCP surface, not a
+browser-assembled bundle.
+
+This requires no new governing spec. Spec `023` already defines a
+non-stdio browser-hosted transport in general terms (FR-006) without
+naming or restricting which MCP tools are reachable over it, and
+`execute_entrypoint` is one of the ordinary tools `traverse-mcp` exposes —
+there is no separate allowlist excluding it from browser-hosted
+consumption. What remains is implementation and validation work, not new
+governance: confirming end-to-end that a browser-hosted client can
+actually reach `execute_entrypoint` over spec `023`'s approved transport,
+and that the response is sufficient for a consumer (e.g. discover.html,
+`youaskm3`) to show a real result.
+
+## Consequences
+
+`#1100` is rescoped from "extend the embedder with manifest/digest
+ceremony" to "validate the already-approved browser-hosted MCP execute
+path end-to-end" — an integration/validation ticket, not a spec-needing
+one. Should validation surface a real gap (spec `023`'s transport not
+actually carrying `execute_entrypoint` calls, or trace-summary redaction
+omitting something a browser consumer needs), that is a new finding to
+file on its own, since it was not independently re-tested when this ADR
+was written.
+
+## Alternatives considered
+
+- Extend `BundleEmbedder` / add a browser-side `resolveManifest(capabilityRef)`
+  helper that fetches WASM bytes and computes the FNV-1a digest
+  client-side: rejected — duplicates the manifest/digest ceremony in two
+  places (server enforcement plus client construction) instead of one, and
+  would need the registry to expose a raw digest field it doesn't have
+  today.
+- Have the registry publish a ready-made `manifest.json` per capability
+  version, keeping `BundleEmbedder`'s flow but removing client-side digest
+  computation: not rejected outright, but deferred — a registry-side
+  change with its own review, not something this browser-execution
+  decision should presuppose; revisit only if `execute_entrypoint` proves
+  insufficient.
+- Author a new spec to formally govern browser-hosted access to
+  `execute_entrypoint`: rejected — spec `023` already covers this
+  generically (transport and packaging boundary, no tool-level allowlist),
+  and a parallel spec re-covering the same surface risks the drift
+  Decision 58 already warned against.

--- a/docs/decision-log.md
+++ b/docs/decision-log.md
@@ -2232,3 +2232,59 @@ corrections). Real unblock condition made explicit: this planner will
 return almost no candidates until registry `#305` backfills real
 `consumes`/`emits` data — that dependency is recorded as a formal
 `blocked by` relationship on `#1098`, not just prose.
+
+## Decision 60: Single-Capability Browser Execution Routes Through `execute_entrypoint`, Not an Extended BundleEmbedder
+
+- **Date**: 2026-08-22
+- **Status**: Accepted
+- **Governing spec**: `023-browser-hosted-mcp-consumer-model` (existing scope confirmed sufficient); ADR-0044; related `006-runtime-request-execution`, `010-runtime-state-machine`, `068-public-platform-embedder-packages`
+- **Related issues**: `#1100`; related `#1097`, `#1098`, `#865`
+- **Origin**: Same discover.html investigation as Decision 59. `#1100` proposed extending `BundleEmbedder` (spec `068`) to construct a `manifest.json`/FNV-1a digest client-side so a browser could run an arbitrary, live-fetched registry capability directly — surfaced while approving specs/ADRs for the remaining `needs-spec` tickets from that investigation.
+
+### Context
+
+Real capability execution requires a `manifest.json` (`agent_package`,
+FNV-1a `expected_digest`) and a `runtime-request.json`, with a digest match
+enforced before anything runs. `#1100` found that a browser fetching a
+capability straight from `catalog.json` has neither, and proposed teaching
+`BundleEmbedder` (or a new browser-side helper) to build both client-side.
+`traverse-mcp`'s existing `execute_entrypoint` tool already performs this
+exact resolution server-side and returns a public trace summary — the
+ceremony `#1100` was proposing to duplicate is already solved once.
+
+### Decision
+
+Do not extend `BundleEmbedder` to build manifests or digests client-side.
+Single-capability execution from a browser-hosted client goes through the
+existing `execute_entrypoint` MCP tool, over whatever non-stdio transport
+spec `023` already defines for browser-hosted consumers (FR-006) — the
+manifest/digest/binary-resolution ceremony stays server-side. `BundleEmbedder`
+keeps its narrower, existing job: executing a pre-vetted application bundle
+(spec `044`) shipped with the app itself, not arbitrary live registry
+content chosen at runtime. No new governing spec is required: spec `023`
+already defines browser-hosted transport access in general terms, with no
+tool-level allowlist excluding `execute_entrypoint`. What remains is
+implementation and validation — confirming a browser-hosted client can
+actually reach `execute_entrypoint` over spec `023`'s transport and that
+the trace-summary response is sufficient for a real consumer.
+
+### Alternatives Considered
+
+- Client-side manifest/digest construction in `BundleEmbedder` — rejected;
+  duplicates server-enforced ceremony in the browser and needs a registry
+  digest field that doesn't exist today.
+- Registry publishes a ready-made `manifest.json` per version, keeping
+  `BundleEmbedder`'s existing flow — deferred, not rejected; a registry-side
+  change with its own review, only worth it if `execute_entrypoint` proves
+  insufficient.
+- A new spec formally governing browser-hosted `execute_entrypoint` access
+  — rejected; spec `023` already covers this generically, and a parallel
+  spec re-covering the same surface risks the drift Decision 58 warned
+  against.
+
+### Outcome
+
+ADR-0044 recorded. `traverse#1100` rescoped from an execution-ceremony
+implementation gap to an integration/validation ticket: confirm the
+already-approved browser-hosted MCP execute path works end-to-end; `needs-spec`
+removed since no new governing document is required.

--- a/specs/governance/approved-specs.json
+++ b/specs/governance/approved-specs.json
@@ -193,7 +193,9 @@
         "docs/app-consumable-acceptance.md",
         "docs/app-consumable-release-checklist.md",
         "docs/youaskm3-integration-validation.md",
-        "docs/mcp-consumption-validation.md"
+        "docs/mcp-consumption-validation.md",
+        "docs/adr/0044-single-capability-execution-via-mcp-not-embedder.md",
+        "docs/decision-log.md"
       ]
     },
     {


### PR DESCRIPTION
## Summary

`traverse#1100` proposed extending `BundleEmbedder` (spec `068`) to build a
`manifest.json`/FNV-1a digest client-side so a browser could run an
arbitrary, live-fetched registry capability directly. `traverse-mcp`
already exposes an `execute_entrypoint` tool that performs that exact
manifest/digest/binary resolution server-side. This PR records the
decision to route single-capability browser execution through that
existing tool over spec `023`'s already-approved browser-hosted transport,
instead of duplicating the ceremony client-side — and confirms this needs
no new governing spec, since `023` already covers browser-hosted transport
access generically with no tool-level allowlist.

## Governing Spec

- `023-browser-hosted-mcp-consumer-model`
- `004-spec-alignment-gate`

## Project Item

- traverse#1100

## Validation

- `python3 -c "import json; json.load(open('specs/governance/approved-specs.json'))"` — valid JSON, spec count unchanged at 116 (existing entry edited, not added).
- Manually reviewed ADR-0044 and Decision 60 against the existing house format (`docs/adr/0043-*.md`, Decision 59).
- `BASE_SHA=$(git merge-base HEAD origin/main) HEAD_SHA=$(git rev-parse HEAD) bash scripts/ci/spec_alignment_check.sh pr-body-1104.md`
- `bash scripts/ci/pr_body_check.sh pr-body-1104.md`
