### PR TITLE
feat(runtime): implement durable trace journal (spec 079-durable-trace-journal)

### DIFF
--- a/crates/traverse-runtime/src/lib.rs
+++ b/crates/traverse-runtime/src/lib.rs
@@ -1937,6 +1937,15 @@ fn map_router_error(
             ExecutionFailureReason::ExecutionFailed,
             Vec::new(),
         ),
+        RouterError::DurableTraceWriteFailed(message) => (
+            runtime_error(
+                RuntimeErrorCode::ExecutionFailed,
+                "the execution trace could not be durably written",
+                json!({"code": "durable_trace_write_failed", "detail": message}),
+            ),
+            ExecutionFailureReason::ExecutionFailed,
+            Vec::new(),
+        ),
     }
 }
 
@@ -3601,6 +3610,12 @@ mod tests {
             ),
         ]));
         assert_eq!(code.code, RuntimeErrorCode::ContractViolation);
+        assert_eq!(reason, ExecutionFailureReason::ExecutionFailed);
+
+        let (code, reason, _) = super::map_router_error(&RouterError::DurableTraceWriteFailed(
+            "simulated durable trace write failure".to_string(),
+        ));
+        assert_eq!(code.code, RuntimeErrorCode::ExecutionFailed);
         assert_eq!(reason, ExecutionFailureReason::ExecutionFailed);
     }
 

--- a/crates/traverse-runtime/src/router/mod.rs
+++ b/crates/traverse-runtime/src/router/mod.rs
@@ -26,7 +26,10 @@ use crate::{
         PlacementConstraintEvaluator, PlacementDecision, PlacementError, PlacementRequest,
         RuntimeSnapshot,
     },
-    trace::{PrivateTraceEntry, PublicTraceEntry, TraceOutcome, TraceStore, new_trace_id_and_time},
+    trace::{
+        DurableTraceConfig, PrivateTraceEntry, PublicTraceEntry, TraceOutcome, TraceStore,
+        new_trace_id_and_time,
+    },
 };
 
 use traverse_contracts::ExecutionTarget;
@@ -71,6 +74,9 @@ pub enum RouterError {
     ContractViolation(Vec<ViolationRecord>),
     /// The trace store lock was poisoned.
     TraceLockPoisoned,
+    /// The trace could not be durably written and this router is configured
+    /// to fail closed on that condition (spec 079 FR-002).
+    DurableTraceWriteFailed(String),
 }
 
 impl std::fmt::Display for RouterError {
@@ -83,6 +89,9 @@ impl std::fmt::Display for RouterError {
                 write!(f, "contract violation: {} violation(s)", violations.len())
             }
             Self::TraceLockPoisoned => write!(f, "trace store lock is poisoned"),
+            Self::DurableTraceWriteFailed(msg) => {
+                write!(f, "durable trace write failed: {msg}")
+            }
         }
     }
 }
