### PR TITLE
feat(web-embedder): make traverse-embedder-web publish-ready (prep only)

### DIFF
--- a/docs/web-embedder-npm-publish-runbook.md
+++ b/docs/web-embedder-npm-publish-runbook.md
@@ -1,0 +1,67 @@
+# Publishing `traverse-embedder-web` to npm
+
+Governed by `068-public-platform-embedder-packages`. Tracks issue `#1097`.
+
+`packages/web/TraverseEmbedder` is a complete, versioned, conformance-tested
+implementation of `embedder-api/1.0.0` — it builds cleanly, all 42 package
+tests pass, and it already satisfies spec 068's package-content requirements
+(FR-006 test double, FR-007 documentation, FR-008 release evidence via
+`releaseEvidence()`, FR-009 conformance corpus — see `npm run build && npm run test`
+and `scripts/ci/embedder_conformance/web_package.sh`). The only remaining gap is
+distribution: it has never been published, so nothing outside this repo can
+`npm install` it.
+
+Publishing is an irreversible, externally-visible action against a
+third-party registry. This repo's automation does not perform it — this
+runbook prepares everything up to that point and hands the actual publish
+command to whoever holds npm publish rights for the intended package name.
+
+## Preflight checklist (verified in this PR)
+
+- [x] `npm run build` compiles cleanly (`tsc`, no errors).
+- [x] `npm test` passes (42/42), including real WASI capability execution and
+      a full checked-in `traverse-starter` bundle run.
+- [x] `npm pack --dry-run` produces the expected tarball: `dist/**`,
+      `README.md`, `LICENSE`, `package.json` (24 → 25 files after adding
+      `LICENSE` to `files` in this PR).
+- [x] `prepublishOnly` now runs `build` automatically so a stale/missing
+      `dist/` can never ship (added in this PR — previously `npm publish`
+      would have shipped whatever `dist/` happened to exist locally).
+- [x] Name availability re-checked live on 2026-08-22:
+      `npm view traverse-embedder-web` → `404 Not Found` (unclaimed, matches
+      the package.json `name` field already committed).
+
+## What is NOT verified here
+
+- Whether `traverse-framework` (or whoever publishes) has an npm
+  organization/account with the intended publish identity already set up.
+- Whether `traverse-embedder-web` is the final desired public package name
+  versus a scoped alternative (e.g. `@traverse-framework/embedder-web`) —
+  the unscoped name in `package.json` was already a deliberate prior choice,
+  kept as-is here rather than relitigated.
+- CI-based publish automation (a GitHub Actions workflow gated on a tag or
+  manual dispatch, using an `NPM_TOKEN` secret) — not built in this PR; ask
+  for it explicitly as a follow-up if wanted, since it requires adding a
+  repository secret this session cannot create.
+
+## To actually publish (run this yourself, with your own npm credentials)
+
+```bash
+cd packages/web/TraverseEmbedder
+npm login                 # if not already authenticated for this identity
+npm publish --access public
+```
+
+`--access public` is required the first time for an unscoped package name
+under an account without a default-private setting.
+
+## Verify after publishing
+
+```bash
+npm view traverse-embedder-web
+npm install traverse-embedder-web   # from a scratch directory, outside this repo
+```
+
+Confirm the installed package's `dist/index.js` exports match
+`packages/web/TraverseEmbedder/dist/index.js` from this build, and that
+`releaseEvidence()` reports the expected version/digests.

