### PR TITLE
docs(governance): approve ADR-0027 and spec 527 (durable trace/audit persistence)

### DIFF
--- a/docs/adr/0027-durable-trace-audit-persistence.md
+++ b/docs/adr/0027-durable-trace-audit-persistence.md
@@ -1,8 +1,9 @@
 # ADR-0027: Host-Owned Durable Trace and Audit Persistence
 
-- Status: Proposed
+- Status: Accepted
 - Date: 2026-07-30
-- Governing draft: `527-durable-trace-productization`
+- Approved: 2026-08-24
+- Governing spec: `527-durable-trace-productization`
 
 ## Decision
 
@@ -24,4 +25,5 @@ workspace-scoped retention or deletion is oldest-first and emits
   behavior have deterministic, testable boundaries.
 - Private trace persistence and remote journal synchronization remain separate
   governed capabilities.
-- This ADR and its draft require maintainer approval before implementation.
+- Approved 2026-08-24; spec `527-durable-trace-productization` is registered
+  as approved and implementation may proceed.

--- a/docs/decision-log.md
+++ b/docs/decision-log.md
@@ -2452,3 +2452,58 @@ rather than by backfill (registry decision-log entry 68, cross-referencing
 this entry). `traverse#1098`'s `blocked by registry#305` relationship is
 removed — it is now unblocked by this spec amendment landing, not by any
 registry-side work.
+
+## Decision 63: Approve ADR-0027 and Spec 527 (Host-Owned Durable Trace and Audit Persistence)
+
+- **Date**: 2026-08-24
+- **Status**: Accepted
+- **Governing spec**: `527-durable-trace-productization` (newly approved), ADR-0027 (Accepted)
+- **Related issues**: `#1093` (partial unblock — see Outcome), `#847` (spec origin)
+- **Origin**: A backlog-validity sweep across traverse + registry (this session) confirmed `#1093`'s stated P1/P2 half of its blocker is resolved (both approved and implemented this session) but its "approved durable host-owned state/trace substrate" half was still real: ADR-0027 and its governing draft spec `527-durable-trace-productization` were sitting at `Proposed`/`Draft`, dated 2026-07-30, with no open questions left unresolved in either document. Owner explicitly requested approval.
+
+### Context
+
+Spec `527` (authored from issue `#847`) defines the host-authorized durable
+trace-journal policy for production embeds: safe evidence persists across
+restart, is retained within deterministic limits (30 days or 10,000 records
+per workspace, oldest-first), and is exported only as explicitly redacted
+evidence. It is additive to the already-approved `079-durable-trace-journal`,
+scoped narrowly to `crates/traverse-runtime/src/trace_journal.rs` and a new
+export schema, and explicitly excludes encryption/key lifecycle, remote
+sync, and DataStore ownership changes. ADR-0027 records the same decision at
+the architecture level: production hosts, not Traverse, own the journal
+root, authorization, keys, tenancy, retention, and deletion authority.
+
+### Decision
+
+Approve both documents as written, no changes: ADR-0027 status
+`Proposed` -> `Accepted`; spec `527` status `Draft` -> `Approved` and
+registered in `specs/governance/approved-specs.json` (version `1.0.0`,
+`immutable: true`, governs the four paths its own "Compatibility and
+Governed Files" section already named). Neither document needed a
+`/brainstorm` pass first — both were already complete, self-consistent, and
+narrowly scoped when written; the only missing step was the owner's
+sign-off itself, which is not something an agent grants on its own
+judgment regardless of how well-formed a draft looks.
+
+### Alternatives Considered
+
+- Defer approval pending a fresh `/brainstorm` review — rejected; neither
+  document had an open question, an unresolved alternative, or a scope gap
+  in its own text, and the owner asked directly for approval, not review.
+- Approve only the ADR, leave spec `527` in Draft — rejected; the ADR
+  explicitly names `527` as its "governing draft" and states "this ADR and
+  its draft require maintainer approval before implementation" as one
+  combined gate. Approving one without the other leaves nothing
+  independently implementable.
+
+### Outcome
+
+ADR-0027 and spec `527-durable-trace-productization` are both Approved.
+This resolves the trace half of `#1093`'s stated blocker
+("approved durable host-owned state/trace substrate"); the checkpoint/state
+half (P3's own "authenticated secret-free checkpoint binds all governing
+snapshots" requirement) is a distinct concern from a trace journal and is
+not addressed by this approval — `#1093` is not yet fully unblocked, and no
+existing Proposed ADR was confirmed to cover checkpoint/state
+specifically. `#1093` left `Blocked` pending that remaining gap.

--- a/specs/527-durable-trace-productization/spec.md
+++ b/specs/527-durable-trace-productization/spec.md
@@ -1,7 +1,7 @@
 # Feature Specification: Durable Trace Productization
 
 **Feature Branch**: `codex/issue-847-durable-trace-productization`
-**Status**: Draft — successor specification requiring maintainer approval before implementation.
+**Status**: Approved (2026-08-24), per ADR-0027.
 **Input**: Issue #847, Decision 38, `524-production-app-readiness`, and Spec 079.
 
 ## Purpose

--- a/specs/governance/approved-specs.json
+++ b/specs/governance/approved-specs.json
@@ -1498,6 +1498,19 @@
         "crates/traverse-mcp/",
         "specs/113-declarative-workflow-planning/"
       ]
+    },
+    {
+      "id": "527-durable-trace-productization",
+      "version": "1.0.0",
+      "status": "approved",
+      "immutable": true,
+      "path": "specs/527-durable-trace-productization/spec.md",
+      "governs": [
+        "crates/traverse-runtime/src/trace_journal.rs",
+        "contracts/trace/durable-trace-export.schema.json",
+        "docs/adr/0027-durable-trace-audit-persistence.md",
+        "specs/527-durable-trace-productization/"
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary

Approves ADR-0027 (Host-Owned Durable Trace and Audit Persistence) and its
governing draft spec `527-durable-trace-productization`, both dated
2026-07-30 and complete/self-consistent since then — the only missing step
was owner sign-off, requested directly this session as part of a backlog
validity sweep that found `#1093`'s "approved durable host-owned state/trace
substrate" blocker half still unresolved.

## Governing Spec

- 527-durable-trace-productization
- 070-runtime-event-sink-boundary
- 004-spec-alignment-gate

## Project Item

N/A — governance approval, not a Project 1 status change. Related: `#1093`
(partially unblocked — see Decision 63), `#847` (spec origin).

## Validation

- Manually reviewed ADR-0027 and spec 527 against the house format (no
  content changes beyond status lines and the registry entry).
- `python3 -c "import json; json.load(open('specs/governance/approved-specs.json'))"` — valid JSON.
- `bash scripts/ci/pr_body_check.sh <this file>`
- `BASE_SHA=origin/main HEAD_SHA=HEAD bash scripts/ci/spec_alignment_check.sh <this file>`
