### PR TITLE
docs(governance): planner chains on schema-shape compatibility, not consumes/emits (Decision 62)

### DIFF
--- a/docs/adr/0043-declarative-workflow-planning-boundary.md
+++ b/docs/adr/0043-declarative-workflow-planning-boundary.md
@@ -1,8 +1,8 @@
 # ADR-0043: Plan Workflows as a Deterministic, Data-Dependency-Only Reader, Never an Auto-Chooser
 
-- Status: Accepted
-- Governing specs: `108-governed-runtime-workflow-composition`, `113-declarative-workflow-planning`
-- Related issues: #865, #1089, #1098
+- Status: Accepted (amended 2026-08-23 for Decision 62)
+- Governing specs: `108-governed-runtime-workflow-composition`, `113-declarative-workflow-planning` (v0.2.0)
+- Related issues: #865, #1089, #1098; registry #305
 
 ## Context
 
@@ -15,36 +15,61 @@ plausible workflow from live registry data required a client-side
 namespace/verb-name heuristic — a guess, not something grounded in the
 contracts themselves.
 
+Implementing this spec's real unblock condition (registry `#305`'s
+backfill) surfaced that `consumes`/`emits` (`EventReference`) is not the
+right signal for most capability pairs: registry's own governed FR-020
+capability inventory classifies 45 of 46 unique published capability IDs —
+including every capability in an already-published, human-reviewed
+`workflows/*.json` chain — as `no-event-required`, synchronous,
+direct-return capabilities with no asynchronous domain fact to broadcast.
+`consumes`/`emits` has consistently meant a real, governed, decoupled-
+subscriber event elsewhere in that repo; "A's output feeds B's input" is
+the *workflow-composition* concept, which `workflows/*.json` already models
+via explicit node edges and field mappings, not the event concept.
+
 ## Decision
 
-The planner reads only declared `consumes`/`emits` contract metadata; it
-never infers a chain from capability names, namespaces, or any other
-signal, and never operates on a capability with no declared linkage. When
-more than one capability could satisfy a need, the planner enumerates every
-resulting complete candidate plan rather than choosing one — ambiguity
-resolution is a caller/reviewer decision, never a runtime one, consistent
-with ADR-0041 treating the planner-adjacent surface as untrusted and this
-runtime's everywhere-else stance against silent inference. Search is
-bounded by fixed, small, non-configurable limits in v1. Field-level
-JSON-path mappings are proposed but always marked unconfirmed until
-reviewed — the planner produces a draft, not an authority. The planner is a
-new phase (P0) of the `108` north star rather than a standalone spec, since
-`109` already named this exact gap as its own boundary.
+The planner derives candidate chains from structural
+`inputs.schema`/`outputs.schema` compatibility — every property named in a
+candidate consumer's `inputs.schema.required` MUST exist in a candidate
+producer's `outputs.schema.properties` with a matching JSON type. This is
+not a new computation: the planner already derives this same structural
+relationship for its per-edge field-mapping step. A capability that
+separately declares real `consumes`/`emits` linkage to a governed event MAY
+also be selected on that basis — the two signals are independent extension
+points, not a replacement of one by the other. The planner never infers a
+chain from capability names, namespaces, or any other signal, and never
+operates on a capability pair with no structural match. When more than one
+capability could satisfy a need, the planner enumerates every resulting
+complete candidate plan rather than choosing one — ambiguity resolution is
+a caller/reviewer decision, never a runtime one, consistent with ADR-0041
+treating the planner-adjacent surface as untrusted and this runtime's
+everywhere-else stance against silent inference. Search is bounded by
+fixed, small, non-configurable limits in v1. Field-level JSON-path mappings
+are proposed but always marked unconfirmed until reviewed — the planner
+produces a draft, not an authority. The planner is a new phase (P0) of the
+`108` north star rather than a standalone spec, since `109` already named
+this exact gap as its own boundary.
 
 ## Consequences
 