@@ -117,10 +126,13 @@ pub struct PlacementRouter {
     executor_registry: CapabilityExecutorRegistry,
     trace_store: Arc<Mutex<TraceStore>>,
     event_broker: Arc<dyn EventBroker>,
+    durable_trace: Option<DurableTraceConfig>,
 }
 
 impl PlacementRouter {
-    /// Construct a new [`PlacementRouter`] from injected dependencies.
+    /// Construct a new [`PlacementRouter`] from injected dependencies. Traces
+    /// are recorded to `trace_store` only (in-memory, process-local) unless
+    /// [`Self::with_durable_trace`] is also called.
     #[must_use]
     pub fn new(
         evaluator: PlacementConstraintEvaluator,
@@ -133,7 +145,17 @@ impl PlacementRouter {
             executor_registry,
             trace_store,
             event_broker,
+            durable_trace: None,
         }
+    }
+
+    /// Additionally persist every recorded trace through a durable trace
+    /// journal (spec `079-durable-trace-journal`). Without this, traces are
+    /// recorded to `trace_store` only and are lost on restart.
+    #[must_use]
+    pub fn with_durable_trace(mut self, durable_trace: DurableTraceConfig) -> Self {
+        self.durable_trace = Some(durable_trace);
+        self
     }
 
     /// Execute a capability end-to-end.
@@ -221,6 +243,17 @@ impl PlacementRouter {
         let output_str = serde_json::to_string(&output).unwrap_or_default();
         let private_entry =
             PrivateTraceEntry::new(trace_id.clone(), &input_str, &output_str, duration_ms);
+
+        // Durable write gates the in-memory record when the caller is
+        // configured to fail closed (spec 079 FR-002): a trace that could
+        // not be durably written is not silently kept in-memory-only for an
+        // auditable execution.
+        if let Some(durable) = &self.durable_trace
+            && let Err(error) = durable.sink.record(&public_entry, Some(&private_entry))
+            && durable.fail_closed
+        {
+            return Err(RouterError::DurableTraceWriteFailed(error.to_string()));
+        }
 
         {
             let mut store = self

--- a/crates/traverse-runtime/src/trace/durable.rs
+++ b/crates/traverse-runtime/src/trace/durable.rs
@@ -1,0 +1,287 @@
+//! Durable, append-only, per-workspace persistence for execution traces.
+//!
+//! Governed by spec `079-durable-trace-journal` (`specs/518-durable-trace-journal/spec.md`,
+//! ADR-0017). Reuses the existing [`crate::events::DurableEventJournal`]
+//! rather than a second storage engine: trace records are canonical JSON
+//! Lines, appended and `fsync`-committed exactly like domain events (FR-001),
+//! and inherit that journal's existing recovery semantics (FR-003, spec 066
+//! FR-009: discard only an incomplete final record, fail loudly on any other
+//! corruption) and deterministic oldest-first, whole-segment pruning
+//! (FR-005) unchanged. "Per workspace" retention (FR-005) is achieved by
+//! opening one journal per workspace root -- a caller opens a
+//! [`DurableTraceJournal`] at a workspace-scoped directory, so pruning is
+//! inherently workspace-isolated without threading a `workspace_id` field
+//! through every trace record, mirroring how [`crate::data_store`] is
+//! host-opened at an explicit root rather than auto-wired by [`crate::Runtime`].
+//!
+//! This is an additive durability layer alongside [`super::TraceStore`]
+//! (spec `012-execution-trace-tiered`'s process-local, in-memory store) and
+//! [`super::store`]/`517-embedded-trace-api`'s process-local query surface --
+//! it does not replace or change either.
+
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
+
+use serde::{Deserialize, Serialize};
+
+use crate::events::{
+    BrokerClock, DurableEventJournal, JournalConfig, JournalError, LifecycleStatus, SystemClock,
+    TraverseEvent,
+};
+
+use super::{PrivateTraceEntry, PublicTraceEntry};
+
+const TRACE_RECORD_EVENT_TYPE: &str = "dev.traverse.trace.recorded";
+const TRACE_RECORD_OWNER: &str = "traverse-runtime";
+const TRACE_RECORD_VERSION: &str = "1.0.0";
+const RECOVERY_REPLAY_PAGE_SIZE: usize = 256;
+
+/// Errors surfaced by the durable trace journal.
+#[derive(Debug, PartialEq, Eq)]
+pub enum TraceJournalError {
+    /// The underlying event journal failed.
+    Journal(JournalError),
+    /// A trace record could not be serialized for durable persistence.
+    Serialize(String),
+    /// A durably-recorded trace record could not be deserialized during
+    /// recovery.
+    Deserialize(String),
+    /// A durable-trace lock was poisoned by a prior panic.
+    LockPoisoned,
+}
+
+impl std::fmt::Display for TraceJournalError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Journal(error) => write!(f, "trace journal failure: {error}"),
+            Self::Serialize(message) => write!(f, "trace record serialization failed: {message}"),
+            Self::Deserialize(message) => {
+                write!(f, "durable trace record deserialization failed: {message}")
+            }
+            Self::LockPoisoned => write!(f, "durable trace journal lock is poisoned"),
+        }
+    }
+}
+
+impl std::error::Error for TraceJournalError {}
+
+impl From<JournalError> for TraceJournalError {
+    fn from(error: JournalError) -> Self {
+        Self::Journal(error)
+    }
+}
+
+/// One durable trace record: the same public/private pair [`super::TraceStore`]
+/// holds in memory, persisted together so recovery never has to guess
+/// whether a private entry's matching public entry survived. Still carries
+/// only non-sensitive metadata and hashes (FR-004) -- exactly what
+/// [`PublicTraceEntry`]/[`PrivateTraceEntry`] already guarantee by
+/// construction; this wrapper adds no new fields.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct DurableTraceRecord {
+    public: PublicTraceEntry,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    private: Option<PrivateTraceEntry>,
+}
+
+/// Deterministic evidence of what survived recovery when a
+/// [`DurableTraceJournal`] was opened (FR-003). A frozen snapshot taken at
+/// open time -- it is not updated by later [`DurableTraceJournal::record`]
+/// calls in the same session, so it always answers "what did recovery find,"
+/// not "what has this session written since." An incomplete final record
+/// left by a crash mid-write is silently absent here (discarded by the
+/// underlying journal's recovery) rather than reconstructed: recovery MUST
+/// NOT invent trace evidence (ADR-0017).
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct TraceRecoveryReport {
+    pub recovered_trace_ids: Vec<String>,
+}
+
+/// Evidence produced by [`DurableTraceJournal::prune`] (FR-005).
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct TracePrunedEvidence {
+    pub workspace_root: PathBuf,
+    pub deleted_segment_paths: Vec<PathBuf>,
+}
+
+/// Durable, per-workspace persistence layer for execution traces.
+pub struct DurableTraceJournal {
+    root: PathBuf,
+    journal: DurableEventJournal,
+    recovery: TraceRecoveryReport,
+}
+
+impl DurableTraceJournal {
+    /// Opens (or creates) a durable trace journal rooted at `root`, using the
+    /// real system clock for segment rollover/retention timing.
+    ///
+    /// # Errors
+    ///
+    /// See [`Self::open_with_clock`].
+    pub fn open(root: &Path, config: JournalConfig) -> Result<Self, TraceJournalError> {
+        Self::open_with_clock(root, config, Arc::new(SystemClock))
+    }
+
+    /// As [`Self::open`], with an injectable clock for deterministic tests.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`TraceJournalError::Journal`] when the journal cannot be
+    /// opened, including when a completed (non-final) on-disk record is
+    /// corrupt (spec 066 FR-009: fail loudly rather than silently discard).
+    /// Returns [`TraceJournalError::Deserialize`] when a durably-recorded
+    /// trace record cannot be parsed back during the open-time recovery scan.
+    pub fn open_with_clock(
+        root: &Path,
+        config: JournalConfig,
+        clock: Arc<dyn BrokerClock>,
+    ) -> Result<Self, TraceJournalError> {
+        let journal = DurableEventJournal::open(root, config, clock)?;
+        let recovery = Self::compute_recovery_report(&journal)?;
+        Ok(Self {
+            root: root.to_path_buf(),
+            journal,
+            recovery,
+        })
+    }
+
+    fn compute_recovery_report(
+        journal: &DurableEventJournal,
+    ) -> Result<TraceRecoveryReport, TraceJournalError> {
+        let mut recovered_trace_ids = Vec::new();
+        let mut cursor = "0".to_string();
+        loop {
+            let page = journal.replay_from(&cursor, RECOVERY_REPLAY_PAGE_SIZE)?;
+            if page.is_empty() {
+                break;
+            }
+            for (next_cursor, event) in &page {
+                cursor.clone_from(next_cursor);
+                let record: DurableTraceRecord = serde_json::from_value(event.data.clone())
+                    .map_err(|error| TraceJournalError::Deserialize(error.to_string()))?;
+                recovered_trace_ids.push(record.public.id);
+            }
+        }
+        Ok(TraceRecoveryReport {
+            recovered_trace_ids,
+        })
+    }
+
+    /// Deterministic evidence of what survived recovery when this journal was
+    /// opened (FR-003).
+    #[must_use]
+    pub fn recovery_report(&self) -> &TraceRecoveryReport {
+        &self.recovery
+    }
+
+    /// Durably appends one trace record, `fsync`-committed before returning
+    /// (FR-001). Returns the journal cursor for the appended record.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`TraceJournalError`] when the durable write fails.
+    pub fn record(
+        &mut self,
+        public: &PublicTraceEntry,
+        private: Option<&PrivateTraceEntry>,
+    ) -> Result<String, TraceJournalError> {
+        let record = DurableTraceRecord {
+            public: public.clone(),
+            private: private.cloned(),
+        };
+        let data = serde_json::to_value(&record)
+            .map_err(|error| TraceJournalError::Serialize(error.to_string()))?;
+        let event = TraverseEvent {
+            id: public.id.clone(),
+            source: public.source.clone(),
+            event_type: TRACE_RECORD_EVENT_TYPE.to_string(),
+            datacontenttype: "application/json".to_string(),
+            time: public.time.clone(),
+            data,
+            owner: TRACE_RECORD_OWNER.to_string(),
+            version: TRACE_RECORD_VERSION.to_string(),
+            lifecycle_status: LifecycleStatus::Active,
+            deduplication_id: None,
+            ordering_scope: None,
+            correlation_id: None,
+            causation_id: None,
+            subject_id: None,
+            actor_id: None,
+        };
+        Ok(self.journal.append(&event)?)
+    }
+
+    /// Reclaims retained trace history past the configured age/size bounds,
+    /// deterministic oldest segment first, never touching the active
+    /// (currently-being-written) segment (FR-005).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`TraceJournalError`] when a segment cannot be removed.
+    pub fn prune(&mut self) -> Result<TracePrunedEvidence, TraceJournalError> {
+        let deleted_segment_paths = self.journal.prune()?;
+        Ok(TracePrunedEvidence {
+            workspace_root: self.root.clone(),
+            deleted_segment_paths,
+        })
+    }
+}
+
+/// Durable persistence sink for execution traces. Implemented for
+/// `Mutex<DurableTraceJournal>` for real persistence; test doubles may
+/// implement this directly to exercise a caller's fail-closed behavior
+/// (FR-002) without real filesystem fault injection.
+pub trait TraceDurabilitySink: Send + Sync {
+    /// # Errors
+    ///
+    /// Returns [`TraceJournalError`] when the durable write fails.
+    fn record(
+        &self,
+        public: &PublicTraceEntry,
+        private: Option<&PrivateTraceEntry>,
+    ) -> Result<String, TraceJournalError>;
+}
+
+impl TraceDurabilitySink for Mutex<DurableTraceJournal> {
+    fn record(
+        &self,
+        public: &PublicTraceEntry,
+        private: Option<&PrivateTraceEntry>,
+    ) -> Result<String, TraceJournalError> {
+        let mut journal = self.lock().map_err(|_| TraceJournalError::LockPoisoned)?;
+        journal.record(public, private)
+    }
+}
+
+/// A durable-trace sink plus the caller's audit posture for it (FR-002).
+pub struct DurableTraceConfig {
+    pub sink: Arc<dyn TraceDurabilitySink>,
+    /// When `true`, a durable-write failure fails the whole execution rather
+    /// than continuing with an in-memory-only trace ("auditable execution
+    /// MUST fail before returning success when its trace cannot be durably
+    /// written," FR-002). Callers set this from their own audit posture --
+    /// e.g. `RuntimeSecurityMode::Production` -- non-audited local
+    /// development work may opt out by setting this `false` (ADR-0017).
+    pub fail_closed: bool,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn trace_journal_error_display_covers_every_variant() {
+        let cases: Vec<TraceJournalError> = vec![
+            TraceJournalError::Journal(JournalError::InvalidCursor("bad cursor".to_string())),
+            TraceJournalError::Serialize("boom".to_string()),
+            TraceJournalError::Deserialize("boom".to_string()),
+            TraceJournalError::LockPoisoned,
+        ];
+        for error in &cases {
+            assert!(
+                !error.to_string().is_empty(),
+                "Display must produce a non-empty string for {error:?}"
+            );
+        }
+    }
+}

