### PR TITLE
feat(mcp): implement P4 governed export and promotion of runtime workflow proposals

### DIFF
--- a/crates/traverse-mcp/src/tools/mod.rs
+++ b/crates/traverse-mcp/src/tools/mod.rs
@@ -7,3 +7,4 @@ pub mod events;
 pub mod parallel_proposals;
 pub mod proposals;
 pub mod traces;
+pub mod workflow_promotion;

--- a/crates/traverse-mcp/src/tools/workflow_promotion.rs
+++ b/crates/traverse-mcp/src/tools/workflow_promotion.rs
@@ -1,0 +1,333 @@
+//! Non-mutating export of a completed runtime workflow proposal into a
+//! human-reviewable candidate workflow artifact (spec
+//! `112-governed-workflow-promotion`, P4, ADR-0042).
+//!
+//! Export never touches the registry or an app manifest (FR-001) — the
+//! candidate is a plain, serializable value with no identity of its own.
+//! Promotion into a reusable, versioned workflow definition still requires
+//! the same human review and existing registry/bundle publication gates
+//! (`traverse_registry::WorkflowRegistry::register`, `traverse-cli workflow
+//! register`) as any hand-authored workflow (FR-002) — this module never
+//! calls them directly, and [`finalize_candidate_into_definition`] only
+//! assembles the `WorkflowDefinition` value a reviewer would still submit
+//! through that unchanged path.
+//!
+//! ## Why the candidate isn't always registrable as-is
+//!
+//! `WorkflowDefinition` predates proposals and only supports a single
+//! direct outgoing edge per node (`traverse_registry`'s own registration
+//! validation rejects more than one with `DuplicateItem`) — a real,
+//! existing v0.1 constraint this module does not relax or work around. A
+//! branching proposal (fan-out/fan-in, which P1/P2 fully support) exports
+//! honestly into a candidate that reflects its real edge structure, and
+//! correctly fails registration if promoted as-is; only proposals whose
+//! nodes each have at most one outgoing edge can currently become a
+//! registrable workflow. This is surfaced, not hidden — the candidate's
+//! `edges` always mirror the proposal exactly.
+//!
+//! `WorkflowNode`'s `from_workflow_input`/`to_workflow_state` model shares
+//! data through named top-level keys in accumulated workflow state, unlike
+//! a proposal's arbitrary-JSON-Pointer field mappings. A mapping whose
+//! source and target path share the same final pointer segment (e.g.
+//! `/value` → `/value`, or `/a/value` → `/b/value`) translates cleanly;
+//! anything else — a rename, or a nested path with a different leaf name —
+//! is listed in `unconfirmed_mappings` for the reviewer to resolve by hand
+//! rather than guessed at.
+
+use serde::Serialize;
+use std::collections::{BTreeMap, BTreeSet};
+
+use traverse_contracts::{
+    CanonicalProposal, Lifecycle, MappingSource, Owner, RiskMetadata, SchemaContainer,
+};
+use traverse_registry::{
+    WorkflowDefinition, WorkflowEdge, WorkflowEdgeTrigger, WorkflowNode, WorkflowNodeInput,
+    WorkflowNodeOutput,
+};
+use traverse_runtime::proposal::{ProposalTerminalState, ProposalTrace, ResolvedProposalNode};
+
+use crate::{McpError, McpErrorCode};
+
+const WORKFLOW_KIND: &str = "workflow_definition";
+const WORKFLOW_SCHEMA_VERSION: &str = "1.0.0";
+const WORKFLOW_GOVERNING_SPEC: &str = "007-workflow-registry-traversal";
+
+/// One candidate node's declared capability and best-effort state-key
+/// wiring, carried for reviewer visibility (spec 112 FR-002a: preserve
+/// reviewed effect/determinism/data-flow/reliability declarations).
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct CandidateNode {
+    pub node_id: String,
+    pub capability_id: String,
+    pub capability_version: String,
+    /// `None` only if `resolved_nodes` (a caller-supplied slice) did not
+    /// include this node id — otherwise always the node's declared risk.
+    pub risk: Option<RiskMetadata>,
+    pub from_workflow_input: Vec<String>,
+    pub to_workflow_state: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct CandidateEdge {
+    pub from: String,
+    pub to: String,
+}
+
+/// A mapping that could not be reduced to a shared top-level state key
+/// unambiguously and needs reviewer correction before promotion — mirrors
+/// spec 113's `mapping_unconfirmed` convention.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct UnconfirmedMapping {
+    pub source_path: String,
+    pub target_node_id: String,
+    pub target_path: String,
+    pub reason: String,
+}
+
+/// A non-mutating, secret-free candidate workflow artifact exported from a
+/// successfully completed runtime workflow proposal (spec 112 FR-001,
+/// FR-002a). Never registered directly — see the module documentation.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct WorkflowCandidateArtifact {
+    pub source_proposal_id: String,
+    pub source_proposal_digest: String,
+    pub source_snapshot_digest: String,
+    pub nodes: Vec<CandidateNode>,
+    pub edges: Vec<CandidateEdge>,
+    pub start_node: String,
+    pub terminal_nodes: Vec<String>,
+    pub unconfirmed_mappings: Vec<UnconfirmedMapping>,
+    /// Proposal fields intentionally never carried into this candidate
+    /// (spec 112 FR-001/FR-002a: no raw inputs, approval material, or
+    /// private bindings) — recorded for audit, mirroring
+    /// `ApplicationEffectiveConfig::redacted_secret_keys`.
+    pub excluded_fields: Vec<String>,
+}
+
+/// Exports a completed proposal's execution as a candidate workflow
+/// artifact (spec 112 FR-001). Only a proposal whose trace reached
+/// `succeeded` may be exported — acceptance scenario 1 requires exporting
+/// a *completed* proposal, and an incomplete or failed execution has no
+/// proven reusable shape to offer a reviewer.
+///
+/// # Errors
+///
+/// Returns [`McpError`] when the trace did not reach `succeeded`.
+#[allow(clippy::too_many_lines)]
+pub fn export_workflow_candidate(
+    canonical: &CanonicalProposal,
+    trace: &ProposalTrace,
+    resolved_nodes: &[ResolvedProposalNode],
+) -> Result<WorkflowCandidateArtifact, McpError> {
+    if trace.terminal_state != ProposalTerminalState::Succeeded {
+        return Err(McpError {
+            code: McpErrorCode::ValidationFailed,
+            message: format!(
+                "only a successfully completed proposal may be exported; terminal state was {:?}",
+                trace.terminal_state
+            ),
+        });
+    }
+
+    let risk_by_node: BTreeMap<&str, &RiskMetadata> = resolved_nodes
+        .iter()
+        .map(|node| (node.node_id.as_str(), &node.contract.risk))
+        .collect();
+
+    let mut from_workflow_input: BTreeMap<&str, BTreeSet<String>> = BTreeMap::new();
+    let mut to_workflow_state: BTreeMap<&str, BTreeSet<String>> = BTreeMap::new();
+    let mut unconfirmed_mappings = Vec::new();
+
+    for mapping in &canonical.proposal.mappings {
+        let target_key = pointer_leaf(&mapping.target_path);
+        let source_key = pointer_leaf(&mapping.source_path);
+        if source_key.is_empty() || target_key.is_empty() || source_key != target_key {
+            unconfirmed_mappings.push(UnconfirmedMapping {
+                source_path: mapping.source_path.clone(),
+                target_node_id: mapping.target_node_id.clone(),
+                target_path: mapping.target_path.clone(),
+                reason: "source and target paths do not share a common field name; \
+                         the shared-state model has no rename step"
+                    .to_string(),
+            });
+            continue;
+        }
+
+        from_workflow_input
+            .entry(mapping.target_node_id.as_str())
+            .or_default()
+            .insert(target_key.to_string());
+        if let MappingSource::Node { node_id } = &mapping.source {
+            to_workflow_state
+                .entry(node_id.as_str())
+                .or_default()
+                .insert(source_key.to_string());
+        }
+    }
+
+    let nodes = canonical
+        .proposal
+        .nodes
+        .iter()
+        .map(|node| CandidateNode {
+            node_id: node.node_id.clone(),
+            capability_id: node.capability_id.clone(),
+            capability_version: node.capability_version.clone(),
+            risk: risk_by_node
+                .get(node.node_id.as_str())
+                .map(|risk| (*risk).clone()),
+            from_workflow_input: from_workflow_input
+                .get(node.node_id.as_str())
+                .map(|keys| keys.iter().cloned().collect())
+                .unwrap_or_default(),
+            to_workflow_state: to_workflow_state
+                .get(node.node_id.as_str())
+                .map(|keys| keys.iter().cloned().collect())
+                .unwrap_or_default(),
+        })
+        .collect();
+
+    let edges = canonical
+        .proposal
+        .edges
+        .iter()
+        .map(|edge| CandidateEdge {
+            from: edge.from_node_id.clone(),
+            to: edge.to_node_id.clone(),
+        })
+        .collect();
+
+    let has_incoming: BTreeSet<&str> = canonical
+        .proposal
+        .edges
+        .iter()
+        .map(|edge| edge.to_node_id.as_str())
+        .collect();
+    let has_outgoing: BTreeSet<&str> = canonical
+        .proposal
+        .edges
+        .iter()
+        .map(|edge| edge.from_node_id.as_str())
+        .collect();
+    let start_node = canonical
+        .proposal
+        .nodes
+        .iter()
+        .find(|node| !has_incoming.contains(node.node_id.as_str()))
+        .map(|node| node.node_id.clone())
+        .unwrap_or_default();
+    let terminal_nodes = canonical
+        .proposal
+        .nodes
+        .iter()
+        .filter(|node| !has_outgoing.contains(node.node_id.as_str()))
+        .map(|node| node.node_id.clone())
+        .collect();
+
+    Ok(WorkflowCandidateArtifact {
+        source_proposal_id: canonical.proposal.proposal_id.clone(),
+        source_proposal_digest: trace.proposal_digest.clone(),
+        source_snapshot_digest: trace.snapshot_digest.clone(),
+        nodes,
+        edges,
+        start_node,
+        terminal_nodes,
+        unconfirmed_mappings,
+        excluded_fields: vec![
+            "initial_input".to_string(),
+            "authorization.approval_token_id".to_string(),
+        ],
+    })
+}
+
+/// The final `unconfirmed_mappings` entries are for reviewer information,
+/// not for callers of this function; returns the leaf (final) JSON Pointer
+/// segment of `pointer`, or an empty string for the root pointer.
+fn pointer_leaf(pointer: &str) -> &str {
+    pointer.rsplit('/').next().unwrap_or("")
+}
+
+/// The identity and metadata a human reviewer assigns at promotion time —
+/// never inferred from the source proposal (spec 112 FR-003).
+pub struct PromotedWorkflowIdentity {
+    pub id: String,
+    pub name: String,
+    pub version: String,
+    pub owner: Owner,
+    pub lifecycle: Lifecycle,
+    pub summary: String,
+    pub tags: Vec<String>,
+}
+
+/// Assembles a registrable `WorkflowDefinition` from a candidate plus the
+/// identity a human reviewer assigns at promotion time (spec 112 FR-002,
+/// FR-003: a promoted workflow has its own immutable identity, decided at
+/// promotion — never inferred from the source proposal). This performs no
+/// registration itself; the caller still submits the result through the
+/// existing `WorkflowRegistry::register` / `traverse-cli workflow
+/// register` path.
+#[must_use]
+pub fn finalize_candidate_into_definition(
+    candidate: &WorkflowCandidateArtifact,
+    identity: PromotedWorkflowIdentity,
+) -> WorkflowDefinition {
+    let PromotedWorkflowIdentity {
+        id,
+        name,
+        version,
+        owner,
+        lifecycle,
+        summary,
+        tags,
+    } = identity;
+    WorkflowDefinition {
+        kind: WORKFLOW_KIND.to_string(),
+        schema_version: WORKFLOW_SCHEMA_VERSION.to_string(),
+        id,
+        name,
+        version,
+        lifecycle,
+        owner,
+        summary,
+        inputs: SchemaContainer {
+            schema: serde_json::json!({"type": "object"}),
+        },
+        outputs: SchemaContainer {
+            schema: serde_json::json!({"type": "object"}),
+        },
+        nodes: candidate
+            .nodes
+            .iter()
+            .map(|node| WorkflowNode {
+                node_id: node.node_id.clone(),
+                capability_id: node.capability_id.clone(),
+                capability_version: node.capability_version.clone(),
+                input: WorkflowNodeInput {
+                    from_workflow_input: node.from_workflow_input.clone(),
+                },
+                output: WorkflowNodeOutput {
+                    to_workflow_state: node.to_workflow_state.clone(),
+                    publish_to_state_as: None,
+                },
+            })
+            .collect(),
+        edges: candidate
+            .edges
+            .iter()
+            .enumerate()
+            .map(|(index, edge)| WorkflowEdge {
+                edge_id: format!("edge-{index}"),
+                from: edge.from.clone(),
+                to: edge.to.clone(),
+                trigger: WorkflowEdgeTrigger::Direct,
+                event: None,
+                predicate: None,
+            })
+            .collect(),
+        start_node: candidate.start_node.clone(),
+        terminal_nodes: candidate.terminal_nodes.clone(),
+        output_projection: Vec::new(),
+        tags,
+        governing_spec: WORKFLOW_GOVERNING_SPEC.to_string(),
+    }
+}