-A planner call against today's registry (per registry#305: `consumes`/
-`emits` populated on roughly 1 of 116 published capability versions) will
-mostly return zero candidates. That is treated as correct, honest behavior
-— not a bug to route around with a heuristic — and makes this spec's real
-unblock condition explicit: registry#305's backfill, not more runtime code.
-`traverse#1098`'s original framing (which implied the review/execution/
-trust architecture was still undecided) is superseded by this narrower
-reading; `108`–`112` already own that.
+A planner call against today's registry finds candidates wherever a
+capability's `outputs.schema` structurally satisfies another's
+`inputs.schema.required` — which, unlike `consumes`/`emits`, is already
+true for many already-published capability pairs (e.g. the `doc-approval`
+and `traverse-starter` reference chains) without requiring any registry-side
+backfill. Registry `#305` is resolved by this redirect, not by a backfill;
+`traverse#1098` is unblocked by this spec amendment rather than by
+registry-side work. A pair whose schemas happen to overlap without being
+genuinely composable (e.g. two unrelated capabilities that both take
+`{id: string}`) can still surface as a false-positive candidate — this is
+accepted, not solved here, because FR-005/FR-006's `mapping_unconfirmed`
+flag and mandatory human review before any submission already gate exactly
+this risk; nothing a planner proposes ever executes unreviewed.
 
 ## Alternatives considered
 
