### PR TITLE
fix(cli): pin down and regression-test artifact-metadata trust boundary

### DIFF
--- a/crates/traverse-cli/src/main.rs
+++ b/crates/traverse-cli/src/main.rs
@@ -3515,6 +3515,13 @@ fn capability_publish_plan(
         )
     })?;
     merge_author_fields_into_publish_contract(&mut contract_value, &raw_contract_value);
+    // Issue #859: `artifact.digest`/`artifact.url` are always computed here from the real
+    // artifact binary (`request.artifact_path`), never taken from the author-supplied
+    // contract. `CapabilityContract` intentionally has no `artifact` field for this reason:
+    // an author cannot know the real digest before the artifact is built, and a value they
+    // did supply must not be trusted into a published index entry. Do not add `artifact`
+    // to `merge_author_fields_into_publish_contract` — that would let an author-forged
+    // digest/url reach the registry.
     contract_value["artifact"] = serde_json::json!({
         "digest": artifact_digest,
         "url": artifact_url,
@@ -7560,6 +7567,45 @@ mod tests {
         assert!(!commands.contains("056-capability-publish"));
         assert_eq!(json["registry_repo"], "traverse-framework/registry");
         assert!(commands.contains("--repo traverse-framework/registry"));
+    }
+
+    #[test]
+    fn capability_publish_overrides_author_supplied_artifact_field() {
+        // Issue #859: `CapabilityContract` has no `artifact` field, so an author-supplied
+        // one is dropped on parse; publish must still end up with the real digest/url
+        // computed from the actual artifact binary, never a forged author value.
+        let fixture = capability_publish_fixture();
+        let mut contract: Value = serde_json::from_str(
+            &fs::read_to_string(&fixture.contract).expect("fixture contract should read"),
+        )
+        .expect("fixture contract should parse");
+        contract["artifact"] = serde_json::json!({
+            "digest": "sha256:forged-by-author",
+            "url": "https://evil.example/fake.wasm",
+        });
+        fs::write(
+            &fixture.contract,
+            serde_json::to_string_pretty(&contract).expect("forged contract should serialize"),
+        )
+        .expect("forged contract should write");
+        let runner = RecordingPublishRunner::default();
+
+        let output = capability_publish_at(&fixture.request(false), &runner)
+            .expect("publish should open PR with fake runner");
+        let json: Value = serde_json::from_str(&output).expect("publish output must be JSON");
+        let published: Value = serde_json::from_str(
+            &fs::read_to_string(fixture.registry_contract_path())
+                .expect("published registry contract should read"),
+        )
+        .expect("published registry contract should parse");
+
+        assert_ne!(published["artifact"]["digest"], "sha256:forged-by-author");
+        assert_ne!(
+            published["artifact"]["url"],
+            "https://evil.example/fake.wasm"
+        );
+        assert_eq!(published["artifact"]["digest"], json["artifact_digest"]);
+        assert_eq!(published["artifact"]["url"], json["artifact_url"]);
     }
 
     #[test]


### PR DESCRIPTION
## Governing Spec

- `056-capability-publish`

## Project Item

https://github.com/traverse-framework/traverse/issues/859

## Summary

Issue #859 reported that `CapabilityContract` has no `artifact` field, so an
author-supplied `artifact.digest`/`artifact.url` is silently dropped on parse,
and asked us to either require the field before a non-dry-run publish or make
the artifact-less-contract behavior an explicit, documented decision instead
of silence.

Investigation confirmed the described gap in the *validation* path
(`parse_contract`/`validate_contract` don't require or check an `artifact`
field), but also confirmed that `capability_publish_plan` (#1019, merged after
this issue was filed) already closes the actual failure mode described in the
issue: it always computes `artifact.digest`/`artifact.url` from the real
artifact binary passed via `--artifact` (`publish_file_sha256_digest`,
`publish_artifact_asset_name`) and unconditionally overwrites
`contract_value["artifact"]` with that computed value before writing
`contract.json` to the registry PR. An author-supplied `artifact` field in the
source contract is dropped on parse (the struct has no such field) and, even
if it survived, would still be overwritten at serialize time. So a published
index entry can no longer end up with a null/missing digest — spec
`056-capability-publish` FR-003/FR-004 ("reject ... missing artifact metadata,
or a missing digest" / "compute or verify the artifact digest") are already
satisfied by the required `--artifact` flag plus digest computation failing
loudly (`capability_publish_artifact_read_failed`) when that file is missing
or unreadable — already covered by existing tests.

What was missing: a regression test proving the trust boundary (author input
never wins over the real computed digest) and an explicit, documented comment
at the injection site, per the issue's own alternative-resolution clause.

## Changes

- `crates/traverse-cli/src/main.rs`: added
  `capability_publish_overrides_author_supplied_artifact_field`, which forges
  an `artifact.digest`/`artifact.url` in the source contract and asserts the
  published `contract.json` still carries the real computed digest/url, not
  the forged values.
- Documented the decision inline at the `contract_value["artifact"] = ...`
  injection site: digest/url are always computed from the real binary and
  must never be sourced from `merge_author_fields_into_publish_contract`.

## Out of scope / follow-up

Issue #859's second DoD bullet (`capability_validation.py` in
`traverse-framework/registry` should fail loudly rather than silently skip
when a contract lacks `artifact`) is registry-repo scope, not this repo.
Filed as a follow-up issue in `traverse-framework/registry` referencing #859.

## Validation

- [x] Spec alignment checked (declared `056-capability-publish` above; no
      contract or spec text changed)
- [x] Contract alignment checked (`CapabilityContract` unchanged; no new
      author-facing field)
- [x] Tests updated and passing (`cargo test -p traverse-cli-rs` — 386
      passed, including the new regression test)
- [x] Core coverage preserved (`traverse-cli` is not yet 100%-gated; change
      is additive-only, no lines removed)
- [x] Required validation gates passing
      (`BASE_SHA=$(git merge-base HEAD origin/main) bash
      scripts/ci/local_preflight.sh --pr-body <file>` — clean;
      `cargo clippy -p traverse-cli-rs --all-targets` — clean)

Fixes #859.
