### PR TITLE
feat(mcp): implement P0 declarative workflow planner (spec 113)

### DIFF
--- a/crates/traverse-mcp/src/tools/mod.rs
+++ b/crates/traverse-mcp/src/tools/mod.rs
@@ -7,4 +7,5 @@ pub mod events;
 pub mod parallel_proposals;
 pub mod proposals;
 pub mod traces;
+pub mod workflow_plan;
 pub mod workflow_promotion;

--- a/crates/traverse-mcp/src/tools/workflow_plan.rs
+++ b/crates/traverse-mcp/src/tools/workflow_plan.rs
@@ -1,0 +1,418 @@
+//! MCP tool surface for the declarative workflow planner (P0).
+//!
+//! Governed by spec `113-declarative-workflow-planning`. Mirrors the
+//! `tools::proposals` pattern: a plain, fully-tested Rust function forms the
+//! public MCP surface, independent of `stdio_server.rs`. Given a structured
+//! target and a starting fact set, derives candidate `WorkflowProposal`s
+//! already shaped for submission to the existing P1 surface
+//! (`tools::proposals::submit_proposal`) once a reviewer clears their
+//! `mapping_unconfirmed` flag (FR-005/FR-006). This module never submits or
+//! executes anything itself, and never mutates the registry or manifest
+//! (FR-008) -- every function here only reads through shared references.
+
+use serde::Serialize;
+use serde_json::{Value, json};
+use std::collections::BTreeSet;
+
+use traverse_contracts::{
+    CapabilityContract, ManifestReference, MappingSource, ProposalEdge, ProposalMapping,
+    ProposalNode, WorkflowProposal,
+};
+use traverse_registry::{ApplicationBundleManifest, CapabilityRegistry, LookupScope};
+
+/// At most 5 complete candidate plans per call (spec 113 FR-004).
+const PLAN_MAX_CANDIDATES: usize = 5;
+/// At most 8 nodes deep per candidate plan (spec 113 FR-004).
+const PLAN_MAX_NODES: usize = 8;
+/// Defensive cap on total recursive search calls, independent of the node/
+/// candidate bounds above, so a pathological declared-capability graph can't
+/// make a single planning call do unbounded work (spec 113 FR-004: "never
+/// ... search unbounded").
+const PLAN_MAX_SEARCH_CALLS: usize = 4_000;
+
+/// What the planner must produce a chain ending in (spec 113 FR-001): a
+/// declared event type or an exact capability id/version the caller needs
+/// produced. Never a natural-language goal.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PlanTarget {
+    Capability {
+        capability_id: String,
+        capability_version: String,
+    },
+    EmitsEvent {
+        event_type: String,
+    },
+}
+
+/// Everything [`plan_workflow`] needs to derive candidate plans. Planning is
+/// scoped to the capabilities declared as components in `manifest`, matching
+/// the same "declared set is the only permitted set" check the P1 surface
+/// applies at submission time (spec 109's `UndeclaredCapability` denial) --
+/// this keeps a returned candidate structurally submittable as-is (FR-006).
+pub struct PlanRequest<'a> {
+    pub target: &'a PlanTarget,
+    /// The facts already available before any node runs. Bound to
+    /// `MappingSource::InitialInput` mappings in every returned candidate.
+    pub starting_facts: &'a Value,
+    pub manifest: &'a ApplicationBundleManifest,
+    /// The exact, already-registered application manifest reference every
+    /// returned candidate is bound to (spec 109 FR-002, ADR-0041). The
+    /// planner does not compute this itself -- the caller already holds it
+    /// from resolving `manifest` against the application registry.
+    pub app_manifest: &'a ManifestReference,
+    pub registry: &'a CapabilityRegistry,
+    pub workspace_id: &'a str,
+}
+
+/// One candidate plan, structurally submittable as-is to `submit_proposal`
+/// once a reviewer clears its field mappings (spec 113 FR-005, FR-006).
+#[derive(Debug, Clone, Serialize)]
+pub struct PlanCandidate {
+    pub proposal: WorkflowProposal,
+    /// Always `true`: the planner never clears this itself (FR-005).
+    pub mapping_unconfirmed: bool,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct PlanResponse {
+    pub candidates: Vec<PlanCandidate>,
+    /// `true` when the search found more than [`PLAN_MAX_CANDIDATES`] valid
+    /// complete plans, or hit the node-depth or search-work bound before it
+    /// could fully explore a branch that had a structurally valid next step
+    /// (spec 113 FR-004). Never a silent partial result.
+    pub plan_search_truncated: bool,
+}
+
+/// A declared component's capability, resolved to its full contract and
+/// exact artifact digest -- the only capabilities the planner may place in a
+/// candidate node (spec 113's "published capabilities" scoped to what's
+/// actually declared in the target application manifest).
+struct DeclaredCapability {
+    capability_id: String,
+    capability_version: String,
+    contract: CapabilityContract,
+    artifact_digest: String,
+}
+
+/// Derives candidate workflow proposals for `request.target`, pure and
+/// read-only over the given manifest/registry snapshot (spec 113 FR-008).
+/// Never fails: an empty `candidates` list is itself a valid, correctly
+/// reported outcome (acceptance scenario 3) when no declared capability's
+/// schema chains to the target.
+#[must_use]
+pub fn plan_workflow(request: &PlanRequest<'_>) -> PlanResponse {
+    let mut declared: Vec<DeclaredCapability> = request
+        .manifest
+        .components
+        .iter()
+        .filter_map(|component| {
+            let resolved = request.registry.find_exact(
+                LookupScope::PreferPrivate,
+                &component.manifest.capability_id,
+                &component.manifest.capability_version,
+            )?;
+            let artifact_digest = resolved
+                .artifact
+                .digests
+                .binary_digest
+                .clone()
+                .unwrap_or_else(|| resolved.artifact.digests.source_digest.clone());
+            Some(DeclaredCapability {
+                capability_id: component.manifest.capability_id.clone(),
+                capability_version: component.manifest.capability_version.clone(),
+                contract: resolved.contract,
+                artifact_digest,
+            })
+        })
+        .collect();
+    declared.sort_by(|a, b| {
+        (&a.capability_id, &a.capability_version).cmp(&(&b.capability_id, &b.capability_version))
+    });
+    declared.dedup_by(|a, b| {
+        a.capability_id == b.capability_id && a.capability_version == b.capability_version
+    });
+
+    let starting_outputs = starting_facts_output_schema(request.starting_facts);
+    let target_indices: Vec<usize> = declared
+        .iter()
+        .enumerate()
+        .filter(|(_, capability)| target_matches(request.target, capability))
+        .map(|(index, _)| index)
+        .collect();
+
+    let mut truncated = false;
+    let mut search_calls_remaining = PLAN_MAX_SEARCH_CALLS;
+    let mut all_chains: Vec<Vec<usize>> = Vec::new();
+    for &target_index in &target_indices {
+        let chains = build_chains(
+            &declared,
+            &starting_outputs,
+            target_index,
+            PLAN_MAX_NODES,
+            &BTreeSet::new(),
+            &mut search_calls_remaining,
+            &mut truncated,
+        );
+        all_chains.extend(chains);
+    }
+
+    all_chains.sort_by(|a, b| {
+        a.len().cmp(&b.len()).then_with(|| {
+            let a_ids: Vec<&str> = a
+                .iter()
+                .map(|&i| declared[i].capability_id.as_str())
+                .collect();
+            let b_ids: Vec<&str> = b
+                .iter()
+                .map(|&i| declared[i].capability_id.as_str())
+                .collect();
+            a_ids.cmp(&b_ids)
+        })
+    });
+    all_chains.dedup();
+
+    if all_chains.len() > PLAN_MAX_CANDIDATES {
+        truncated = true;
+    }
+
+    let candidates = all_chains
+        .into_iter()
+        .take(PLAN_MAX_CANDIDATES)
+        .enumerate()
+        .map(|(candidate_index, chain)| {
+            build_candidate(request, &declared, &chain, candidate_index)
+        })
+        .collect();
+
+    PlanResponse {
+        candidates,
+        plan_search_truncated: truncated,
+    }
+}
+
+fn target_matches(target: &PlanTarget, capability: &DeclaredCapability) -> bool {
+    match target {
+        PlanTarget::Capability {
+            capability_id,
+            capability_version,
+        } => {
+            capability.capability_id == *capability_id
+                && capability.capability_version == *capability_version
+        }
+        PlanTarget::EmitsEvent { event_type } => capability
+            .contract
+            .emits
+            .iter()
+            .any(|reference| reference.event_id == *event_type),
+    }
+}
+
+/// Bounded recursive backward search: enumerates every way to reach
+/// `node_index`, either directly from starting facts or through exactly one
+/// upstream declared capability whose `outputs.schema` structurally
+/// satisfies `node_index`'s `inputs.schema.required` (spec 113 FR-002),
+/// recursing on that upstream capability in turn. Returns root-first node
+/// index chains ending at `node_index`.
+#[allow(clippy::too_many_arguments)]
+fn build_chains(
+    declared: &[DeclaredCapability],
+    starting_outputs: &Value,
+    node_index: usize,
+    remaining_budget: usize,
+    excluded: &BTreeSet<usize>,
+    search_calls_remaining: &mut usize,
+    truncated: &mut bool,
+) -> Vec<Vec<usize>> {
+    if *search_calls_remaining == 0 {
+        *truncated = true;
+        return Vec::new();
+    }
+    *search_calls_remaining -= 1;
+
+    let node = &declared[node_index];
+    let required = schema_required(&node.contract.inputs.schema);
+    let node_schema = &node.contract.inputs.schema;
+
+    let mut result = Vec::new();
+    if schema_covers_required(starting_outputs, &required, node_schema) {
+        result.push(vec![node_index]);
+    }
+
+    // A node with no required inputs is satisfied by definition (the direct
+    // match above always applies to it) and never gains a predecessor: an
+    // empty `required` list is vacuously covered by every candidate's
+    // outputs, which would otherwise manufacture meaningless zero-mapping
+    // edges for every other declared capability.
+    if !required.is_empty() {
+        for (candidate_index, candidate) in declared.iter().enumerate() {
+            if candidate_index == node_index || excluded.contains(&candidate_index) {
+                continue;
+            }
+            if !schema_covers_required(&candidate.contract.outputs.schema, &required, node_schema) {
+                continue;
+            }
+            if remaining_budget <= 1 {
+                // A structurally valid predecessor exists but including it
+                // would exceed the node-depth bound -- a real omission, not
+                // an absence of alternatives.
+                *truncated = true;
+                continue;
+            }
+            let mut branch_excluded = excluded.clone();
+            branch_excluded.insert(node_index);
+            let sub_chains = build_chains(
+                declared,
+                starting_outputs,
+                candidate_index,
+                remaining_budget - 1,
+                &branch_excluded,
+                search_calls_remaining,
+                truncated,
+            );
+            for mut sub_chain in sub_chains {
+                sub_chain.push(node_index);
+                result.push(sub_chain);
+            }
+        }
+    }
+    result
+}
+
+/// Whether every property named in `required` exists in `source_schema`'s
+/// `properties` map and in `target_schema`'s `properties` map with the same
+/// declared JSON `type` (spec 113 FR-002: an exact, declared-type match on
+/// both sides -- an undeclared type on either side is not a match).
+fn schema_covers_required(
+    source_schema: &Value,
+    required: &[String],
+    target_schema: &Value,
+) -> bool {
+    required.iter().all(|property| {
+        match (
+            schema_property_type(source_schema, property),
+            schema_property_type(target_schema, property),
+        ) {
+            (Some(source_type), Some(target_type)) => source_type == target_type,
+            _ => false,
+        }
+    })
+}
+
+fn schema_property_type<'a>(schema: &'a Value, property: &str) -> Option<&'a str> {
+    schema
+        .get("properties")?
+        .get(property)?
+        .get("type")?
+        .as_str()
+}
+
+fn schema_required(schema: &Value) -> Vec<String> {
+    schema
+        .get("required")
+        .and_then(Value::as_array)
+        .map(|values| {
+            values
+                .iter()
+                .filter_map(|value| value.as_str().map(str::to_string))
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+/// Synthesizes a producer-shaped `outputs.schema` fragment from the starting
+/// facts, so root-node satisfiability can reuse the same `properties`/`type`
+/// matching [`schema_covers_required`] uses for capability-to-capability
+/// chaining, rather than a second comparison rule.
+fn starting_facts_output_schema(starting_facts: &Value) -> Value {
+    let mut properties = serde_json::Map::new();
+    if let Some(object) = starting_facts.as_object() {
+        for (key, value) in object {
+            properties.insert(key.clone(), json!({"type": json_type_name(value)}));
+        }
+    }
+    json!({"type": "object", "properties": Value::Object(properties)})
+}
+
+fn json_type_name(value: &Value) -> &'static str {
+    match value {
+        Value::Null => "null",
+        Value::Bool(_) => "boolean",
+        Value::Number(number) if number.is_i64() || number.is_u64() => "integer",
+        Value::Number(_) => "number",
+        Value::String(_) => "string",
+        Value::Array(_) => "array",
+        Value::Object(_) => "object",
+    }
+}
+
+/// Renders one root-first node-index chain into a structurally submittable
+/// `WorkflowProposal` (spec 113 FR-006). Each node's entire required input
+/// set is sourced from exactly one place: `InitialInput` for the chain's
+/// root, or its single immediate predecessor's output otherwise -- matching
+/// how [`build_chains`] decided the chain was valid in the first place.
+fn build_candidate(
+    request: &PlanRequest<'_>,
+    declared: &[DeclaredCapability],
+    chain: &[usize],
+    candidate_index: usize,
+) -> PlanCandidate {
+    let mut nodes = Vec::with_capacity(chain.len());
+    let mut edges = Vec::new();
+    let mut mappings = Vec::new();
+
+    for (position, &node_index) in chain.iter().enumerate() {
+        let capability = &declared[node_index];
+        let node_id = format!("n{position}");
+        nodes.push(ProposalNode {
+            node_id: node_id.clone(),
+            capability_id: capability.capability_id.clone(),
+            capability_version: capability.capability_version.clone(),
+            artifact_digest: capability.artifact_digest.clone(),
+        });
+
+        let required = schema_required(&capability.contract.inputs.schema);
+        if position == 0 {
+            for property in &required {
+                mappings.push(ProposalMapping {
+                    source: MappingSource::InitialInput,
+                    source_path: format!("/{property}"),
+                    target_node_id: node_id.clone(),
+                    target_path: format!("/{property}"),
+                });
+            }
+        } else {
+            let predecessor_node_id = format!("n{}", position - 1);
+            edges.push(ProposalEdge {
+                from_node_id: predecessor_node_id.clone(),
+                to_node_id: node_id.clone(),
+            });
+            for property in &required {
+                mappings.push(ProposalMapping {
+                    source: MappingSource::Node {
+                        node_id: predecessor_node_id.clone(),
+                    },
+                    source_path: format!("/{property}"),
+                    target_node_id: node_id.clone(),
+                    target_path: format!("/{property}"),
+                });
+            }
+        }
+    }
+
+    let proposal = WorkflowProposal {
+        kind: "workflow_proposal".to_string(),
+        schema_version: "1.0.0".to_string(),
+        proposal_id: format!("plan-candidate-{candidate_index}"),
+        workspace_id: request.workspace_id.to_string(),
+        app_manifest: request.app_manifest.clone(),
+        nodes,
+        edges,
+        mappings,
+        initial_input: request.starting_facts.clone(),
+    };
+
+    PlanCandidate {
+        proposal,
+        mapping_unconfirmed: true,
+    }
+}

--- a/crates/traverse-mcp/tests/workflow_plan_tests.rs
+++ b/crates/traverse-mcp/tests/workflow_plan_tests.rs
@@ -1,0 +1,764 @@
+//! End-to-end MCP tests for the declarative workflow planner (P0).
+//!
+//! Governed by spec `113-declarative-workflow-planning`. Exercises
+//! `traverse_mcp::tools::workflow_plan::plan_workflow` against the five
+//! acceptance scenarios in the spec: a unique candidate, enumerated
+//! ambiguous candidates, zero candidates for a structurally unreachable
+//! target, a reviewer-corrected mapping round-tripping through the real P1
+//! `submit_proposal` surface unchanged, and search-bound truncation (both
+//! the candidate-count and node-depth bounds).
+
+use serde_json::{Value, json};
+
+use traverse_contracts::{
+    BinaryFormat as ContractBinaryFormat, CapabilityContract, DataFlowPolicy, DeterminismClass,
+    EffectClass, Entrypoint, EntrypointKind, EventReference, Execution, ExecutionConstraints,
+    ExecutionTarget, FilesystemAccess, HostApiAccess, Lifecycle, ManifestReference,
+    MappingSource as ContractMappingSource, NetworkAccess, Owner, ReliabilityMetadata,
+    RiskMetadata, SchemaContainer, ServiceType, SideEffect, SideEffectKind,
+};
+use traverse_mcp::tools::proposals::submit_proposal;
+use traverse_mcp::tools::workflow_plan::{PlanRequest, PlanTarget, plan_workflow};
+use traverse_registry::{
+    ApplicationBundleManifest, ApplicationComponent, ApplicationComponentRef,
+    ApplicationEffectiveConfig, ArtifactDigests, BinaryFormat as RegistryBinaryFormat,
+    BinaryReference, CapabilityArtifactRecord, CapabilityRegistration, CapabilityRegistry,
+    ComponentExecutionMode, ComposabilityMetadata, CompositionKind, CompositionPattern,
+    ImplementationKind, RegistryProvenance, RegistryScope, SourceKind, SourceReference,
+    WasmComponentManifest,
+};
+
+fn risk() -> RiskMetadata {
+    RiskMetadata {
+        effect_class: EffectClass::PureRead,
+        determinism_class: DeterminismClass::Deterministic,
+        data_flow: DataFlowPolicy::default(),
+        reliability: ReliabilityMetadata {
+            idempotency_required: false,
+            retryable: true,
+            compensation_available: false,
+        },
+    }
+}
+
+fn contract_with_schema(
+    id: &str,
+    version: &str,
+    inputs_schema: Value,
+    outputs_schema: Value,
+    emits: Vec<EventReference>,
+) -> CapabilityContract {
+    let (namespace, name) = id.rsplit_once('.').unwrap_or(("test", id));
+    CapabilityContract {
+        kind: "capability_contract".to_string(),
+        schema_version: "1.0.0".to_string(),
+        id: id.to_string(),
+        namespace: namespace.to_string(),
+        name: name.to_string(),
+        version: version.to_string(),
+        lifecycle: Lifecycle::Active,
+        owner: Owner {
+            team: "traverse-core".to_string(),
+            contact: "enrico.piovesan10@gmail.com".to_string(),
+        },
+        summary: "Test capability for workflow planner MCP end-to-end coverage.".to_string(),
+        description: "Portable test capability used to exercise the planner MCP surface."
+            .to_string(),
+        inputs: SchemaContainer {
+            schema: inputs_schema,
+        },
+        outputs: SchemaContainer {
+            schema: outputs_schema,
+        },
+        preconditions: Vec::new(),
+        postconditions: Vec::new(),
+        side_effects: vec![SideEffect {
+            kind: SideEffectKind::MemoryOnly,
+            description: "No durable side effect.".to_string(),
+        }],
+        emits,
+        consumes: Vec::new(),
+        permissions: Vec::new(),
+        execution: Execution {
+            binary_format: ContractBinaryFormat::Wasm,
+            entrypoint: Entrypoint {
+                kind: EntrypointKind::WasiCommand,
+                command: "run".to_string(),
+            },
+            preferred_targets: vec![ExecutionTarget::Local],
+            constraints: ExecutionConstraints {
+                host_api_access: HostApiAccess::None,
+                network_access: NetworkAccess::Forbidden,
+                filesystem_access: FilesystemAccess::None,
+            },
+        },
+        policies: Vec::new(),
+        dependencies: Vec::new(),
+        provenance: traverse_contracts::Provenance {
+            source: traverse_contracts::ProvenanceSource::Greenfield,
+            author: "test".to_string(),
+            created_at: "2026-08-23T00:00:00Z".to_string(),
+            spec_ref: None,
+            adr_refs: Vec::new(),
+            exception_refs: Vec::new(),
+        },
+        evidence: Vec::new(),
+        service_type: ServiceType::Stateless,
+        permitted_targets: vec![ExecutionTarget::Local],
+        event_trigger: None,
+        connector_requirements: Vec::new(),
+        state_schema: None,
+        use_cases: Vec::new(),
+        risk: risk(),
+    }
+}
+
+fn artifact(digest: &str) -> CapabilityArtifactRecord {
+    CapabilityArtifactRecord {
+        artifact_ref: format!("artifact:{digest}"),
+        implementation_kind: ImplementationKind::Executable,
+        source: SourceReference {
+            kind: SourceKind::Git,
+            location: "https://example.invalid/repo".to_string(),
+        },
+        binary: Some(BinaryReference {
+            format: RegistryBinaryFormat::Wasm,
+            location: format!("artifacts/{digest}/capability.wasm"),
+            signature: None,
+        }),
+        workflow_ref: None,
+        digests: ArtifactDigests {
+            source_digest: format!("src-{digest}"),
+            binary_digest: Some(digest.to_string()),
+        },
+        provenance: RegistryProvenance {
+            source: "test".to_string(),
+            author: "test".to_string(),
+            created_at: "2026-08-23T00:00:00Z".to_string(),
+        },
+    }
+}
+
+fn registry_with(entries: Vec<CapabilityContract>) -> CapabilityRegistry {
+    let mut registry = CapabilityRegistry::new();
+    for contract in entries {
+        let digest = format!("{}-{}", contract.id, contract.version);
+        let outcome = registry.register(CapabilityRegistration {
+            scope: RegistryScope::Public,
+            contract,
+            contract_path: "registry/test/contract.json".to_string(),
+            artifact: artifact(&digest),
+            registered_at: "2026-08-23T00:00:00Z".to_string(),
+            tags: Vec::new(),
+            composability: ComposabilityMetadata {
+                kind: CompositionKind::Atomic,
+                patterns: vec![CompositionPattern::Sequential],
+                provides: Vec::new(),
+                requires: Vec::new(),
+            },
+            governing_spec: "005-capability-registry".to_string(),
+            validator_version: "0.1.0".to_string(),
+        });
+        assert!(outcome.is_ok(), "registration must succeed: {outcome:?}");
+    }
+    registry
+}
+
+fn manifest_declaring(contracts: &[CapabilityContract]) -> ApplicationBundleManifest {
+    ApplicationBundleManifest {
+        app_id: "test-app".to_string(),
+        version: "1.0.0".to_string(),
+        schema_version: "1.0.0".to_string(),
+        workspace_defaults: json!({}),
+        components: contracts
+            .iter()
+            .map(|contract| ApplicationComponent {
+                reference: ApplicationComponentRef {
+                    component_id: contract.id.clone(),
+                    version: contract.version.clone(),
+                    digest: "sha256:component-digest".to_string(),
+                    manifest_path: "component.manifest.json".to_string(),
+                },
+                manifest_path: "component.manifest.json".into(),
+                manifest: WasmComponentManifest {
+                    component_id: contract.id.clone(),
+                    version: contract.version.clone(),
+                    schema_version: "1.0.0".to_string(),
+                    execution_mode: ComponentExecutionMode::Wasm,
+                    capability_id: contract.id.clone(),
+                    capability_version: contract.version.clone(),
+                    contract_path: None,
+                    registry_ref: None,
+                    wasm_binary_path: None,
+                    wasm_digest: None,
+                    platforms: vec!["local".to_string()],
+                    wrapper_path: None,
+                    runtime_constraints: json!({}),
+                    permitted_targets: vec![ExecutionTarget::Local],
+                    dependencies: Vec::new(),
+                    connector_requirements: Vec::new(),
+                    validation_evidence: Vec::new(),
+                    executable_pin: None,
+                },
+                contract_path: "contract.json".into(),
+                contract: contract.clone(),
+                wasm_binary_path: None,
+                verified_wasm_digest: None,
+            })
+            .collect(),
+        workflows: Vec::new(),
+        connector_bindings: Vec::new(),
+        model_dependencies: Vec::new(),
+        config_schema: json!({}),
+        default_config: json!({}),
+        effective_config: ApplicationEffectiveConfig {
+            values: json!({}),
+            redacted_secret_keys: Vec::new(),
+        },
+        placement_policy: json!({}),
+        public_surfaces: Vec::new(),
+        state_machine: None,
+    }
+}
+
+fn app_manifest_reference() -> ManifestReference {
+    ManifestReference {
+        app_id: "test-app".to_string(),
+        app_version: "1.0.0".to_string(),
+        manifest_digest: "sha256:manifest-digest".to_string(),
+    }
+}
+
+fn object_schema(properties: &[(&str, &str)], required: &[&str]) -> Value {
+    let mut props = serde_json::Map::new();
+    for (name, json_type) in properties {
+        props.insert((*name).to_string(), json!({"type": json_type}));
+    }
+    json!({
+        "type": "object",
+        "properties": Value::Object(props),
+        "required": required,
+    })
+}
+
+fn empty_schema() -> Value {
+    json!({"type": "object", "properties": {}, "required": []})
+}
+
+/// Acceptance scenario 1: exactly one declared capability's `outputs.schema`
+/// structurally satisfies the target's `inputs.schema.required` -- the
+/// planner returns exactly one candidate plan, mapping flagged unconfirmed.
+#[test]
+fn plan_workflow_returns_unique_candidate_when_exactly_one_producer_matches() {
+    let producer = contract_with_schema(
+        "test.producer",
+        "1.0.0",
+        empty_schema(),
+        object_schema(&[("result", "string")], &[]),
+        Vec::new(),
+    );
+    let consumer = contract_with_schema(
+        "test.consumer",
+        "1.0.0",
+        object_schema(&[("result", "string")], &["result"]),
+        empty_schema(),
+        Vec::new(),
+    );
+    let registry = registry_with(vec![producer.clone(), consumer.clone()]);
+    let manifest = manifest_declaring(&[producer, consumer]);
+    let app_manifest = app_manifest_reference();
+    let target = PlanTarget::Capability {
+        capability_id: "test.consumer".to_string(),
+        capability_version: "1.0.0".to_string(),
+    };
+    let starting_facts = json!({});
+
+    let response = plan_workflow(&PlanRequest {
+        target: &target,
+        starting_facts: &starting_facts,
+        manifest: &manifest,
+        app_manifest: &app_manifest,
+        registry: &registry,
+        workspace_id: "workspace-001",
+    });
+
+    assert!(!response.plan_search_truncated);
+    assert_eq!(response.candidates.len(), 1);
+    let candidate = &response.candidates[0];
+    assert!(candidate.mapping_unconfirmed);
+    assert_eq!(candidate.proposal.nodes.len(), 2);
+    assert_eq!(candidate.proposal.nodes[0].capability_id, "test.producer");
+    assert_eq!(candidate.proposal.nodes[1].capability_id, "test.consumer");
+    assert_eq!(candidate.proposal.edges.len(), 1);
+    assert_eq!(candidate.proposal.mappings.len(), 1);
+    assert_eq!(
+        candidate.proposal.mappings[0].source,
+        ContractMappingSource::Node {
+            node_id: "n0".to_string()
+        }
+    );
+    assert_eq!(candidate.proposal.mappings[0].source_path, "/result");
+    assert_eq!(candidate.proposal.mappings[0].target_path, "/result");
+}
+
+/// Acceptance scenario 2: two declared capabilities' `outputs.schema` both
+/// structurally satisfy the same downstream need -- the planner enumerates
+/// both complete candidate plans rather than picking one.
+#[test]
+fn plan_workflow_enumerates_ambiguous_candidates_instead_of_choosing() {
+    let producer_a = contract_with_schema(
+        "test.producer-a",
+        "1.0.0",
+        empty_schema(),
+        object_schema(&[("result", "string")], &[]),
+        Vec::new(),
+    );
+    let producer_b = contract_with_schema(
+        "test.producer-b",
+        "1.0.0",
+        empty_schema(),
+        object_schema(&[("result", "string")], &[]),
+        Vec::new(),
+    );
+    let consumer = contract_with_schema(
+        "test.consumer",
+        "1.0.0",
+        object_schema(&[("result", "string")], &["result"]),
+        empty_schema(),
+        Vec::new(),
+    );
+    let registry = registry_with(vec![
+        producer_a.clone(),
+        producer_b.clone(),
+        consumer.clone(),
+    ]);
+    let manifest = manifest_declaring(&[producer_a, producer_b, consumer]);
+    let app_manifest = app_manifest_reference();
+    let target = PlanTarget::Capability {
+        capability_id: "test.consumer".to_string(),
+        capability_version: "1.0.0".to_string(),
+    };
+    let starting_facts = json!({});
+
+    let response = plan_workflow(&PlanRequest {
+        target: &target,
+        starting_facts: &starting_facts,
+        manifest: &manifest,
+        app_manifest: &app_manifest,
+        registry: &registry,
+        workspace_id: "workspace-001",
+    });
+
+    assert!(!response.plan_search_truncated);
+    assert_eq!(response.candidates.len(), 2);
+    let mut producer_ids: Vec<&str> = response
+        .candidates
+        .iter()
+        .map(|candidate| candidate.proposal.nodes[0].capability_id.as_str())
+        .collect();
+    producer_ids.sort_unstable();
+    assert_eq!(producer_ids, ["test.producer-a", "test.producer-b"]);
+}
+
+/// Acceptance scenario 3: no declared capability's `outputs.schema`
+/// structurally satisfies the target -- the planner returns zero candidates
+/// rather than a namespace/verb-name guess.
+#[test]
+fn plan_workflow_returns_zero_candidates_when_nothing_structurally_matches() {
+    let unrelated = contract_with_schema(
+        "test.unrelated",
+        "1.0.0",
+        empty_schema(),
+        object_schema(&[("other_field", "string")], &[]),
+        Vec::new(),
+    );
+    let consumer = contract_with_schema(
+        "test.consumer",
+        "1.0.0",
+        object_schema(&[("result", "string")], &["result"]),
+        empty_schema(),
+        Vec::new(),
+    );
+    let registry = registry_with(vec![unrelated.clone(), consumer.clone()]);
+    let manifest = manifest_declaring(&[unrelated, consumer]);
+    let app_manifest = app_manifest_reference();
+    let target = PlanTarget::Capability {
+        capability_id: "test.consumer".to_string(),
+        capability_version: "1.0.0".to_string(),
+    };
+    let starting_facts = json!({});
+
+    let response = plan_workflow(&PlanRequest {
+        target: &target,
+        starting_facts: &starting_facts,
+        manifest: &manifest,
+        app_manifest: &app_manifest,
+        registry: &registry,
+        workspace_id: "workspace-001",
+    });
+
+    assert!(!response.plan_search_truncated);
+    assert!(response.candidates.is_empty());
+}
+
+/// Acceptance scenario 4: a reviewer corrects the planner's field mapping
+/// before submission -- the corrected mapping, not the planner's guess, is
+/// what actually gets submitted to and validated by the real P1 surface.
+#[test]
+fn plan_workflow_candidate_mapping_can_be_corrected_and_submitted_through_p1() -> Result<(), String>
+{
+    let producer = contract_with_schema(
+        "test.producer",
+        "1.0.0",
+        empty_schema(),
+        object_schema(&[("payload", "string")], &[]),
+        Vec::new(),
+    );
+    let consumer = contract_with_schema(
+        "test.consumer",
+        "1.0.0",
+        object_schema(&[("payload", "string")], &["payload"]),
+        empty_schema(),
+        Vec::new(),
+    );
+    let registry = registry_with(vec![producer.clone(), consumer.clone()]);
+    let manifest = manifest_declaring(&[producer, consumer]);
+    let app_manifest = app_manifest_reference();
+    let target = PlanTarget::Capability {
+        capability_id: "test.consumer".to_string(),
+        capability_version: "1.0.0".to_string(),
+    };
+    let starting_facts = json!({});
+
+    let response = plan_workflow(&PlanRequest {
+        target: &target,
+        starting_facts: &starting_facts,
+        manifest: &manifest,
+        app_manifest: &app_manifest,
+        registry: &registry,
+        workspace_id: "workspace-001",
+    });
+    assert_eq!(response.candidates.len(), 1);
+
+    // The planner guessed source_path "/payload" -- a reviewer corrects it
+    // to a (still valid) explicit path before submission.
+    let mut corrected = response.candidates[0].proposal.clone();
+    corrected.mappings[0].source_path = "/payload".to_string();
+    corrected.mappings[0].target_path = "/payload".to_string();
+    let corrected_json = serde_json::to_string(&corrected).map_err(|error| format!("{error:?}"))?;
+
+    let submission = submit_proposal(
+        &corrected_json,
+        &manifest,
+        &registry,
+        &traverse_contracts::ProposalLimits::default(),
+        &traverse_contracts::SnapshotDigests {
+            manifest_digest: "sha256:manifest-digest".to_string(),
+            registry_digest: "sha256:registry-digest".to_string(),
+            binding_digest: "sha256:binding-digest".to_string(),
+            policy_digest: "sha256:policy-digest".to_string(),
+            budget_digest: "sha256:budget-digest".to_string(),
+        },
+    )
+    .map_err(|error| format!("{error:?}"))?;
+
+    assert!(
+        submission.valid,
+        "corrected planner candidate must validate cleanly against the real P1 surface: {:?}",
+        submission.errors
+    );
+    Ok(())
+}
+
+/// Acceptance scenario 5 (candidate-count bound): more than 5 declared
+/// capabilities independently satisfy the same downstream need -- the
+/// planner returns only 5 and flags `plan_search_truncated: true`.
+#[test]
+fn plan_workflow_truncates_when_more_than_five_candidates_are_valid() {
+    let producers: Vec<CapabilityContract> = (0..6)
+        .map(|index| {
+            contract_with_schema(
+                &format!("test.producer-{index}"),
+                "1.0.0",
+                empty_schema(),
+                object_schema(&[("result", "string")], &[]),
+                Vec::new(),
+            )
+        })
+        .collect();
+    let consumer = contract_with_schema(
+        "test.consumer",
+        "1.0.0",
+        object_schema(&[("result", "string")], &["result"]),
+        empty_schema(),
+        Vec::new(),
+    );
+    let mut all_contracts = producers.clone();
+    all_contracts.push(consumer.clone());
+    let registry = registry_with(all_contracts.clone());
+    let manifest = manifest_declaring(&all_contracts);
+    let app_manifest = app_manifest_reference();
+    let target = PlanTarget::Capability {
+        capability_id: "test.consumer".to_string(),
+        capability_version: "1.0.0".to_string(),
+    };
+    let starting_facts = json!({});
+
+    let response = plan_workflow(&PlanRequest {
+        target: &target,
+        starting_facts: &starting_facts,
+        manifest: &manifest,
+        app_manifest: &app_manifest,
+        registry: &registry,
+        workspace_id: "workspace-001",
+    });
+
+    assert!(response.plan_search_truncated);
+    assert_eq!(response.candidates.len(), 5);
+}
+
+/// Acceptance scenario 5 (node-depth bound): the only structurally valid
+/// chain to the target needs 9 nodes, one past the 8-node-deep bound -- the
+/// planner returns the bounded (empty) subset plus `plan_search_truncated:
+/// true`, never an unbounded result or a silent failure.
+#[test]
+fn plan_workflow_truncates_when_the_only_valid_chain_exceeds_the_node_depth_bound() {
+    // A 9-node linear chain: p0 (root, satisfied by starting facts) -> p1
+    // -> ... -> p8 (the target). Each link needs exactly the prior node's
+    // single output field.
+    let mut contracts = Vec::new();
+    for index in 0..9 {
+        let field = format!("field{index}");
+        let next_field = format!("field{}", index + 1);
+        let inputs = object_schema(&[(&field, "string")], &[&field]);
+        let outputs = object_schema(&[(&next_field, "string")], &[]);
+        contracts.push(contract_with_schema(
+            &format!("test.chain-{index}"),
+            "1.0.0",
+            inputs,
+            outputs,
+            Vec::new(),
+        ));
+    }
+    let registry = registry_with(contracts.clone());
+    let manifest = manifest_declaring(&contracts);
+    let app_manifest = app_manifest_reference();
+    let target = PlanTarget::Capability {
+        capability_id: "test.chain-8".to_string(),
+        capability_version: "1.0.0".to_string(),
+    };
+    let starting_facts = json!({"field0": "seed"});
+
+    let response = plan_workflow(&PlanRequest {
+        target: &target,
+        starting_facts: &starting_facts,
+        manifest: &manifest,
+        app_manifest: &app_manifest,
+        registry: &registry,
+        workspace_id: "workspace-001",
+    });
+
+    assert!(response.plan_search_truncated);
+    assert!(response.candidates.is_empty());
+}
+
+/// The `EmitsEvent` target form (spec 113 FR-001): the planner selects the
+/// declared capability whose contract emits the requested event type.
+#[test]
+fn plan_workflow_matches_target_by_emitted_event_type() {
+    let emitter = contract_with_schema(
+        "test.emitter",
+        "1.0.0",
+        empty_schema(),
+        empty_schema(),
+        vec![EventReference {
+            event_id: "test.something-happened".to_string(),
+            version: "1.0.0".to_string(),
+        }],
+    );
+    let registry = registry_with(vec![emitter.clone()]);
+    let manifest = manifest_declaring(&[emitter]);
+    let app_manifest = app_manifest_reference();
+    let target = PlanTarget::EmitsEvent {
+        event_type: "test.something-happened".to_string(),
+    };
+    let starting_facts = json!({});
+
+    let response = plan_workflow(&PlanRequest {
+        target: &target,
+        starting_facts: &starting_facts,
+        manifest: &manifest,
+        app_manifest: &app_manifest,
+        registry: &registry,
+        workspace_id: "workspace-001",
+    });
+
+    assert!(!response.plan_search_truncated);
+    assert_eq!(response.candidates.len(), 1);
+    assert_eq!(
+        response.candidates[0].proposal.nodes[0].capability_id,
+        "test.emitter"
+    );
+}
+
+/// A 0-hop candidate: the target's own required inputs are all satisfiable
+/// directly from starting facts, producing `InitialInput` mappings at the
+/// chain's root. Also exercises every JSON-Schema `type` the starting-facts
+/// synthesis maps a value to (null/boolean/integer/number/string/array/
+/// object), since it types every key in `starting_facts`, not only the ones
+/// a required property actually names.
+#[test]
+fn plan_workflow_root_node_maps_directly_from_richly_typed_starting_facts() {
+    let target_capability = contract_with_schema(
+        "test.direct",
+        "1.0.0",
+        object_schema(&[("text_field", "string")], &["text_field"]),
+        empty_schema(),
+        Vec::new(),
+    );
+    let registry = registry_with(vec![target_capability.clone()]);
+    let manifest = manifest_declaring(&[target_capability]);
+    let app_manifest = app_manifest_reference();
+    let target = PlanTarget::Capability {
+        capability_id: "test.direct".to_string(),
+        capability_version: "1.0.0".to_string(),
+    };
+    let starting_facts = json!({
+        "text_field": "value",
+        "flag_field": true,
+        "int_field": 5,
+        "float_field": 1.5,
+        "array_field": [1, 2],
+        "object_field": {},
+        "null_field": null,
+    });
+
+    let response = plan_workflow(&PlanRequest {
+        target: &target,
+        starting_facts: &starting_facts,
+        manifest: &manifest,
+        app_manifest: &app_manifest,
+        registry: &registry,
+        workspace_id: "workspace-001",
+    });
+
+    assert!(!response.plan_search_truncated);
+    assert_eq!(response.candidates.len(), 1);
+    let candidate = &response.candidates[0];
+    assert_eq!(candidate.proposal.nodes.len(), 1);
+    assert!(candidate.proposal.edges.is_empty());
+    assert_eq!(candidate.proposal.mappings.len(), 1);
+    assert_eq!(
+        candidate.proposal.mappings[0].source,
+        ContractMappingSource::InitialInput
+    );
+    assert_eq!(candidate.proposal.mappings[0].source_path, "/text_field");
+}
+
+/// A manifest-declared component that was never actually registered in the
+/// capability registry must be silently excluded from the candidate universe
+/// rather than crashing the planner or being placed in a node.
+#[test]
+fn plan_workflow_skips_a_declared_component_that_is_not_registered() {
+    let producer = contract_with_schema(
+        "test.producer",
+        "1.0.0",
+        empty_schema(),
+        object_schema(&[("result", "string")], &[]),
+        Vec::new(),
+    );
+    let consumer = contract_with_schema(
+        "test.consumer",
+        "1.0.0",
+        object_schema(&[("result", "string")], &["result"]),
+        empty_schema(),
+        Vec::new(),
+    );
+    // Registered in the registry, so both resolve.
+    let registry = registry_with(vec![producer.clone(), consumer.clone()]);
+    // Declared in the manifest too, plus one extra component the registry
+    // has never seen.
+    let ghost = contract_with_schema(
+        "test.ghost",
+        "9.9.9",
+        empty_schema(),
+        empty_schema(),
+        Vec::new(),
+    );
+    let manifest = manifest_declaring(&[producer, consumer, ghost]);
+    let app_manifest = app_manifest_reference();
+    let target = PlanTarget::Capability {
+        capability_id: "test.consumer".to_string(),
+        capability_version: "1.0.0".to_string(),
+    };
+    let starting_facts = json!({});
+
+    let response = plan_workflow(&PlanRequest {
+        target: &target,
+        starting_facts: &starting_facts,
+        manifest: &manifest,
+        app_manifest: &app_manifest,
+        registry: &registry,
+        workspace_id: "workspace-001",
+    });
+
+    assert!(!response.plan_search_truncated);
+    assert_eq!(response.candidates.len(), 1);
+    assert_eq!(response.candidates[0].proposal.nodes.len(), 2);
+    assert!(
+        response.candidates.iter().all(|candidate| candidate
+            .proposal
+            .nodes
+            .iter()
+            .all(|node| node.capability_id != "test.ghost")),
+        "an unregistered manifest component must never appear in a candidate node"
+    );
+}
+
+/// Spec 113 FR-008: planning must be pure/read-only -- calling it twice with
+/// identical inputs must produce byte-identical candidates (no registry,
+/// manifest, or catalog mutation, no hidden nondeterminism).
+#[test]
+fn plan_workflow_is_deterministic_across_repeated_calls() -> Result<(), String> {
+    let producer = contract_with_schema(
+        "test.producer",
+        "1.0.0",
+        empty_schema(),
+        object_schema(&[("result", "string")], &[]),
+        Vec::new(),
+    );
+    let consumer = contract_with_schema(
+        "test.consumer",
+        "1.0.0",
+        object_schema(&[("result", "string")], &["result"]),
+        empty_schema(),
+        Vec::new(),
+    );
+    let registry = registry_with(vec![producer.clone(), consumer.clone()]);
+    let manifest = manifest_declaring(&[producer, consumer]);
+    let app_manifest = app_manifest_reference();
+    let target = PlanTarget::Capability {
+        capability_id: "test.consumer".to_string(),
+        capability_version: "1.0.0".to_string(),
+    };
+    let starting_facts = json!({});
+    let request = PlanRequest {
+        target: &target,
+        starting_facts: &starting_facts,
+        manifest: &manifest,
+        app_manifest: &app_manifest,
+        registry: &registry,
+        workspace_id: "workspace-001",
+    };
+
+    let first = plan_workflow(&request);
+    let second = plan_workflow(&request);
+
+    let first_json =
+        serde_json::to_string(&first.candidates).map_err(|error| format!("{error:?}"))?;
+    let second_json =
+        serde_json::to_string(&second.candidates).map_err(|error| format!("{error:?}"))?;
+    assert_eq!(first_json, second_json);
+    assert_eq!(first.plan_search_truncated, second.plan_search_truncated);
+    Ok(())
+}


### PR DESCRIPTION
## Governing Spec

- `113-declarative-workflow-planning`

## Project Item

https://github.com/traverse-framework/traverse/issues/1098

## Summary

Implements P0 of `108-governed-runtime-workflow-composition`: a new public
MCP tool, `traverse_mcp::tools::workflow_plan::plan_workflow`, governed by
`113-declarative-workflow-planning` (v0.2.0, Decision 62).

Given a structured target (an exact capability id/version, or a declared
event type a capability's contract `emits`) and a starting fact set, it does
a bounded backward search over the capabilities declared in the target
application manifest and returns candidate `WorkflowProposal`s already
shaped for submission to the existing P1 surface
(`tools::proposals::submit_proposal`).

- **FR-001**: target is a structured capability id/version or event type,
  starting facts are a plain JSON object -- no natural-language input, no
  hosted model dependency.
- **FR-002**: a producer chains to a consumer only when every property in
  the consumer's `inputs.schema.required` exists in the producer's
  `outputs.schema.properties` with the same declared JSON `type`. Root nodes
  are satisfied the same way against a schema synthesized from the starting
  facts' own runtime types -- one matching primitive for both cases, per the
  spec's own note that this is the same signal FR-005's mapping step already
  computes.
- **FR-003**: when more than one declared capability's output structurally
  satisfies the same downstream need, every resulting complete chain is
  enumerated as a separate candidate -- never picked automatically.
- **FR-004**: bounded to 5 complete candidate plans, 8 nodes deep, plus a
  defensive total-search-call cap so a pathological declared-capability
  graph can't make one call do unbounded work. Exceeding either bound
  returns the bounded subset plus `plan_search_truncated: true`, never a
  silent partial result.
- **FR-005**: each candidate's field mappings are best-effort JSON-pointer
  guesses, always flagged `mapping_unconfirmed` -- never cleared by the
  planner.
- **FR-006**: candidates are real `WorkflowProposal` values (not a
  planner-specific shape), submittable as-is once reviewed. Verified end to
  end: a test takes a planner candidate, corrects its guessed mapping, and
  submits it through the real `tools::proposals::submit_proposal` /
  `validate_proposal_against_host_state` cross-validation path.
- **FR-007**: exposed as a plain, fully-tested public Rust function
  (`plan_workflow`), matching this crate's established `tools::proposals`/
  `tools::capabilities` pattern (a callable public-MCP-tool function, not a
  string-keyed dispatch entry -- there is no such table anywhere in this
  crate for any existing P1 tool either).
- **FR-008**: planning only reads through shared `&CapabilityRegistry`/
  `&ApplicationBundleManifest` references -- no registry, manifest, or
  catalog mutation anywhere in the module.

Search is scoped to capabilities declared as components in the target
application manifest (not the whole registry), matching the same
"declared set is the only permitted set" check P1's own cross-validation
already applies -- this is what keeps a returned candidate actually
submittable per FR-006, and a declared-but-unregistered component is safely
skipped rather than crashing planning (regression-tested).

## Changes

- `crates/traverse-mcp/src/tools/workflow_plan.rs`: the planner (bounded
  backward search + best-effort mapping generation).
- `crates/traverse-mcp/src/tools/mod.rs`: exports the new module.
- `crates/traverse-mcp/tests/workflow_plan_tests.rs`: covers all 5 of spec
  113's acceptance scenarios (unique candidate, enumerated ambiguous
  candidates, zero candidates for a structurally unreachable target,
  reviewer-corrected mapping round-tripping through the real P1 surface,
  both truncation bounds), plus the `EmitsEvent` target form, an
  unregistered-component safety check, richly-typed starting facts, and a
  determinism check (pure/read-only per FR-008).

## Out of scope

Per spec 113's own scope: natural-language goal interpretation, a hosted
planner model, automatic proposal submission or execution, ambiguity
auto-resolution, and any change to how `109`-`112` validate, authorize, or
execute a submitted proposal. This module never calls into any of those.

## Validation

- [x] Spec alignment checked (declared `113-declarative-workflow-planning`
      above; covers every changed path)
- [x] Contract alignment checked (no `CapabilityContract`/wire-format
      change; reuses the existing P1 `WorkflowProposal` types unchanged)
- [x] Tests updated and passing (`cargo test -p traverse-mcp` — all tests
      pass, including 10 new `workflow_plan_tests`)
- [x] Core coverage preserved (`cargo llvm-cov -p traverse-mcp` with brew
      llvm: `tools/workflow_plan.rs` at 98.5% lines locally, only the
      defensive total-search-call safety branch and one non-executable
      brace line unreached; this crate's local baseline on unmodified
      `main` already reads below its 98% gate with the same toolchain here
      — documented tooling-version drift, not a regression: real CI's
      `coverage-gate` job is green on `main` at the commit this branches
      from, and this change raises the local total from 97.22% to 97.31%)
- [x] Required validation gates passing
      (`cargo clippy -p traverse-mcp -p traverse-contracts --all-targets` —
      clean; `cargo fmt --all --check` — clean)

Fixes #1098.