-- Fall back to a namespace/verb heuristic when `consumes`/`emits` is empty
+- Fall back to a namespace/verb heuristic when there is no structural match
   (matching the discover.html demo): rejected — mixing a real, data-grounded
   candidate with a guessed one on the same governed proposal surface blurs
   exactly the honesty line this org has held elsewhere (registry
@@ -55,3 +80,17 @@ reading; `108`–`112` already own that.
 - Accept natural-language goals and interpret them in-runtime: rejected —
   reintroduces exactly the hosted-model dependency `109` FR-001 and
   ADR-0041 explicitly excluded.
+- Loosen registry's FR-020 inventory criterion instead, keep `consumes`/
+  `emits` as the sole signal: rejected — would require ~26 capabilities to
+  carry full governed-event ceremony (privacy field classification,
+  retention policy, CloudEvents mapping) for relationships that were never
+  really asynchronous events, and blurs a distinction registry's decision
+  57 deliberately drew.
+- Exact full-schema match (not just required-property overlap): rejected —
+  independently-authored capabilities' schemas are rarely exactly equal or
+  superset even when genuinely composable; would find very few real chains.
+- A new named/tagged data-shape identifier capabilities opt into: deferred,
+  not rejected — avoids both false positives and event ceremony, but is
+  itself a new schema convention needing its own spec and per-capability
+  adoption; worth reconsidering if structural matching's false-positive
+  rate proves too high in practice.

--- a/docs/decision-log.md
+++ b/docs/decision-log.md
@@ -2357,3 +2357,98 @@ ADR-0044 recorded. `traverse#1100` rescoped from an execution-ceremony
 implementation gap to an integration/validation ticket: confirm the
 already-approved browser-hosted MCP execute path works end-to-end; `needs-spec`
 removed since no new governing document is required.
+
+## Decision 62: Declarative Workflow Planner Chains on Schema-Shape Compatibility, Not `consumes`/`emits`
+
+- **Date**: 2026-08-23
+- **Status**: Accepted; Spec `113` amended to v0.2.0, ADR-0043 amended, both approved same-day
+- **Governing spec**: `113-declarative-workflow-planning` (v0.2.0); ADR-0043 (amended)
+- **Related issues**: `traverse#1098`; registry `#305`
+- **Origin**: A registry-ops session working registry `#305` (Decision 61's reopened, scoped backfill ask) found that registry's own already-governed FR-020 capability inventory directly contradicts the premise that a real `consumes`/`emits` backfill exists to do, and raised it as a live, owner-participated brainstorm spanning both repos rather than either fabricating the backfill or leaving `#1098` blocked indefinitely.
+
+### Context
+
+Decision 59 / spec `113` FR-002 required the planner to chain on declared
+`consumes`/`emits` (`EventReference`) linkage. Decision 61 reopened
+registry `#305` to get that data populated for the 98 in-source
+capabilities. Before attempting the backfill, registry's own
+`contracts/governance/ecca-capability-inventory.json` (registry decision
+57, CI-enforced) was checked directly rather than assumed: it classifies
+45 of registry's 46 unique published capability IDs as `no-event-required`
+— reviewed, merged content stating they are synchronous, direct-return
+capabilities with no asynchronous domain fact to broadcast. This holds even
+for the five capabilities in two already-published, human-reviewed
+`workflows/*.json` chains (`doc-approval.analyze` -> `doc-approval.recommend`;
+`traverse-starter.validate` -> `.process` -> `.summarize`) — real,
+structurally-composable data dependencies that are nonetheless not
+asynchronous events. Registry's own `graph.rs` composition-graph builder
+confirmed this isn't just a labeling question: a declared `emits`/`consumes`
+`EventReference` only produces a graph edge when it resolves against a real,
+registered `events/**/product.json`; an unbacked reference is functionally
+inert there, not a working shortcut.
+
+### Decision
+
+Change the planner's chain-discovery signal (spec `113` FR-002/FR-003) from
+declared `consumes`/`emits` linkage to structural `inputs.schema`/
+`outputs.schema` compatibility: a candidate producer's `outputs.schema`
+structurally satisfies a candidate consumer's `inputs.schema` when every
+property named in the consumer's `inputs.schema.required` exists in the
+producer's `outputs.schema.properties` with a matching JSON type. This is
+not new computation — the planner already derives this exact relationship
+for its FR-005 field-mapping step. A capability that separately declares
+real `consumes`/`emits` linkage to a governed event may still be selected
+on that basis too; the two signals are independent, not a replacement of
+one by the other. `consumes`/`emits` keeps meaning what it means everywhere
+else in the org (a real, governed, decoupled-subscriber event); nothing
+about registry's FR-020 classification needed to change.
+
+False-positive risk (two unrelated capabilities whose schemas happen to
+overlap, e.g. both taking `{id: string}`) is accepted rather than solved
+here: FR-005/FR-006's `mapping_unconfirmed` flag and mandatory human review
+before any submission already gate exactly this risk, and nothing a planner
+proposes ever executes unreviewed.
+
+Both the spec and ADR amendments are approved on creation, per this org's
+existing precedent that a decision tracing directly to a live,
+owner-participated brainstorm — not an agent-invented draft — already has
+its sign-off.
+
+### Alternatives Considered
+
+- Loosen registry's FR-020 inventory criterion instead, keep `consumes`/
+  `emits` as the sole signal — rejected; would require ~26 capabilities to
+  carry full governed-event ceremony (privacy field classification,
+  retention policy, CloudEvents mapping, spec `534`'s full descriptor) for
+  relationships that were never really asynchronous events, and blurs the
+  event-vs-workflow-composition distinction registry's decision 57
+  deliberately drew.
+- Backfill `consumes`/`emits` anyway, treating a bare `EventReference` with
+  no matching `events/**/product.json` as sufficient — rejected; produces
+  zero graph edges in registry's own tooling (functionally inert) and
+  repeats the overclaiming pattern registry decision-log entries 61/64
+  exist to prevent.
+- Exact full-schema match instead of required-property overlap — rejected;
+  independently-authored capabilities' schemas are rarely exactly equal or
+  a strict superset even when genuinely composable, so this would find very
+  few real chains.
+- A new named/tagged data-shape identifier capabilities opt into (e.g. an
+  `x-data-shape` tag) — deferred, not rejected; avoids both false positives
+  and event ceremony, but is itself a new schema convention needing its own
+  spec and per-capability adoption. Worth reconsidering if structural
+  matching's false-positive rate proves too high in practice.
+- Do nothing, accept the planner finds almost no candidates until genuinely
+  event-driven capabilities grow organically — rejected; leaves `#1098`
+  effectively blocked indefinitely and doesn't address why registry `#305`
+  was reopened in the first place.
+
+### Outcome
+
+Spec `113` amended to v0.2.0 (FR-002/FR-003, Purpose, and Acceptance
+scenarios 1-3 updated; no other requirement changed). ADR-0043 amended in
+place (status line notes the amendment; Decision/Consequences/Alternatives
+rewritten to the new signal). Registry `#305` closed as resolved-by-redirect
+rather than by backfill (registry decision-log entry 68, cross-referencing
+this entry). `traverse#1098`'s `blocked by registry#305` relationship is
+removed — it is now unblocked by this spec amendment landing, not by any
+registry-side work.

--- a/specs/113-declarative-workflow-planning/spec.md
+++ b/specs/113-declarative-workflow-planning/spec.md
@@ -2,14 +2,44 @@
 
 **Status**: Approved
 **Canonical governing ID**: `113-declarative-workflow-planning`
-**Version**: 0.1.0
+**Version**: 0.2.0
 **Implements phase**: P0 of `108-governed-runtime-workflow-composition` (precedes the P1 proposal-submission surface)
 **Input**: Decision 59 (`docs/decision-log.md`); traverse #1098; registry #305.
 
+**Amendment (2026-08-23, version 0.1.0 -> 0.2.0, approved 2026-08-23)**: implementing this
+spec's real unblock condition (registry `#305`'s backfill) surfaced a direct conflict
+with registry's own already-governed FR-020 capability inventory
+(`contracts/governance/ecca-capability-inventory.json`, registry decision-log entry 57):
+45 of registry's 46 unique published capability IDs — including every capability
+involved in an already-published, human-reviewed `workflows/*.json` chain — are
+classified `no-event-required`, with reviewed evidence that they are synchronous,
+direct-return capabilities with no asynchronous domain fact to broadcast. FR-002's
+original text asked the planner to chain on `consumes`/`emits` (`EventReference`)
+linkage specifically, which — per registry's own `graph.rs` composition-graph builder
+and its FR-020 classification criterion — has consistently meant a real, governed,
+decoupled-subscriber domain event elsewhere in that repo, not "capability A's output
+happens to feed capability B's input" (which `workflows/*.json` already models
+separately, via explicit node edges and field-level mappings, with no `EventReference`
+involved). Backfilling `consumes`/`emits` for capabilities registry's own governance
+already, deliberately, classified as not needing an event would have repeated the
+overclaiming pattern registry decision-log entries 61/64 exist to prevent.
+
+Resolved via a live, owner-participated brainstorm (2026-08-23, cross-posted to
+registry decision-log entry 68): the planner's chain-discovery signal changes from
+declared `consumes`/`emits` linkage to structural `inputs.schema`/`outputs.schema`
+compatibility — a signal the planner already computes for its per-edge field-mapping
+step (FR-005), not a new one. This keeps `consumes`/`emits` meaning what it means
+everywhere else in the org (a real governed async event) and removes this spec's
+dependency on registry backfilling anything. FR-002 and FR-003 below reflect the
+amended signal; Acceptance scenarios 1-3 updated to match. No other requirement
+changed. Approved on creation per this org's existing precedent for a decision that
+traces directly to a live, owner-participated brainstorm rather than an
+agent-invented draft.
+
 ## Purpose
 
-Define a deterministic planner that, given a structured target and the
-declared `consumes`/`emits` metadata of published capabilities, derives one
+Define a deterministic planner that, given a structured target and the published
+`inputs.schema`/`outputs.schema` of published capabilities, derives one
 or more complete candidate workflow proposals — each already shaped to
 satisfy `109-runtime-workflow-proposals` FR-002/FR-004/FR-011 (explicit
 capability IDs/versions, explicit edges, explicit field-level JSON-path
@@ -25,13 +55,18 @@ remain entirely owned by `109`–`112`.
   It MUST NOT accept or interpret open-ended natural-language goals, and
   MUST NOT require or embed a hosted language model, matching FR-001 of
   spec `109`.
-- **FR-002**: The planner MUST derive candidate chains only from capabilities
-  whose contract declares non-empty `consumes`/`emits` linkage to the target
-  and to each other. A capability with no declared linkage MUST NOT be
-  selected, even if its name or namespace suggests a plausible fit.
-- **FR-003**: When more than one published capability's declared `emits`
-  could satisfy the same downstream `consumes` need, the planner MUST NOT
-  pick one automatically. It MUST enumerate each resulting complete
+- **FR-002**: The planner MUST derive candidate chains only from capability pairs
+  where the candidate producer's `outputs.schema` structurally satisfies the
+  candidate consumer's `inputs.schema` — every property named in the consumer's
+  `inputs.schema.required` MUST exist in the producer's `outputs.schema.properties`
+  with a matching JSON type. A capability pair with no such structural match MUST
+  NOT be selected, even if its name or namespace suggests a plausible fit. A
+  capability whose contract separately declares real `consumes`/`emits`
+  (`EventReference`) linkage to a governed event MAY also be selected on that
+  basis — the two signals are independent, and a match on either is sufficient.
+- **FR-003**: When more than one published capability's `outputs.schema` could
+  structurally satisfy the same downstream `inputs.schema` need, the planner MUST
+  NOT pick one automatically. It MUST enumerate each resulting complete
   candidate plan separately and return the full set to the caller.
 - **FR-004**: The planner MUST bound its search: at most 5 complete
   candidate plans, each at most 8 nodes deep, per planning call. A call
@@ -58,15 +93,18 @@ remain entirely owned by `109`–`112`.
 
 ## Acceptance scenarios
 
-1. A caller requests a plan targeting an event only one published capability
-   chain can produce; the planner returns exactly one candidate plan with
-   field mappings flagged `mapping_unconfirmed`.
-2. A caller requests a plan where two published capabilities both emit a
-   compatible event for the same downstream need; the planner returns two
-   complete candidate plans, one per choice, rather than picking one.
-3. A caller requests a plan for a target no published capability declares
-   `emits` linkage to; the planner returns zero candidates rather than
-   falling back to a name/namespace guess.
+1. A caller requests a plan targeting a capability whose `inputs.schema` only
+   one other published capability's `outputs.schema` structurally satisfies;
+   the planner returns exactly one candidate plan with field mappings flagged
+   `mapping_unconfirmed`.
+2. A caller requests a plan where two published capabilities' `outputs.schema`
+   both structurally satisfy the same downstream `inputs.schema` need; the
+   planner returns two complete candidate plans, one per choice, rather than
+   picking one.
+3. A caller requests a plan for a target no published capability's
+   `outputs.schema` structurally satisfies (and that declares no real
+   `consumes`/`emits` linkage either); the planner returns zero candidates
+   rather than falling back to a name/namespace guess.
 4. A candidate plan's field mapping is reviewed and corrected by a human
    before submission; the corrected mapping, not the planner's original
    guess, is what gets submitted to and validated by the P1 surface.

--- a/specs/governance/approved-specs.json
+++ b/specs/governance/approved-specs.json
@@ -1488,7 +1488,7 @@
     },
     {
       "id": "113-declarative-workflow-planning",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "status": "approved",
       "immutable": true,
       "path": "specs/113-declarative-workflow-planning/spec.md",


### PR DESCRIPTION
## Summary

Registry's own governed FR-020 capability inventory (`contracts/governance/ecca-capability-inventory.json`, registry decision 57) classifies 45 of 46 unique published capability IDs as `no-event-required` — synchronous, direct-return capabilities with no asynchronous domain fact to broadcast — including every capability in an already-published, human-reviewed `workflows/*.json` chain. `consumes`/`emits` (`EventReference`) has consistently meant a real, governed async event elsewhere in that repo, not "A's output feeds B's input." Backfilling `consumes`/`emits` for capabilities registry's own governance already, deliberately, classified as not needing an event would repeat the overclaiming pattern registry decision-log entries 61/64 exist to prevent — and registry's own `graph.rs` composition-graph builder only produces an edge when a declared `EventReference` resolves against a real, registered event, so a bare backfill wouldn't even be functionally useful.

Resolved via a live, owner-participated brainstorm spanning both repos.

## Changes

- `specs/113-declarative-workflow-planning/spec.md`: amended 0.1.0 → 0.2.0. FR-002/FR-003 now chain on structural `inputs.schema`/`outputs.schema` compatibility (producer's output structurally satisfies consumer's required input properties + types) instead of declared `consumes`/`emits` linkage — a signal the planner already computes for its FR-005 field-mapping step, not a new one. A capability that separately declares real `consumes`/`emits` to a governed event may still be selected on that basis too; the two signals are independent. Acceptance scenarios 1–3 updated to match.
- `docs/adr/0043-declarative-workflow-planning-boundary.md`: amended to match — Decision/Consequences/Alternatives rewritten for the new signal, status line notes the amendment.
- `docs/decision-log.md`: Decision 62 records the full reasoning, cross-referencing registry decision-log entry 68 (companion registry-side PR).
- `specs/governance/approved-specs.json`: spec 113's `version` bumped 1.0.0 → 1.1.0, matching spec 102's existing amendment precedent (spec.md's own header uses its own 0.x drafting scheme, independent of this file's edition number — verified against 102/108/109/110/111/112, not assumed).
- `traverse#1098` (companion, not in this diff): `Blocked by: registry#305` removed, DoD reworded for the new FR-002 signal.

## Why no implementation in this PR

This PR is the spec/ADR/decision-log amendment only — the actual planner implementation is `#1098`'s own scope, now unblocked by this landing rather than by any registry-side backfill.

## Project Item

traverse#1098 (companion issue, updated separately: `Blocked by: registry#305` removed, DoD reworded for the new FR-002 signal)

## Governing Spec

- 113-declarative-workflow-planning
- 108-governed-runtime-workflow-composition
- 004-spec-alignment-gate

## Validation

- `python3 -c "import json; json.load(open('specs/governance/approved-specs.json'))"` — valid JSON
- Reviewed spec.md/approved-specs.json versioning convention against specs 102, 108, 109, 110, 111, 112 before choosing the 1.0.0 → 1.1.0 bump, rather than assuming a mismatch was a bug.