--- a/crates/traverse-mcp/tests/workflow_promotion_tests.rs
+++ b/crates/traverse-mcp/tests/workflow_promotion_tests.rs
@@ -1,0 +1,526 @@
+//! End-to-end tests for exporting a completed runtime workflow proposal
+//! into a candidate workflow artifact and promoting it through the
+//! existing, unchanged workflow registration path (spec
+//! `112-governed-workflow-promotion`, P4, ADR-0042).
+//!
+//! The key end-to-end scenario the spec's own Definition of Done names is
+//! "export -> review fixture -> published workflow discovery" — this file
+//! proves exactly that using the real `traverse_registry::WorkflowRegistry`,
+//! not a mock.
+
+use serde_json::json;
+
+use traverse_contracts::{
+    BinaryFormat as ContractBinaryFormat, CanonicalProposal, CapabilityContract, DataFlowPolicy,
+    DeterminismClass, EffectClass, Entrypoint, EntrypointKind, Execution, ExecutionConstraints,
+    ExecutionTarget, FilesystemAccess, HostApiAccess, Lifecycle, ManifestReference, MappingSource,
+    NetworkAccess, Owner, ProposalEdge, ProposalLimits, ProposalMapping, ProposalNode,
+    ReliabilityMetadata, RiskMetadata, SchemaContainer, ServiceType, SideEffect, SideEffectKind,
+    WorkflowProposal, canonicalize_proposal, proposal_digest,
+};
+use traverse_mcp::tools::workflow_promotion::{
+    PromotedWorkflowIdentity, export_workflow_candidate, finalize_candidate_into_definition,
+};
+use traverse_registry::{
+    ApplicationBundleManifest, ApplicationComponent, ApplicationComponentRef,
+    ApplicationEffectiveConfig, ArtifactDigests, BinaryFormat as RegistryBinaryFormat,
+    BinaryReference, CapabilityArtifactRecord, CapabilityRegistration, CapabilityRegistry,
+    ComponentExecutionMode, ComposabilityMetadata, CompositionKind, CompositionPattern,
+    ImplementationKind, LookupScope, RegistryProvenance, RegistryScope, SourceKind,
+    SourceReference, WasmComponentManifest, WorkflowRegistration, WorkflowRegistry,
+};
+use traverse_runtime::proposal::{
+    AuthorizationSummary, ProposalTerminalState, execute_proposal,
+    validate_proposal_against_host_state,
+};
+use traverse_runtime::security::RuntimeSecurityConfig;
+use traverse_runtime::{LocalExecutionFailure, LocalExecutionOutput, LocalExecutor, Runtime};
+
+fn risk(effect_class: EffectClass) -> RiskMetadata {
+    RiskMetadata {
+        effect_class,
+        determinism_class: DeterminismClass::Deterministic,
+        data_flow: DataFlowPolicy::default(),
+        reliability: ReliabilityMetadata {
+            idempotency_required: false,
+            retryable: true,
+            compensation_available: false,
+        },
+    }
+}
+
+fn contract(id: &str) -> CapabilityContract {
+    let (namespace, name) = id.rsplit_once('.').unwrap_or(("test", id));
+    CapabilityContract {
+        kind: "capability_contract".to_string(),
+        schema_version: "1.0.0".to_string(),
+        id: id.to_string(),
+        namespace: namespace.to_string(),
+        name: name.to_string(),
+        version: "1.0.0".to_string(),
+        lifecycle: Lifecycle::Active,
+        owner: Owner {
+            team: "traverse-core".to_string(),
+            contact: "enrico.piovesan10@gmail.com".to_string(),
+        },
+        summary: "Test capability for workflow promotion coverage.".to_string(),
+        description: "Portable test capability used to exercise workflow promotion export."
+            .to_string(),
+        inputs: SchemaContainer {
+            schema: json!({"type": "object"}),
+        },
+        outputs: SchemaContainer {
+            schema: json!({"type": "object"}),
+        },
+        preconditions: Vec::new(),
+        postconditions: Vec::new(),
+        side_effects: vec![SideEffect {
+            kind: SideEffectKind::MemoryOnly,
+            description: "No durable side effect.".to_string(),
+        }],
+        emits: Vec::new(),
+        consumes: Vec::new(),
+        permissions: Vec::new(),
+        execution: Execution {
+            binary_format: ContractBinaryFormat::Wasm,
+            entrypoint: Entrypoint {
+                kind: EntrypointKind::WasiCommand,
+                command: "run".to_string(),
+            },
+            preferred_targets: vec![ExecutionTarget::Local],
+            constraints: ExecutionConstraints {
+                host_api_access: HostApiAccess::None,
+                network_access: NetworkAccess::Forbidden,
+                filesystem_access: FilesystemAccess::None,
+            },
+        },
+        policies: Vec::new(),
+        dependencies: Vec::new(),
+        provenance: traverse_contracts::Provenance {
+            source: traverse_contracts::ProvenanceSource::Greenfield,
+            author: "test".to_string(),
+            created_at: "2026-08-23T00:00:00Z".to_string(),
+            spec_ref: None,
+            adr_refs: Vec::new(),
+            exception_refs: Vec::new(),
+        },
+        evidence: Vec::new(),
+        service_type: ServiceType::Stateless,
+        permitted_targets: vec![ExecutionTarget::Local],
+        event_trigger: None,
+        connector_requirements: Vec::new(),
+        state_schema: None,
+        use_cases: Vec::new(),
+        risk: risk(EffectClass::PureRead),
+    }
+}
+
+fn artifact(digest: &str) -> CapabilityArtifactRecord {
+    CapabilityArtifactRecord {
+        artifact_ref: format!("artifact:{digest}"),
+        implementation_kind: ImplementationKind::Executable,
+        source: SourceReference {
+            kind: SourceKind::Git,
+            location: "https://example.invalid/repo".to_string(),
+        },
+        binary: Some(BinaryReference {
+            format: RegistryBinaryFormat::Wasm,
+            location: format!("artifacts/{digest}/capability.wasm"),
+            signature: None,
+        }),
+        workflow_ref: None,
+        digests: ArtifactDigests {
+            source_digest: format!("src-{digest}"),
+            binary_digest: Some(digest.to_string()),
+        },
+        provenance: RegistryProvenance {
+            source: "test".to_string(),
+            author: "test".to_string(),
+            created_at: "2026-08-23T00:00:00Z".to_string(),
+        },
+    }
+}
+
+fn registry_with(
+    entries: Vec<(CapabilityContract, CapabilityArtifactRecord)>,
+) -> CapabilityRegistry {
+    let mut registry = CapabilityRegistry::new();
+    for (contract, artifact) in entries {
+        let outcome = registry.register(CapabilityRegistration {
+            scope: RegistryScope::Public,
+            contract,
+            contract_path: "registry/test/contract.json".to_string(),
+            artifact,
+            registered_at: "2026-08-23T00:00:00Z".to_string(),
+            tags: Vec::new(),
+            composability: ComposabilityMetadata {
+                kind: CompositionKind::Atomic,
+                patterns: vec![CompositionPattern::Sequential],
+                provides: Vec::new(),
+                requires: Vec::new(),
+            },
+            governing_spec: "005-capability-registry".to_string(),
+            validator_version: "0.1.0".to_string(),
+        });
+        assert!(outcome.is_ok(), "registration must succeed: {outcome:?}");
+    }
+    registry
+}
+
+fn manifest_declaring(components: &[&str]) -> ApplicationBundleManifest {
+    ApplicationBundleManifest {
+        app_id: "test-app".to_string(),
+        version: "1.0.0".to_string(),
+        schema_version: "1.0.0".to_string(),
+        workspace_defaults: json!({}),
+        components: components
+            .iter()
+            .map(|capability_id| ApplicationComponent {
+                reference: ApplicationComponentRef {
+                    component_id: (*capability_id).to_string(),
+                    version: "1.0.0".to_string(),
+                    digest: "sha256:component-digest".to_string(),
+                    manifest_path: "component.manifest.json".to_string(),
+                },
+                manifest_path: "component.manifest.json".into(),
+                manifest: WasmComponentManifest {
+                    component_id: (*capability_id).to_string(),
+                    version: "1.0.0".to_string(),
+                    schema_version: "1.0.0".to_string(),
+                    execution_mode: ComponentExecutionMode::Wasm,
+                    capability_id: (*capability_id).to_string(),
+                    capability_version: "1.0.0".to_string(),
+                    contract_path: None,
+                    registry_ref: None,
+                    wasm_binary_path: None,
+                    wasm_digest: None,
+                    platforms: vec!["local".to_string()],
+                    wrapper_path: None,
+                    runtime_constraints: json!({}),
+                    permitted_targets: vec![ExecutionTarget::Local],
+                    dependencies: Vec::new(),
+                    connector_requirements: Vec::new(),
+                    validation_evidence: Vec::new(),
+                    executable_pin: None,
+                },
+                contract_path: "contract.json".into(),
+                contract: contract(capability_id),
+                wasm_binary_path: None,
+                verified_wasm_digest: None,
+            })
+            .collect(),
+        workflows: Vec::new(),
+        connector_bindings: Vec::new(),
+        model_dependencies: Vec::new(),
+        config_schema: json!({}),
+        default_config: json!({}),
+        effective_config: ApplicationEffectiveConfig {
+            values: json!({}),
+            redacted_secret_keys: Vec::new(),
+        },
+        placement_policy: json!({}),
+        public_surfaces: Vec::new(),
+        state_machine: None,
+    }
+}
+
+fn node(node_id: &str, capability_id: &str) -> ProposalNode {
+    ProposalNode {
+        node_id: node_id.to_string(),
+        capability_id: capability_id.to_string(),
+        capability_version: "1.0.0".to_string(),
+        artifact_digest: format!("digest-{node_id}"),
+    }
+}
+
+/// A strictly linear a -> b proposal, mapping `/value` to `/value` — the
+/// shared field name lets the export cleanly reduce the mapping to a
+/// shared state key.
+fn linear_proposal() -> WorkflowProposal {
+    WorkflowProposal {
+        kind: "workflow_proposal".to_string(),
+        schema_version: "1.0.0".to_string(),
+        proposal_id: "proposal-promo-001".to_string(),
+        workspace_id: "workspace-001".to_string(),
+        app_manifest: ManifestReference {
+            app_id: "test-app".to_string(),
+            app_version: "1.0.0".to_string(),
+            manifest_digest: "sha256:manifest-digest".to_string(),
+        },
+        nodes: vec![node("a", "test.a"), node("b", "test.b")],
+        edges: vec![ProposalEdge {
+            from_node_id: "a".to_string(),
+            to_node_id: "b".to_string(),
+        }],
+        mappings: vec![ProposalMapping {
+            source: MappingSource::Node {
+                node_id: "a".to_string(),
+            },
+            source_path: "/value".to_string(),
+            target_node_id: "b".to_string(),
+            target_path: "/value".to_string(),
+        }],
+        initial_input: json!({}),
+    }
+}
+
+/// Same shape as `linear_proposal`, but the mapping renames the field
+/// (`/draft_id` -> `/value`), which cannot be reduced to a shared state key.
+fn linear_proposal_with_a_rename() -> WorkflowProposal {
+    let mut proposal = linear_proposal();
+    proposal.mappings[0].source_path = "/draft_id".to_string();
+    proposal
+}
+
+/// a fans out to b and c — more than one direct outgoing edge from `a`,
+/// which the existing `WorkflowRegistry` registration validation rejects.
+fn diamond_proposal() -> WorkflowProposal {
+    let mut proposal = linear_proposal();
+    let mut c = node("c", "test.a");
+    c.artifact_digest = "digest-a".to_string(); // shares capability test.a with node "a"
+    proposal.nodes.push(c);
+    proposal.edges.push(ProposalEdge {
+        from_node_id: "a".to_string(),
+        to_node_id: "c".to_string(),
+    });
+    proposal.mappings.clear();
+    proposal
+}
+
+struct EchoExecutor;
+
+impl LocalExecutor for EchoExecutor {
+    fn execute(
+        &self,
+        _capability: &traverse_registry::ResolvedCapability,
+        input: &serde_json::Value,
+    ) -> Result<LocalExecutionOutput, LocalExecutionFailure> {
+        Ok(LocalExecutionOutput {
+            value: input.clone(),
+            emitted_events: Vec::new(),
+        })
+    }
+}
+
+fn two_capability_registry() -> CapabilityRegistry {
+    registry_with(vec![
+        (contract("test.a"), artifact("digest-a")),
+        (contract("test.b"), artifact("digest-b")),
+    ])
+}
+
+fn run_to_success(
+    proposal: WorkflowProposal,
+    manifest: &ApplicationBundleManifest,
+    registry: &CapabilityRegistry,
+) -> Result<(CanonicalProposal, traverse_runtime::proposal::ProposalTrace), String> {
+    let canonical = canonicalize_proposal(proposal, &ProposalLimits::default())
+        .map_err(|e| format!("{e:?}"))?;
+    let resolved = validate_proposal_against_host_state(&canonical, manifest, registry)
+        .map_err(|e| format!("{e:?}"))?;
+    let runtime = Runtime::new(registry.clone(), EchoExecutor)
+        .with_security_config(RuntimeSecurityConfig::development());
+    let digest = proposal_digest(&canonical.proposal);
+    let trace = execute_proposal(
+        &runtime,
+        &canonical,
+        &resolved,
+        AuthorizationSummary {
+            automatic: true,
+            approval_token_id: None,
+        },
+        &digest,
+        "snapshot-digest",
+    );
+    if trace.terminal_state != ProposalTerminalState::Succeeded {
+        return Err(format!(
+            "expected Succeeded, got {:?}",
+            trace.terminal_state
+        ));
+    }
+    Ok((canonical, trace))
+}
+
+fn reviewer_identity() -> PromotedWorkflowIdentity {
+    PromotedWorkflowIdentity {
+        id: "promoted-workflow-001".to_string(),
+        name: "Promoted Test Workflow".to_string(),
+        version: "1.0.0".to_string(),
+        owner: Owner {
+            team: "traverse-core".to_string(),
+            contact: "enrico.piovesan10@gmail.com".to_string(),
+        },
+        lifecycle: Lifecycle::Active,
+        summary: "A promoted workflow reviewed and published from a proposal.".to_string(),
+        tags: vec!["promoted".to_string()],
+    }
+}
+
+#[test]
+fn export_then_promote_then_discover_end_to_end() -> Result<(), String> {
+    let manifest = manifest_declaring(&["test.a", "test.b"]);
+    let registry = two_capability_registry();
+    let (canonical, trace) = run_to_success(linear_proposal(), &manifest, &registry)?;
+    let resolved = validate_proposal_against_host_state(&canonical, &manifest, &registry)
+        .map_err(|e| format!("{e:?}"))?;
+
+    let candidate =
+        export_workflow_candidate(&canonical, &trace, &resolved).map_err(|e| format!("{e:?}"))?;
+    assert!(candidate.unconfirmed_mappings.is_empty());
+    assert_eq!(candidate.start_node, "a");
+    assert_eq!(candidate.terminal_nodes, vec!["b".to_string()]);
+    assert!(
+        candidate
+            .excluded_fields
+            .iter()
+            .any(|f| f == "initial_input")
+    );
+
+    let definition = finalize_candidate_into_definition(&candidate, reviewer_identity());
+
+    let mut workflow_registry = WorkflowRegistry::new();
+    let outcome = workflow_registry
+        .register(
+            &registry,
+            WorkflowRegistration {
+                scope: RegistryScope::Public,
+                definition,
+                workflow_path: "workflows/promoted-workflow-001.json".to_string(),
+                registered_at: "2026-08-23T00:00:00Z".to_string(),
+                validator_version: "0.1.0".to_string(),
+            },
+        )
+        .map_err(|e| format!("registration must succeed: {e:?}"))?;
+    assert_eq!(outcome.record.id, "promoted-workflow-001");
+
+    let resolved_workflow = workflow_registry
+        .find_exact(LookupScope::PublicOnly, "promoted-workflow-001", "1.0.0")
+        .ok_or_else(|| "promoted workflow must be discoverable by exact lookup".to_string())?;
+    assert_eq!(resolved_workflow.definition.nodes.len(), 2);
+
+    let discovered = workflow_registry.discover(LookupScope::PublicOnly);
+    assert!(
+        discovered
+            .iter()
+            .any(|entry| entry.id == "promoted-workflow-001"),
+        "promoted workflow must appear in discovery listing"
+    );
+    Ok(())
+}
+
+#[test]
+fn export_rejects_a_proposal_that_did_not_succeed() -> Result<(), String> {
+    let manifest = manifest_declaring(&["test.a", "test.b"]);
+    let registry = two_capability_registry();
+    let canonical = canonicalize_proposal(linear_proposal(), &ProposalLimits::default())
+        .map_err(|e| format!("{e:?}"))?;
+    let resolved = validate_proposal_against_host_state(&canonical, &manifest, &registry)
+        .map_err(|e| format!("{e:?}"))?;
+
+    let runtime = Runtime::new(registry, FailingExecutor)
+        .with_security_config(RuntimeSecurityConfig::development());
+    let digest = proposal_digest(&canonical.proposal);
+    let trace = execute_proposal(
+        &runtime,
+        &canonical,
+        &resolved,
+        AuthorizationSummary {
+            automatic: true,
+            approval_token_id: None,
+        },
+        &digest,
+        "snapshot-digest",
+    );
+    assert_eq!(trace.terminal_state, ProposalTerminalState::Failed);
+
+    let result = export_workflow_candidate(&canonical, &trace, &resolved);
+    assert!(result.is_err());
+    Ok(())
+}
+
+struct FailingExecutor;
+
+impl LocalExecutor for FailingExecutor {
+    fn execute(
+        &self,
+        _capability: &traverse_registry::ResolvedCapability,
+        _input: &serde_json::Value,
+    ) -> Result<LocalExecutionOutput, LocalExecutionFailure> {
+        Err(LocalExecutionFailure {
+            code: traverse_runtime::LocalExecutionFailureCode::ExecutionFailed,
+            message: "always fails".to_string(),
+        })
+    }
+}
+
+#[test]
+fn export_flags_a_renamed_mapping_as_unconfirmed() -> Result<(), String> {
+    let manifest = manifest_declaring(&["test.a", "test.b"]);
+    let registry = two_capability_registry();
+    let (canonical, trace) = run_to_success(linear_proposal_with_a_rename(), &manifest, &registry)?;
+    let resolved = validate_proposal_against_host_state(&canonical, &manifest, &registry)
+        .map_err(|e| format!("{e:?}"))?;
+
+    let candidate =
+        export_workflow_candidate(&canonical, &trace, &resolved).map_err(|e| format!("{e:?}"))?;
+    assert_eq!(candidate.unconfirmed_mappings.len(), 1);
+    assert_eq!(candidate.unconfirmed_mappings[0].source_path, "/draft_id");
+    // Since the mapping did not reduce, neither node gets a state-key wire.
+    assert!(candidate.nodes[0].to_workflow_state.is_empty());
+    assert!(candidate.nodes[1].from_workflow_input.is_empty());
+    Ok(())
+}
+
+#[test]
+fn export_preserves_each_nodes_declared_risk_for_review() -> Result<(), String> {
+    let manifest = manifest_declaring(&["test.a", "test.b"]);
+    let registry = two_capability_registry();
+    let (canonical, trace) = run_to_success(linear_proposal(), &manifest, &registry)?;
+    let resolved = validate_proposal_against_host_state(&canonical, &manifest, &registry)
+        .map_err(|e| format!("{e:?}"))?;
+
+    let candidate =
+        export_workflow_candidate(&canonical, &trace, &resolved).map_err(|e| format!("{e:?}"))?;
+    for candidate_node in &candidate.nodes {
+        let risk = candidate_node
+            .risk
+            .as_ref()
+            .ok_or_else(|| format!("node '{}' must have resolved risk", candidate_node.node_id))?;
+        assert_eq!(risk.effect_class, EffectClass::PureRead);
+    }
+    Ok(())
+}
+
+#[test]
+fn a_branching_proposals_candidate_is_honestly_unregistrable() -> Result<(), String> {
+    // Documents the real, existing WorkflowDefinition v0.1 constraint (at
+    // most one direct outgoing edge per node) rather than hiding it: this
+    // export is not "buggy," the *target format* cannot yet express fan-out.
+    let manifest = manifest_declaring(&["test.a", "test.b"]);
+    let registry = two_capability_registry();
+    let (canonical, trace) = run_to_success(diamond_proposal(), &manifest, &registry)?;
+    let resolved = validate_proposal_against_host_state(&canonical, &manifest, &registry)
+        .map_err(|e| format!("{e:?}"))?;
+
+    let candidate =
+        export_workflow_candidate(&canonical, &trace, &resolved).map_err(|e| format!("{e:?}"))?;
+    assert_eq!(candidate.edges.len(), 2); // a->b and a->c, honestly preserved
+
+    let definition = finalize_candidate_into_definition(&candidate, reviewer_identity());
+    let mut workflow_registry = WorkflowRegistry::new();
+    let result = workflow_registry.register(
+        &registry,
+        WorkflowRegistration {
+            scope: RegistryScope::Public,
+            definition,
+            workflow_path: "workflows/branching.json".to_string(),
+            registered_at: "2026-08-23T00:00:00Z".to_string(),
+            validator_version: "0.1.0".to_string(),
+        },
+    );
+    assert!(
+        result.is_err(),
+        "a branching candidate must be rejected by the existing single-outgoing-edge constraint"
+    );
+    Ok(())
+}