--- a/crates/traverse-runtime/src/trace/mod.rs
+++ b/crates/traverse-runtime/src/trace/mod.rs
@@ -1,11 +1,18 @@
 //! Two-tier execution trace: public (`CloudEvents`) + private (hashed).
 //!
-//! Governed by spec `012-execution-trace-tiered`.
+//! Governed by spec `012-execution-trace-tiered`. The additive durable
+//! persistence layer in [`durable`] is governed by spec
+//! `079-durable-trace-journal`.
 
+pub mod durable;
 pub mod private;
 pub mod public;
 pub mod store;
 
+pub use durable::{
+    DurableTraceConfig, DurableTraceJournal, TraceDurabilitySink, TraceJournalError,
+    TracePrunedEvidence, TraceRecoveryReport,
+};
 pub use private::PrivateTraceEntry;
 pub use public::{PublicTraceEntry, TraceOutcome};
 pub use store::TraceStore;

--- a/crates/traverse-runtime/tests/durable_trace_journal_tests.rs
+++ b/crates/traverse-runtime/tests/durable_trace_journal_tests.rs
@@ -1,0 +1,312 @@
+//! Governed by spec `079-durable-trace-journal`.
+//!
+//! Integration tests for [`traverse_runtime::trace::DurableTraceJournal`]:
+//! durable fsync-committed writes surviving a full close+reopen (FR-001),
+//! recovery discarding only an incomplete final record while failing loudly
+//! on any other corruption (FR-003), durable records carrying only
+//! non-sensitive metadata and hashes (FR-004), and deterministic
+//! oldest-first, per-workspace-root retention (FR-005).
+
+use std::fs;
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, SystemTime};
+
+use uuid::Uuid;
+
+use traverse_runtime::events::{BrokerClock, JournalConfig, JournalError};
+use traverse_runtime::trace::{
+    DurableTraceJournal, PrivateTraceEntry, PublicTraceEntry, TraceJournalError, TraceOutcome,
+};
+
+fn test_root(name: &str) -> PathBuf {
+    std::env::temp_dir().join(format!("traverse-trace-journal-{name}-{}", Uuid::new_v4()))
+}
+
+fn sample_public(id: &str) -> PublicTraceEntry {
+    PublicTraceEntry::new(
+        id.to_string(),
+        "durable.trace.tests.subject".to_string(),
+        "Local".to_string(),
+        TraceOutcome::Success,
+        12,
+        "2026-08-24T00:00:00Z".to_string(),
+    )
+}
+
+fn sample_private(id: &str) -> PrivateTraceEntry {
+    PrivateTraceEntry::new(
+        id.to_string(),
+        "super-secret raw input",
+        "super-secret raw output",
+        12,
+    )
+}
+
+struct TestClock {
+    now: Mutex<SystemTime>,
+}
+
+impl TestClock {
+    fn at_secs(secs: u64) -> Arc<Self> {
+        Arc::new(Self {
+            now: Mutex::new(SystemTime::UNIX_EPOCH + Duration::from_secs(secs)),
+        })
+    }
+
+    fn advance(&self, secs: u64) {
+        let Ok(mut guard) = self.now.lock() else {
+            return;
+        };
+        *guard += Duration::from_secs(secs);
+    }
+}
+
+impl BrokerClock for TestClock {
+    fn now(&self) -> SystemTime {
+        self.now
+            .lock()
+            .map_or(SystemTime::UNIX_EPOCH, |guard| *guard)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// FR-001: durable, fsync-committed writes survive a full close+reopen
+// ---------------------------------------------------------------------------
+
+#[test]
+fn recorded_trace_survives_a_full_close_and_reopen() -> Result<(), String> {
+    let root = test_root("survives-reopen");
+    let clock = TestClock::at_secs(1_000);
+
+    {
+        let mut journal =
+            DurableTraceJournal::open_with_clock(&root, JournalConfig::default(), clock.clone())
+                .map_err(|e| e.to_string())?;
+        journal
+            .record(&sample_public("trace-a"), Some(&sample_private("trace-a")))
+            .map_err(|e| e.to_string())?;
+        // `journal` is dropped here, closing its file handle -- simulating
+        // process exit. `record` already fsync'd before returning.
+    }
+
+    let reopened = DurableTraceJournal::open_with_clock(&root, JournalConfig::default(), clock)
+        .map_err(|e| e.to_string())?;
+
+    assert_eq!(
+        reopened.recovery_report().recovered_trace_ids,
+        vec!["trace-a".to_string()]
+    );
+
+    fs::remove_dir_all(&root).ok();
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// FR-003: recovery discards only an incomplete final record; anything else
+// malformed fails loudly.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn recovery_discards_only_a_torn_final_record() -> Result<(), String> {
+    let root = test_root("torn-tail");
+    let clock = TestClock::at_secs(1_000);
+
+    {
+        let mut journal =
+            DurableTraceJournal::open_with_clock(&root, JournalConfig::default(), clock.clone())
+                .map_err(|e| e.to_string())?;
+        journal
+            .record(&sample_public("trace-a"), Some(&sample_private("trace-a")))
+            .map_err(|e| e.to_string())?;
+    }
+
+    // Simulate a crash mid-write: append a syntactically-invalid, unterminated
+    // JSON fragment directly to the on-disk segment (no journal API call, so
+    // it was never fsync-acknowledged).
+    let segment_path = fs::read_dir(&root)
+        .map_err(|e| e.to_string())?
+        .filter_map(std::result::Result::ok)
+        .map(|entry| entry.path())
+        .find(|path| path.extension().is_some_and(|ext| ext == "jsonl"))
+        .ok_or_else(|| "expected exactly one segment file".to_string())?;
+    let mut bytes = fs::read(&segment_path).map_err(|e| e.to_string())?;
+    bytes.extend_from_slice(b"{\"seq\":2,\"truncated");
+    fs::write(&segment_path, &bytes).map_err(|e| e.to_string())?;
+
+    let reopened = DurableTraceJournal::open_with_clock(&root, JournalConfig::default(), clock)
+        .map_err(|e| e.to_string())?;
+
+    // The torn record is silently absent; the prior, fully-written record
+    // survives -- recovery does not invent evidence for the discarded record.
+    assert_eq!(
+        reopened.recovery_report().recovered_trace_ids,
+        vec!["trace-a".to_string()]
+    );
+
+    fs::remove_dir_all(&root).ok();
+    Ok(())
+}
+
+#[test]
+fn recovery_fails_loudly_on_a_corrupt_completed_record() -> Result<(), String> {
+    let root = test_root("corrupt-completed");
+    fs::create_dir_all(&root).map_err(|e| e.to_string())?;
+    // Write a whole malformed segment directly, bypassing the journal API
+    // entirely -- this is a corrupt *completed* record (no trailing torn
+    // line), so recovery must fail loudly rather than silently drop it.
+    fs::write(root.join("segment-1.jsonl"), b"not-json\n").map_err(|e| e.to_string())?;
+
+    let result = DurableTraceJournal::open_with_clock(
+        &root,
+        JournalConfig::default(),
+        TestClock::at_secs(1_000),
+    );
+
+    match result {
+        Ok(_) => return Err("expected open() to fail on a corrupt completed record".to_string()),
+        Err(TraceJournalError::Journal(JournalError::Corrupt { .. })) => {}
+        Err(other) => return Err(format!("expected Corrupt journal error, got {other}")),
+    }
+
+    fs::remove_dir_all(&root).ok();
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// FR-004: durable records carry only non-sensitive metadata and hashes.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn durable_record_never_contains_raw_input_or_output_payloads() -> Result<(), String> {
+    let root = test_root("no-raw-payloads");
+    let clock = TestClock::at_secs(1_000);
+    let mut journal = DurableTraceJournal::open_with_clock(&root, JournalConfig::default(), clock)
+        .map_err(|e| e.to_string())?;
+
+    let public = sample_public("trace-secret");
+    let private = sample_private("trace-secret");
+    journal
+        .record(&public, Some(&private))
+        .map_err(|e| e.to_string())?;
+
+    let segment_path = fs::read_dir(&root)
+        .map_err(|e| e.to_string())?
+        .filter_map(std::result::Result::ok)
+        .map(|entry| entry.path())
+        .find(|path| path.extension().is_some_and(|ext| ext == "jsonl"))
+        .ok_or_else(|| "expected exactly one segment file".to_string())?;
+    let on_disk = fs::read_to_string(&segment_path).map_err(|e| e.to_string())?;
+
+    assert!(
+        !on_disk.contains("super-secret raw input"),
+        "durable record must never contain the raw input payload"
+    );
+    assert!(
+        !on_disk.contains("super-secret raw output"),
+        "durable record must never contain the raw output payload"
+    );
+    assert!(
+        on_disk.contains(&private.inputs_hash),
+        "durable record must contain the canonical input hash"
+    );
+    assert!(
+        on_disk.contains(&private.outputs_hash),
+        "durable record must contain the canonical output hash"
+    );
+
+    fs::remove_dir_all(&root).ok();
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// FR-005: deterministic oldest-first retention, evidence, and per-workspace
+// isolation.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn prune_reclaims_oldest_segments_first_and_reports_evidence() -> Result<(), String> {
+    let root = test_root("prune-oldest-first");
+    let clock = TestClock::at_secs(1_000);
+    let config = JournalConfig {
+        max_segment_bytes: 1, // force one record per segment (rollover by size)
+        max_segment_age_secs: 600,
+        retention_max_age_secs: Some(50),
+        retention_max_total_bytes: None,
+    };
+    let mut journal = DurableTraceJournal::open_with_clock(&root, config, clock.clone())
+        .map_err(|e| e.to_string())?;
+
+    journal
+        .record(&sample_public("trace-old"), None)
+        .map_err(|e| e.to_string())?;
+    clock.advance(100); // age the first segment well past the 50s bound
+    journal
+        .record(&sample_public("trace-new"), None)
+        .map_err(|e| e.to_string())?;
+
+    let evidence = journal.prune().map_err(|e| e.to_string())?;
+
+    assert_eq!(evidence.workspace_root, root);
+    assert_eq!(
+        evidence.deleted_segment_paths.len(),
+        1,
+        "exactly the aged-out oldest segment must be reclaimed, not the active one"
+    );
+
+    fs::remove_dir_all(&root).ok();
+    Ok(())
+}
+
+#[test]
+fn two_workspace_roots_are_fully_isolated_from_each_other() -> Result<(), String> {
+    let root_a = test_root("workspace-a");
+    let root_b = test_root("workspace-b");
+    let clock = TestClock::at_secs(1_000);
+
+    let mut journal_a =
+        DurableTraceJournal::open_with_clock(&root_a, JournalConfig::default(), clock.clone())
+            .map_err(|e| e.to_string())?;
+    let mut journal_b =
+        DurableTraceJournal::open_with_clock(&root_b, JournalConfig::default(), clock)
+            .map_err(|e| e.to_string())?;
+
+    journal_a
+        .record(&sample_public("trace-workspace-a"), None)
+        .map_err(|e| e.to_string())?;
+    journal_b
+        .record(&sample_public("trace-workspace-b"), None)
+        .map_err(|e| e.to_string())?;
+
+    assert_eq!(
+        journal_a.recovery_report().recovered_trace_ids,
+        Vec::<String>::new(),
+        "recovery report is a frozen open-time snapshot, unaffected by later records"
+    );
+
+    let reopened_a = DurableTraceJournal::open_with_clock(
+        &root_a,
+        JournalConfig::default(),
+        TestClock::at_secs(2_000),
+    )
+    .map_err(|e| e.to_string())?;
+    let reopened_b = DurableTraceJournal::open_with_clock(
+        &root_b,
+        JournalConfig::default(),
+        TestClock::at_secs(2_000),
+    )
+    .map_err(|e| e.to_string())?;
+
+    assert_eq!(
+        reopened_a.recovery_report().recovered_trace_ids,
+        vec!["trace-workspace-a".to_string()]
+    );
+    assert_eq!(
+        reopened_b.recovery_report().recovered_trace_ids,
+        vec!["trace-workspace-b".to_string()]
+    );
+
+    fs::remove_dir_all(&root_a).ok();
+    fs::remove_dir_all(&root_b).ok();
+    Ok(())
+}

--- a/crates/traverse-runtime/tests/router_tests.rs
+++ b/crates/traverse-runtime/tests/router_tests.rs
@@ -13,8 +13,8 @@ use traverse_contracts::{
 };
 use traverse_runtime::{
     events::{
-        EventBroker, EventCatalog, EventCatalogEntry, InProcessBroker, LifecycleStatus,
-        TraverseEvent,
+        EventBroker, EventCatalog, EventCatalogEntry, InProcessBroker, JournalConfig,
+        LifecycleStatus, TraverseEvent,
     },
     executor::{
         ArtifactType, CapabilityExecutor, ExecutorCapability, ExecutorError, ExecutorOutput,
@@ -22,7 +22,10 @@ use traverse_runtime::{
     },
     placement::{PlacementConstraintEvaluator, PlacementError, RuntimeSnapshot},
     router::{CapabilityExecutorRegistry, PlacementRouter, RouterError, RouterRequest},
-    trace::TraceStore,
+    trace::{
+        DurableTraceConfig, DurableTraceJournal, PrivateTraceEntry, PublicTraceEntry,
+        TraceDurabilitySink, TraceJournalError, TraceStore,
+    },
 };
 
 // ---------------------------------------------------------------------------
@@ -481,6 +484,7 @@ fn router_error_display_covers_all_variants() {
             "test message",
         )]),
         RouterError::TraceLockPoisoned,
+        RouterError::DurableTraceWriteFailed("simulated durable trace write failure".to_string()),
     ];
 
     for err in &cases {
@@ -533,6 +537,151 @@ fn executor_error_returns_execution_failed() -> Result<(), String> {
         matches!(err, RouterError::ExecutionFailed(_)),
         "expected ExecutionFailed, got {err:?}"
     );
+
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Durable trace integration (spec 079-durable-trace-journal FR-002)
+// ---------------------------------------------------------------------------
+
+/// A [`TraceDurabilitySink`] test double that always fails, standing in for
+/// a real durable-write failure without filesystem fault injection.
+struct FailingTraceDurabilitySink;
+
+impl TraceDurabilitySink for FailingTraceDurabilitySink {
+    fn record(
+        &self,
+        _public: &PublicTraceEntry,
+        _private: Option<&PrivateTraceEntry>,
+    ) -> Result<String, TraceJournalError> {
+        Err(TraceJournalError::Serialize(
+            "simulated durable trace write failure".to_string(),
+        ))
+    }
+}
+
+fn trace_journal_test_root(name: &str) -> std::path::PathBuf {
+    std::env::temp_dir().join(format!(
+        "traverse-router-durable-trace-{name}-{}",
+        uuid::Uuid::new_v4()
+    ))
+}
+
+#[test]
+fn durable_trace_write_failure_fails_closed_for_auditable_execution() -> Result<(), String> {
+    let trace_store = Arc::new(Mutex::new(TraceStore::new()));
+    let broker: Arc<dyn EventBroker> = broker_with_event("dev.traverse.test.happened")?;
+
+    let router =
+        make_router_with_native(json!({ "result": "ok" }), Arc::clone(&trace_store), broker)
+            .with_durable_trace(DurableTraceConfig {
+                sink: Arc::new(FailingTraceDurabilitySink),
+                fail_closed: true,
+            });
+
+    let request = RouterRequest {
+        capability_id: "router.tests.subject".to_string(),
+        artifact_type: ArtifactType::Native,
+        contract: base_contract(ServiceType::Stateless),
+        target_hint: Some(ExecutionTarget::Local),
+        runtime_snapshot: idle_snapshot(),
+        input: json!({ "key": "value" }),
+        executor_capability: native_executor_capability("router.tests.subject"),
+        trace_id_override: None,
+    };
+
+    let err = must_err(router.execute(request), "expected a durable-trace failure")?;
+    assert!(
+        matches!(err, RouterError::DurableTraceWriteFailed(_)),
+        "expected DurableTraceWriteFailed, got {err:?}"
+    );
+
+    let store = trace_store.lock().map_err(|_| "lock poisoned")?;
+    assert!(
+        store.list_public(Some("router.tests.subject")).is_empty(),
+        "an auditable execution that failed closed must not keep an in-memory-only trace"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn durable_trace_write_failure_does_not_fail_open_execution_when_not_fail_closed()
+-> Result<(), String> {
+    let trace_store = Arc::new(Mutex::new(TraceStore::new()));
+    let broker: Arc<dyn EventBroker> = broker_with_event("dev.traverse.test.happened")?;
+
+    let router =
+        make_router_with_native(json!({ "result": "ok" }), Arc::clone(&trace_store), broker)
+            .with_durable_trace(DurableTraceConfig {
+                sink: Arc::new(FailingTraceDurabilitySink),
+                fail_closed: false,
+            });
+
+    let request = RouterRequest {
+        capability_id: "router.tests.subject".to_string(),
+        artifact_type: ArtifactType::Native,
+        contract: base_contract(ServiceType::Stateless),
+        target_hint: Some(ExecutionTarget::Local),
+        runtime_snapshot: idle_snapshot(),
+        input: json!({ "key": "value" }),
+        executor_capability: native_executor_capability("router.tests.subject"),
+        trace_id_override: None,
+    };
+
+    let response = router.execute(request).map_err(|e| e.to_string())?;
+    assert_eq!(response.output, json!({ "result": "ok" }));
+
+    let store = trace_store.lock().map_err(|_| "lock poisoned")?;
+    assert_eq!(
+        store.list_public(Some("router.tests.subject")).len(),
+        1,
+        "non-audited work must keep its in-memory trace even when the durable write fails"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn durable_trace_journal_round_trips_through_a_real_execution() -> Result<(), String> {
+    let root = trace_journal_test_root("round-trip");
+    let journal =
+        DurableTraceJournal::open(&root, JournalConfig::default()).map_err(|e| e.to_string())?;
+
+    let trace_store = Arc::new(Mutex::new(TraceStore::new()));
+    let broker: Arc<dyn EventBroker> = broker_with_event("dev.traverse.test.happened")?;
+
+    let router =
+        make_router_with_native(json!({ "result": "ok" }), Arc::clone(&trace_store), broker)
+            .with_durable_trace(DurableTraceConfig {
+                sink: Arc::new(Mutex::new(journal)),
+                fail_closed: true,
+            });
+
+    let request = RouterRequest {
+        capability_id: "router.tests.subject".to_string(),
+        artifact_type: ArtifactType::Native,
+        contract: base_contract(ServiceType::Stateless),
+        target_hint: Some(ExecutionTarget::Local),
+        runtime_snapshot: idle_snapshot(),
+        input: json!({ "key": "value" }),
+        executor_capability: native_executor_capability("router.tests.subject"),
+        trace_id_override: None,
+    };
+
+    let response = router.execute(request).map_err(|e| e.to_string())?;
+
+    // Reopen a fresh journal at the same root -- the trace this execution
+    // wrote must have survived durably, independent of the in-memory store.
+    let reopened =
+        DurableTraceJournal::open(&root, JournalConfig::default()).map_err(|e| e.to_string())?;
+    assert_eq!(
+        reopened.recovery_report().recovered_trace_ids,
+        vec![response.trace_id]
+    );
+
+    std::fs::remove_dir_all(&root).ok();
 
     Ok(())
 }


### PR DESCRIPTION
## Governing Spec

- `079-durable-trace-journal`

## Project Item

https://github.com/traverse-framework/traverse/issues/1116

## Summary

Implements spec `079-durable-trace-journal` (`specs/518-durable-trace-journal/spec.md`,
ADR-0017): durable, append-only persistence for execution traces, adding
`DurableTraceJournal` in `crates/traverse-runtime/src/trace/durable.rs`.

Persists traces through the *existing* append-only `DurableEventJournal`
(`crates/traverse-runtime/src/events/journal.rs`) rather than a second
storage engine:

- **FR-001**: trace records are canonical JSON Lines, appended and
  `fsync`-committed exactly like domain events, before `record()` returns.
- **FR-002**: wired into `PlacementRouter` via an opt-in
  `with_durable_trace(DurableTraceConfig)` builder (existing
  `PlacementRouter::new` call sites are unaffected — 10 of them across the
  crate, none touched). A durable-write failure fails the whole execution
  only when the caller marks the sink `fail_closed`; non-audited local
  development work may opt out (ADR-0017) by setting it `false`. The caller
  decides `fail_closed` from its own audit posture (e.g.
  `RuntimeSecurityMode::Production`) — `PlacementRouter` itself stays
  decoupled from that concept, matching the existing separation between
  `security.rs` and `router/mod.rs`.
- **FR-003**: reuses the underlying journal's existing recovery unchanged —
  an incomplete final record from a crash mid-write is silently discarded,
  any other corruption fails loudly (already proven generically by
  `journal.rs`'s own test suite for domain events; regression-tested here
  again specifically for trace records).
- **FR-004**: `PublicTraceEntry`/`PrivateTraceEntry` already carry only
  non-sensitive metadata and canonical hashes, never raw payloads — this
  layer persists them as-is and adds no new fields.
- **FR-005**: retention reuses the journal's existing deterministic
  oldest-first, whole-segment pruning. "Per workspace" is achieved by
  opening one journal per workspace-scoped root, rather than threading a
  `workspace_id` field through every trace record and `RouterRequest` (which
  doesn't carry one today) — mirrors how `DataStore` is already host-opened
  at an explicit root rather than auto-wired by `Runtime`.

## Why this scope (not spec 527)

While this branch was in flight, a separate session's backlog sweep got
spec `527-durable-trace-productization` approved (ADR-0045, renumbered
same-day from ADR-0027 to resolve a collision; Decision 63) —
a host-authorization/redacted-export/retention-policy layer explicitly
described as *additive* to this spec (079), scoped to a different future
file (`crates/traverse-runtime/src/trace_journal.rs`) and stating "this
issue implements none" itself. This PR is unaffected by and does not
attempt that layer.

## Unblocks

`#1093` (P3 durable dynamic orchestration) cited "approved durable
host-owned state/trace substrate" as half its blocker. The DataStore half
was already implemented; this closes the trace half. Per Decision 63,
`#1093` still needs its separate checkpoint/state requirement resolved
before it's fully unblocked — not addressed here.

## Changes

- `crates/traverse-runtime/src/trace/durable.rs` (new): `DurableTraceJournal`,
  `TraceDurabilitySink` trait (+ impl for `Mutex<DurableTraceJournal>`,
  enabling deterministic router-level fail-closed tests without filesystem
  fault injection), `DurableTraceConfig`, `TraceRecoveryReport`,
  `TracePrunedEvidence`, `TraceJournalError`.
- `crates/traverse-runtime/src/trace/mod.rs`: exports the new module.
- `crates/traverse-runtime/src/router/mod.rs`: `PlacementRouter` gains an
  optional `durable_trace` field, `with_durable_trace` builder, and a new
  `RouterError::DurableTraceWriteFailed` variant.
- `crates/traverse-runtime/src/lib.rs`: maps the new `RouterError` variant
  in `map_router_error` (reuses `RuntimeErrorCode::ExecutionFailed` with a
  distinguishing `"code": "durable_trace_write_failed"` detail, matching the
  existing `TraceLockPoisoned` precedent rather than adding a new
  `RuntimeErrorCode` variant and its other exhaustive-match sites).
- `crates/traverse-runtime/tests/durable_trace_journal_tests.rs` (new): FR-001
  (close+reopen durability), FR-003 (torn-tail discard vs. loud failure on
  real corruption), FR-004 (no raw payload ever on disk), FR-005 (oldest-first
  pruning + evidence, per-workspace-root isolation).
- `crates/traverse-runtime/tests/router_tests.rs`: fail-closed vs. best-effort
  router integration tests, plus a full real-journal round-trip through an
  actual `PlacementRouter::execute` call; extended the existing
  `router_error_display_covers_all_variants` test for the new variant.

## Validation

- [x] Spec alignment checked (declared `079-durable-trace-journal` above;
      covers every changed path under `crates/traverse-runtime/`)
- [x] Contract alignment checked (no `CapabilityContract`/wire-format
      change)
- [x] Tests updated and passing (`cargo test -p traverse-runtime` — 353
      unit tests + all integration test binaries green, including 6 new
      standalone journal tests and 3 new router-integration tests)
- [x] Core coverage preserved (`traverse-runtime` is 100%-gated:
      `bash scripts/ci/coverage_gate.sh` with brew llvm reports
      `traverse-runtime: 100.00% (22705/22705 lines)`)
- [x] Required validation gates passing
      (`cargo clippy -p traverse-runtime --all-targets -- -D warnings` —
      clean; `cargo fmt --all --check` — clean)

Fixes #1116.