--- a/packages/web/TraverseEmbedder/LICENSE
+++ b/packages/web/TraverseEmbedder/LICENSE
@@ -1,0 +1,160 @@
+Apache License
+Version 2.0, January 2004
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+"License" shall mean the terms and conditions for use, reproduction, and
+distribution as defined by Sections 1 through 9 of this document.
+
+"Licensor" shall mean the copyright owner or entity authorized by the copyright
+owner that is granting the License.
+
+"Legal Entity" shall mean the union of the acting entity and all other entities
+that control, are controlled by, or are under common control with that entity.
+For the purposes of this definition, "control" means (i) the power, direct or
+indirect, to cause the direction or management of such entity, whether by
+contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the
+outstanding shares, or (iii) beneficial ownership of such entity.
+
+"You" (or "Your") shall mean an individual or Legal Entity exercising
+permissions granted by this License.
+
+"Source" form shall mean the preferred form for making modifications, including
+but not limited to software source code, documentation source, and configuration
+files.
+
+"Object" form shall mean any form resulting from mechanical transformation or
+translation of a Source form, including but not limited to compiled object code,
+generated documentation, and conversions to other media types.
+
+"Work" shall mean the work of authorship, whether in Source or Object form,
+made available under the License, as indicated by a copyright notice that is
+included in or attached to the work (an example is provided in the Appendix
+below).
+
+"Derivative Works" shall mean any work, whether in Source or Object form, that
+is based on (or derived from) the Work and for which the editorial revisions,
+annotations, elaborations, or other modifications represent, as a whole, an
+original work of authorship. For the purposes of this License, Derivative Works
+shall not include works that remain separable from, or merely link (or bind by
+name) to the interfaces of, the Work and Derivative Works thereof.
+
+"Contribution" shall mean any work of authorship, including the original version
+of the Work and any modifications or additions to that Work or Derivative Works
+thereof, that is intentionally submitted to Licensor for inclusion in the Work
+by the copyright owner or by an individual or Legal Entity authorized to submit
+on behalf of the copyright owner. For the purposes of this definition,
+"submitted" means any form of electronic, verbal, or written communication sent
+to the Licensor or its representatives, including but not limited to
+communication on electronic mailing lists, source code control systems, and
+issue tracking systems that are managed by, or on behalf of, the Licensor for
+the purpose of discussing and improving the Work, but excluding communication
+that is conspicuously marked or otherwise designated in writing by the copyright
+owner as "Not a Contribution."
+
+"Contributor" shall mean Licensor and any individual or Legal Entity on behalf
+of whom a Contribution has been received by Licensor and subsequently
+incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of this
+License, each Contributor hereby grants to You a perpetual, worldwide,
+non-exclusive, no-charge, royalty-free, irrevocable copyright license to
+reproduce, prepare Derivative Works of, publicly display, publicly perform,
+sublicense, and distribute the Work and such Derivative Works in Source or
+Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of this License,
+each Contributor hereby grants to You a perpetual, worldwide, non-exclusive,
+no-charge, royalty-free, irrevocable (except as stated in this section) patent
+license to make, have made, use, offer to sell, sell, import, and otherwise
+transfer the Work, where such license applies only to those patent claims
+licensable by such Contributor that are necessarily infringed by their
+Contribution(s) alone or by combination of their Contribution(s) with the Work
+to which such Contribution(s) was submitted. If You institute patent litigation
+against any entity (including a cross-claim or counterclaim in a lawsuit)
+alleging that the Work or a Contribution incorporated within the Work
+constitutes direct or contributory patent infringement, then any patent licenses
+granted to You under this License for that Work shall terminate as of the date
+such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the Work or
+Derivative Works thereof in any medium, with or without modifications, and in
+Source or Object form, provided that You meet the following conditions:
+
+(a) You must give any other recipients of the Work or Derivative Works a copy of
+this License; and
+
+(b) You must cause any modified files to carry prominent notices stating that You
+changed the files; and
+
+(c) You must retain, in the Source form of any Derivative Works that You
+distribute, all copyright, patent, trademark, and attribution notices from the
+Source form of the Work, excluding those notices that do not pertain to any part
+of the Derivative Works; and
+
+(d) If the Work includes a "NOTICE" text file as part of its distribution, then
+any Derivative Works that You distribute must include a readable copy of the
+attribution notices contained within such NOTICE file, excluding those notices
+that do not pertain to any part of the Derivative Works, in at least one of the
+following places: within a NOTICE text file distributed as part of the
+Derivative Works; within the Source form or documentation, if provided along
+with the Derivative Works; or, within a display generated by the Derivative
+Works, if and wherever such third-party notices normally appear. The contents of
+the NOTICE file are for informational purposes only and do not modify the
+License. You may add Your own attribution notices within Derivative Works that
+You distribute, alongside or as an addendum to the NOTICE text from the Work,
+provided that such additional attribution notices cannot be construed as
+modifying the License.
+
+You may add Your own copyright statement to Your modifications and may provide
+additional or different license terms and conditions for use, reproduction, or
+distribution of Your modifications, or for any such Derivative Works as a whole,
+provided Your use, reproduction, and distribution of the Work otherwise complies
+with the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise, any
+Contribution intentionally submitted for inclusion in the Work by You to the
+Licensor shall be under the terms and conditions of this License, without any
+additional terms or conditions. Notwithstanding the above, nothing herein shall
+supersede or modify the terms of any separate license agreement you may have
+executed with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade names,
+trademarks, service marks, or product names of the Licensor, except as required
+for reasonable and customary use in describing the origin of the Work and
+reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or agreed to in
+writing, Licensor provides the Work (and each Contributor provides its
+Contributions) on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied, including, without limitation, any warranties
+or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+PARTICULAR PURPOSE. You are solely responsible for determining the
+appropriateness of using or redistributing the Work and assume any risks
+associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory, whether in
+tort (including negligence), contract, or otherwise, unless required by
+applicable law (such as deliberate and grossly negligent acts) or agreed to in
+writing, shall any Contributor be liable to You for damages, including any
+direct, indirect, special, incidental, or consequential damages of any character
+arising as a result of this License or out of the use or inability to use the
+Work (including but not limited to damages for loss of goodwill, work stoppage,
+computer failure or malfunction, or any and all other commercial damages or
+losses), even if such Contributor has been advised of the possibility of such
+damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing the Work or
+Derivative Works thereof, You may choose to offer, and charge a fee for,
+acceptance of support, warranty, indemnity, or other liability obligations
+and/or rights consistent with this License. However, in accepting such
+obligations, You may act only on Your own behalf and on Your sole responsibility,
+not on behalf of any other Contributor, and only if You agree to indemnify,
+defend, and hold each Contributor harmless for any liability incurred by, or
+claims asserted against, such Contributor by reason of your accepting any such
+warranty or additional liability.
+
+END OF TERMS AND CONDITIONS

