### PR TITLE
test(examples): regression-test input-dependence of expedition example fixtures

### DIFF
--- a/crates/traverse-cli/src/main.rs
+++ b/crates/traverse-cli/src/main.rs
@@ -10062,6 +10062,43 @@ mod tests {
     }
 
     #[test]
+    fn execute_capability_package_first_governed_request_reflects_varied_input() {
+        // Issue #888: guard against this fixture regressing to fixed output
+        // that ignores its input -- vary preferences.style/priority and
+        // assert the real WASM execution's route_preferences/constraints
+        // track them, rather than only matching one canned request.
+        let manifest_path =
+            repo_root().join("examples/capabilities/expedition-intent-agent/manifest.json");
+        build_real_capability_package_artifact(&manifest_path);
+        let request_path = repo_root()
+            .join("examples/capabilities/runtime-requests/interpret-expedition-intent.json");
+        let mut request: Value = serde_json::from_str(
+            &fs::read_to_string(&request_path).expect("canonical request fixture should read"),
+        )
+        .expect("canonical request fixture should parse");
+        request["input"]["objective"]["preferences"]["style"] =
+            serde_json::json!("aggressive-summit-push");
+        request["input"]["objective"]["preferences"]["priority"] =
+            serde_json::json!("fastest-route");
+        let modified_request_path =
+            unique_temp_dir().join("interpret-expedition-intent-varied.json");
+        fs::write(
+            &modified_request_path,
+            serde_json::to_string_pretty(&request).expect("modified request should serialize"),
+        )
+        .expect("modified request should write");
+
+        let output = execute_capability_package(&manifest_path, &modified_request_path)
+            .expect("capability package execution should succeed for the varied request");
+
+        assert!(output.contains("\"aggressive-summit-push\""));
+        assert!(output.contains("\"fastest-route\""));
+        assert!(output.contains("priority:fastest-route"));
+        assert!(!output.contains("\"conservative-alpine-push\""));
+        assert!(!output.contains("priority:same-day-return"));
+    }
+
+    #[test]
     fn inspect_capability_package_renders_second_governed_wasm_capability_package() {
         let fixture = create_validate_team_readiness_capability_fixture();
 
@@ -10090,6 +10127,37 @@ mod tests {
         assert!(output.contains("capability_version: 1.0.0"));
         assert!(output.contains("status: completed"));
         assert!(output.contains("\"status\": \"ready\"") || output.contains("\"ready\""));
+    }
+
+    #[test]
+    fn execute_capability_package_second_governed_request_reflects_varied_input() {
+        // Issue #888: guard against this fixture regressing to fixed output
+        // that ignores its input -- flip team_profile.equipment_ready and
+        // assert the real WASM execution's status/required_actions track it.
+        let manifest_path =
+            repo_root().join("examples/capabilities/team-readiness-agent/manifest.json");
+        build_real_capability_package_artifact(&manifest_path);
+        let request_path =
+            repo_root().join("examples/capabilities/runtime-requests/validate-team-readiness.json");
+        let mut request: Value = serde_json::from_str(
+            &fs::read_to_string(&request_path).expect("canonical request fixture should read"),
+        )
+        .expect("canonical request fixture should parse");
+        request["input"]["team_profile"]["equipment_ready"] = serde_json::json!(false);
+        let modified_request_path =
+            unique_temp_dir().join("validate-team-readiness-not-ready.json");
+        fs::write(
+            &modified_request_path,
+            serde_json::to_string_pretty(&request).expect("modified request should serialize"),
+        )
+        .expect("modified request should write");
+
+        let output = execute_capability_package(&manifest_path, &modified_request_path)
+            .expect("capability package execution should succeed for the varied request");
+
+        assert!(output.contains("\"status\": \"needs_action\""));
+        assert!(output.contains("\"complete equipment verification\""));
+        assert!(!output.contains("\"status\": \"ready\""));
     }
 
     #[test]


### PR DESCRIPTION
## Governing Spec

- `516-agent-artifact-execution`

## Project Item

https://github.com/traverse-framework/traverse/issues/888

## Summary

Issue #888 reported that `examples/capabilities/expedition-intent-agent/` and
`examples/capabilities/team-readiness-agent/` were fixed-output fixtures
whose `src/agent.rs` writes a hardcoded `static OUTPUT` regardless of input.

Investigation confirmed that's no longer true: #948 (merged 2026-08-04, after
this issue was filed on 2026-07-29) already replaced both with real,
input-driven logic. Verified directly:

- `cargo run -p traverse-cli-rs -- capability-package inspect <manifest>` on
  both fixtures reports a `binary_digest` matching each manifest's
  `expected_digest`, confirming the checked-in `.wasm` artifacts are built
  from the current (real-logic) source, not stale fixed-output binaries.
- Ran `capability-package execute` against both fixtures' canonical request
  and a manually varied one (`team_profile.equipment_ready` flipped,
  `preferences.style`/`priority` changed) and confirmed the real WASM output
  changes accordingly (`status: "ready"` -> `"needs_action"` with a populated
  `required_actions`; `route_preferences`/`constraints` reflect the new
  style/priority).

What was missing: a regression test locking this in. The existing
`execute_capability_package_runs_governed_capability_package_request` /
`..._runs_second_governed_capability_package_request` tests only match
output against the one canonical request — a hardcoded fixture whose static
output happens to contain that request's literal values would also pass.

## Changes

- `crates/traverse-cli/src/main.rs`: added
  `execute_capability_package_first_governed_request_reflects_varied_input`
  and `..._second_governed_request_reflects_varied_input`, which vary the
  canonical request fixtures and assert the real WASM execution's output
  tracks the change (matching the existing precedent set by
  `execute_expedition_output_changes_with_real_wasm_input_across_the_full_chain`
  for the full expedition chain).

## Validation

- [x] Spec alignment checked (declared `516-agent-artifact-execution` above)
- [x] Contract alignment checked (no contract changed)
- [x] Tests updated and passing (`cargo test -p traverse-cli-rs` — 399
      passed, including the two new regression tests)
- [x] Core coverage preserved (`traverse-cli` is not yet 100%-gated; change
      is additive-only, no lines removed)
- [x] Required validation gates passing
      (`BASE_SHA=$(git merge-base HEAD origin/main) bash
      scripts/ci/local_preflight.sh --pr-body <file>` — clean;
      `cargo clippy -p traverse-cli-rs --all-targets` — clean)

Fixes #888.