--- a/docs/governed-workflow-promotion.md
+++ b/docs/governed-workflow-promotion.md
@@ -1,0 +1,134 @@
+# Governed Workflow Promotion (P4)
+
+Governed by spec [`112-governed-workflow-promotion`](../specs/112-governed-workflow-promotion/spec.md)
+and [ADR-0042](adr/0042-phased-dynamic-orchestration-evolution.md). Tracks
+issue `#1094`.
+
+P4 defines the non-mutating export and human-reviewed promotion path from a
+completed [P1 runtime workflow proposal](workflow-proposal-lifecycle.md) to a
+reusable, versioned workflow. It adds no new registration mechanism: export
+produces a plain candidate value, and promotion still goes through the
+existing `traverse_registry::WorkflowRegistry::register` /
+`traverse-cli workflow register` path unchanged — exactly as for any
+hand-authored workflow.
+
+## Where the code lives
+
+Spec 112 governs `crates/traverse-registry/`, `crates/traverse-cli/`, and
+`crates/traverse-mcp/` — notably not `traverse-runtime` or
+`traverse-contracts`. `traverse-registry` is an external, independently
+versioned crate (spec `051-registry-extraction`); this PR's actionable
+surface is entirely new code in `traverse-mcp::tools::workflow_promotion`,
+consuming `traverse_registry`'s existing `WorkflowDefinition`/
+`WorkflowRegistry` types via its public API.
+
+## Export (FR-001): a candidate, never a mutation
+
+`export_workflow_candidate(canonical, trace, resolved_nodes)` builds a
+`WorkflowCandidateArtifact` from a proposal whose trace reached
+`Succeeded` — acceptance scenario 1 requires exporting a *completed*
+proposal, since an incomplete or failed execution has no proven reusable
+shape to offer a reviewer. The function is pure: it never touches a
+registry or app manifest, and returns a plain, serializable value.
+
+The candidate carries:
+
+- `source_proposal_id` / `source_proposal_digest` / `source_snapshot_digest`
+  — provenance back to the exact proposal and pinned snapshot that produced
+  it (FR-001).
+- `nodes` — each with its `capability_id`/`capability_version` and resolved
+  `risk: RiskMetadata` (FR-002a: preserve reviewed effect, determinism,
+  data-flow, and reliability declarations for the reviewer to see).
+- `edges` — copied exactly from the proposal, including any fan-out (see
+  below).
+- `unconfirmed_mappings` — mappings the export could not reduce cleanly
+  (see next section), for the reviewer to resolve by hand.
+- `excluded_fields` — a fixed audit list (`initial_input`,
+  `authorization.approval_token_id`) naming what was intentionally never
+  carried into the candidate, mirroring
+  `ApplicationEffectiveConfig::redacted_secret_keys`'s convention.
+
+### Why nothing needs active secret-scanning
+
+FR-002a requires the candidate never carry raw inputs, approval tokens,
+private bindings, prompts, or secrets. Rather than scanning for and
+stripping such content at export time, the candidate is built exclusively
+from fields already proven secret-free by construction: `ProposalTrace` is
+itself documented as "a bounded, redacted, immutable projection... no raw
+node input/output payloads" (spec 109 FR-009), and the only proposal field
+that could carry arbitrary caller-supplied content —
+`WorkflowProposal.initial_input` — is simply never read by the exporter.
+This is a structural guarantee, not a runtime check.
+
+## The mapping model gap (and why it's surfaced, not hidden)
+
+A proposal mapping is an arbitrary JSON-Pointer-to-JSON-Pointer wire between
+two exact node fields. `WorkflowDefinition`'s existing model —
+`WorkflowNodeInput.from_workflow_input` / `WorkflowNodeOutput.
+to_workflow_state` — instead shares data through named top-level keys in an
+accumulated, workflow-wide state bag: a downstream node's
+`from_workflow_input` can read any key an upstream node's
+`to_workflow_state` (or the workflow's own `inputs`) already published,
+matched purely by key name, with no rename step.
+
+A mapping whose source and target JSON-Pointer paths share the same final
+segment (`/value` → `/value`, or `/a/value` → `/b/value`) translates
+cleanly to a shared state key. Anything else — a field rename, or two
+nested paths with different leaf names — cannot be expressed by this model
+without guessing, so it is listed in `unconfirmed_mappings` instead: no
+state-key wiring is emitted for it, and the reviewer decides how (or
+whether) to rewire it by hand. This mirrors spec 113's
+`mapping_unconfirmed` convention for the same "don't guess, flag it"
+reason.
+
+## The fan-out gap (and why it's surfaced, not hidden)
+
+`WorkflowDefinition`'s own registration validation already rejects more
+than one direct outgoing edge from any node with a `DuplicateItem` error —
+a real, existing v0.1 constraint this feature does not relax or work
+around. P1/P2 proposals fully support branching DAGs; `export_workflow_
+candidate` copies a proposal's edges exactly, so a branching proposal's
+candidate correctly fails registration if promoted as-is. This is not a bug
+in the export — it is an honest reflection of what the target format can
+currently express. Only proposals whose nodes each have at most one
+outgoing edge can currently become a registrable workflow. A dedicated test
+(`a_branching_proposals_candidate_is_honestly_unregistrable`) proves this
+is surfaced, not silently swallowed.
+
+## Promotion (FR-002, FR-003): identity is a review decision, not inferred
+
+`finalize_candidate_into_definition(candidate, identity)` assembles a
+`WorkflowDefinition` from the candidate plus a `PromotedWorkflowIdentity`
+(`id`, `name`, `version`, `owner`, `lifecycle`, `summary`, `tags`) — fields
+a human reviewer decides at promotion time, never inferred from the source
+proposal (FR-003: "a promoted workflow has its own immutable identity; its
+source proposal does not confer ongoing execution authority"). This
+function performs no registration itself; the caller still submits the
+resulting `WorkflowDefinition` through the unchanged
+`WorkflowRegistry::register` / `traverse-cli workflow register` path, which
+enforces the same canonical validation and per-`(scope, id, version)`
+immutability as any hand-authored workflow (FR-002).
+
+## Yank, rollback, deprecation (FR-004)
+
+Reused entirely: a promoted workflow's `Lifecycle` (`Draft` → `Active` →
+`Deprecated` → `Retired` → `Archived`) is the only lifecycle mechanism
+`WorkflowRegistry` has, for hand-authored or promoted workflows alike. This
+feature introduces no separate yank/rollback verb.
+
+## End-to-end proof
+
+`workflow_promotion_tests.rs`'s
+`export_then_promote_then_discover_end_to_end` test proves the full spec
+112 Definition-of-Done chain against the real
+`traverse_registry::WorkflowRegistry` (not a mock): export a successfully
+completed linear proposal's trace, finalize it with a reviewer identity,
+register it, then confirm it resolves via `find_exact` and appears in
+`discover`.
+
+## Non-goals
+
+Matches spec 112's own "Out of scope": direct runtime publication,
+automatic promotion, or bypassing human review. Nothing in this feature
+calls `WorkflowRegistry::register` itself, opens a PR, or grants a proposal
+any ongoing execution authority.


### PR DESCRIPTION
## Summary

Implements #1094 per spec `112-governed-workflow-promotion` FR-001 through
FR-004: the non-mutating export and human-reviewed promotion path from a
completed P1 runtime workflow proposal to a reusable, versioned workflow.
No new registration mechanism is introduced — promotion still goes through
the existing, unchanged `traverse_registry::WorkflowRegistry::register` /
`traverse-cli workflow register` path.

- **`traverse-mcp::tools::workflow_promotion`**: `export_workflow_candidate`
  builds a plain, serializable `WorkflowCandidateArtifact` from a proposal
  whose trace reached `Succeeded` (FR-001) — never touches a registry or
  app manifest. It carries proposal/snapshot digest provenance, each
  node's resolved `RiskMetadata` for reviewer visibility (FR-002a), and
  best-effort reduces mappings whose source/target JSON-Pointer paths
  share a leaf segment into `WorkflowNode`'s `from_workflow_input`/
  `to_workflow_state` shared-state model — anything else (a rename, or a
  nested path with a different leaf name) is listed in
  `unconfirmed_mappings` for the reviewer to resolve rather than guessed
  at. It never reads `initial_input` or approval-token material, recording
  both in a fixed `excluded_fields` audit list.
- `finalize_candidate_into_definition` assembles a registrable
  `WorkflowDefinition` from the candidate plus a `PromotedWorkflowIdentity`
  a human reviewer supplies (`id`, `name`, `version`, `owner`, `lifecycle`,
  `summary`, `tags`) — never inferred from the source proposal (FR-003).
  Performs no registration itself.
- Two real gaps in the existing `WorkflowDefinition` v0.1 format are
  surfaced honestly rather than worked around: it supports only a single
  direct outgoing edge per node (a branching proposal's candidate
  correctly fails registration — proven by
  `a_branching_proposals_candidate_is_honestly_unregistrable`), and its
  input/output model has no rename step (proven by
  `export_flags_a_renamed_mapping_as_unconfirmed`).
- Yank/rollback/deprecation (FR-004) needed no new code: a promoted
  workflow's `Lifecycle` is the same, only lifecycle mechanism
  `WorkflowRegistry` already has for hand-authored workflows.
- `workflow_promotion_tests.rs`'s
  `export_then_promote_then_discover_end_to_end` proves the full spec 112
  Definition-of-Done chain against the real
  `traverse_registry::WorkflowRegistry` (not a mock): export → finalize
  with a reviewer identity → register → confirm discovery via
  `find_exact` and `discover`.
- `docs/governed-workflow-promotion.md` documents the design, both
  surfaced format gaps, and why no active secret-scanning is needed (the
  candidate is built exclusively from fields already proven secret-free by
  construction — `ProposalTrace` and everything but `initial_input`).

Closes #1094

## Governing Spec

- `112-governed-workflow-promotion`
- `070-runtime-event-sink-boundary`

## Project Item

Project 1 item for #1094: `PVTI_lADOEbiBt84Bbyp1zg3fR9I` (In Progress).

## Validation

- `cargo test --workspace` — all suites pass, including 5 new tests for
  export/finalize/promotion covering success, rejection of a
  non-succeeded trace, mapping-rename detection, risk preservation, and
  the branching-format-gap rejection.
- `cargo clippy --workspace --all-targets` — clean.
- `cargo fmt --check` — clean.
- `bash scripts/ci/coverage_gate.sh` — passes: `traverse-mcp` at 99.13%
  (> 98% threshold); `traverse-contracts`/`traverse-runtime` unaffected
  and still at 100.00% (this PR touches neither crate).
- `bash scripts/ci/spec_alignment_check.sh` — clean against this PR body.

## Non-goals

Matches spec 112's own "Out of scope": direct runtime publication,
automatic promotion, or bypassing human review. Nothing in this PR calls
`WorkflowRegistry::register` itself, opens a PR against the registry, or
grants a proposal any ongoing execution authority.