--- a/packages/web/TraverseEmbedder/README.md
+++ b/packages/web/TraverseEmbedder/README.md
@@ -152,6 +152,12 @@ npm install
 npm test   # builds with tsc, then runs the node:test suite
 ```
 
+## Publishing
+
+This package is not yet published to npm. See
+[docs/web-embedder-npm-publish-runbook.md](../../../docs/web-embedder-npm-publish-runbook.md)
+for the preflight checklist and exact publish commands.
+
 `npm test` compiles a set of real WASI capability modules from WebAssembly
 Text format via `wabt` (a devDependency, mirroring the Rust crate's `wat`
 crate test fixtures) and runs `BundleEmbedder` against them — including one

--- a/packages/web/TraverseEmbedder/package.json
+++ b/packages/web/TraverseEmbedder/package.json
@@ -19,10 +19,12 @@
   },
   "files": [
     "dist",
-    "README.md"
+    "README.md",
+    "LICENSE"
   ],
   "scripts": {
     "build": "tsc",
+    "prepublishOnly": "npm run build",
     "test": "npm run build && node --test tests/embedder.test.mjs tests/bundleEmbedder.test.mjs tests/registryCache.test.mjs tests/indexedDbDataStore.test.mjs"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

Prepares `packages/web/TraverseEmbedder` (`traverse-embedder-web`) for npm
publication, per #1097. The issue speculated this might be an early-stage
wasm-bindgen crate needing significant work; investigation found the
opposite — it's a complete, well-documented TypeScript SDK that already:

- builds cleanly (`npm run build`)
- passes its full 42-test conformance suite (`npm test`,
  `scripts/ci/embedder_conformance/web_package.sh`)
- satisfies spec 068's package-content requirements (FR-006 test double,
  FR-007 documentation, FR-008 `releaseEvidence()`, FR-009 conformance)

The only real gap was distribution: `npm view traverse-embedder-web` still
404s (re-verified live). This PR closes the publish-readiness gaps found
during a `npm pack --dry-run` review:

- adds `prepublishOnly: npm run build` so `npm publish` can never ship a
  stale/missing `dist/` (previously nothing forced a build first)
- copies root `LICENSE` into the package and adds it to `files` (npm tarballs
  don't include the repo's LICENSE otherwise; the Swift package shares this
  gap via git-based consumption instead, so it wasn't previously an npm-only
  problem)
- adds `docs/web-embedder-npm-publish-runbook.md`: preflight evidence, what's
  NOT verified (npm org/account setup, final name choice, CI publish
  automation), and the exact `npm login` / `npm publish --access public`
  commands

**This PR does not run `npm publish`.** Publishing a new public package to a
third-party registry is an irreversible, externally-visible action; this
session also has no npm publish credentials in this environment
(`npm whoami` → `ENEEDAUTH`). Per user decision, this ticket is scoped to
prep-only — the runbook hands the actual publish step to whoever holds npm
publish rights for the intended package identity. **This does not close
#1097** — the issue's actual ask (external consumability) isn't done until
someone runs the publish step; Project 1 status is set to `Blocked` on that
external action rather than `Done`.

Relates to #1097

## Governing Spec

- `068-public-platform-embedder-packages`
- `070-runtime-event-sink-boundary`

## Project Item

Project 1 item for #1097: `PVTI_lADOEbiBt84Bbyp1zg3nh3A` (In Progress).

## Validation

- `npm run build` — clean, no errors.
- `npm test` — 42/42 passing.
- `bash scripts/ci/embedder_conformance/web_package.sh` — passing,
  `{"conformance_passed": true, ...}`.
- `npm pack --dry-run` — 25 files (LICENSE now included), correct tarball
  contents, no stray files.
- `npm view traverse-embedder-web` — confirmed still unclaimed (`404`).
- `BASE_SHA=origin/main bash scripts/ci/local_preflight.sh --pr-body <file>`
- `bash scripts/ci/pr_body_check.sh <file>`
- `bash scripts/ci/spec_alignment_check.sh` — clean against this PR body.

## Non-goals

- Actually running `npm publish` (external, irreversible; needs credentials
  this session doesn't have and explicit human execution regardless).
- Deciding a final scoped-vs-unscoped package name (kept the existing
  `traverse-embedder-web` already committed in `package.json`).
- CI-based publish automation (would need a new `NPM_TOKEN` repo secret this
  session cannot add) — worth a follow-up if wanted.
