### PR TITLE
chore(governance): resolve 5 remaining duplicate ADR numbers

### DIFF
--- a/docs/adr/0030-runtime-usage-telemetry.md
+++ b/docs/adr/0030-runtime-usage-telemetry.md
@@ -5,7 +5,8 @@
 - Governing spec: `536-runtime-usage-telemetry` / `088-runtime-usage-telemetry`
 - Decision evidence: `docs/decision-log.md` Decision 42, originating in
   `traverse-framework/registry`'s Decision 47 (registry#134)
-- Extends: ADR-0029 (provider-neutral port precedent)
+- Extends: ADR-0049 (provider-neutral port precedent; renumbered from
+  ADR-0029 on 2026-08-24)
 
 ## Context
 
@@ -24,7 +25,7 @@ its own portability and that repo's inherited-governance boundary
 ## Decision
 
 Add a `UsageTelemetrySink` port trait to `traverse-contracts`, with a no-op
-default — the same provider-neutral-port pattern ADR-0029 established for
+default — the same provider-neutral-port pattern ADR-0049 established for
 hosted DataStore transport. `traverse-cli` owns the only real
 implementation: a persistent, prompt-free opt-in config command, a locally
 generated anonymous install ID, and an HTTPS client to a purpose-built

--- a/docs/adr/0043-declarative-workflow-planning-boundary.md
+++ b/docs/adr/0043-declarative-workflow-planning-boundary.md
@@ -42,8 +42,9 @@ chain from capability names, namespaces, or any other signal, and never
 operates on a capability pair with no structural match. When more than one
 capability could satisfy a need, the planner enumerates every resulting
 complete candidate plan rather than choosing one — ambiguity resolution is
-a caller/reviewer decision, never a runtime one, consistent with ADR-0041
-treating the planner-adjacent surface as untrusted and this runtime's
+a caller/reviewer decision, never a runtime one, consistent with ADR-0050
+(renumbered from ADR-0041 on 2026-08-24) treating the planner-adjacent
+surface as untrusted and this runtime's
 everywhere-else stance against silent inference. Search is bounded by
 fixed, small, non-configurable limits in v1. Field-level JSON-path mappings
 are proposed but always marked unconfirmed until reviewed — the planner
@@ -79,7 +80,7 @@ this risk; nothing a planner proposes ever executes unreviewed.
   runtime decision `109`'s explicit-mapping requirement exists to prevent.
 - Accept natural-language goals and interpret them in-runtime: rejected —
   reintroduces exactly the hosted-model dependency `109` FR-001 and
-  ADR-0041 explicitly excluded.
+  ADR-0050 (renumbered from ADR-0041 on 2026-08-24) explicitly excluded.
 - Loosen registry's FR-020 inventory criterion instead, keep `consumes`/
   `emits` as the sole signal: rejected — would require ~26 capabilities to
   carry full governed-event ceremony (privacy field classification,

--- a/docs/adr/0046-agent-artifact-stdout-only.md
+++ b/docs/adr/0046-agent-artifact-stdout-only.md
@@ -1,6 +1,9 @@
-# ADR 0011: Constrained stdout-only agent artifact output
+# ADR 0046: Constrained stdout-only agent artifact output
 
 **Status:** Approved (2026-07-21)
+
+**Renumbered:** 2026-08-24 from ADR-0011 (that number collided with the
+already-Accepted `docs/adr/0011-swift-native-resource-controls.md`)
 
 ## Context
 

--- a/docs/adr/0047-swift-host-coverage-gate-policy.md
+++ b/docs/adr/0047-swift-host-coverage-gate-policy.md
@@ -1,7 +1,9 @@
-# ADR-0018: Protect the Production Swift Host with a Measured Coverage Ratchet
+# ADR-0047: Protect the Production Swift Host with a Measured Coverage Ratchet
 
 - Status: Accepted
 - Date: 2026-07-22
+- Renumbered: 2026-08-24 from ADR-0018 (that number collided with the
+  already-Accepted `docs/adr/0018-durable-local-datastore.md`)
 - Governing specs: `001-foundation-v0-1`, `076-production-swift-wasmi-cabi`
 - Owner: Traverse maintainers
 - Review by: 2026-10-22

--- a/docs/adr/0048-mode-a-registry-mcp-host.md
+++ b/docs/adr/0048-mode-a-registry-mcp-host.md
@@ -1,7 +1,9 @@
-# ADR-0024: Mode A as a Local Registry-Backed Stdio MCP Host
+# ADR-0048: Mode A as a Local Registry-Backed Stdio MCP Host
 
 - Status: Accepted
 - Date: 2026-07-30
+- Renumbered: 2026-08-24 from ADR-0024 (that number collided with the
+  already-Accepted `docs/adr/0024-remote-key-value-datastore-contract.md`)
 - Governing spec: Approved `086-mode-a-registry-mcp` / `530-mode-a-registry-mcp`
 - Decided in: Traverse #865; governed by #906
 

--- a/docs/adr/0049-hosted-datastore-transport.md
+++ b/docs/adr/0049-hosted-datastore-transport.md
@@ -1,7 +1,9 @@
-# ADR-0029: Managed Hosted Transport Behind a Provider-Neutral Boundary
+# ADR-0049: Managed Hosted Transport Behind a Provider-Neutral Boundary
 
 - Status: Accepted
 - Date: 2026-07-30
+- Renumbered: 2026-08-24 from ADR-0029 (that number collided with the
+  already-Accepted `docs/adr/0029-s3-compatible-remote-datastore.md`)
 - Governing spec: `535-hosted-datastore-transport` / `087-hosted-datastore-transport`
 - Decision evidence: Traverse #887
 - Extends: ADR-0025, ADR-0028

--- a/docs/adr/0050-governed-runtime-workflow-proposal-authority.md
+++ b/docs/adr/0050-governed-runtime-workflow-proposal-authority.md
@@ -1,6 +1,8 @@
-# ADR-0041: Govern Runtime Workflow Proposals as Untrusted, Manifest-Bounded Snapshots
+# ADR-0050: Govern Runtime Workflow Proposals as Untrusted, Manifest-Bounded Snapshots
 
 - Status: Accepted
+- Renumbered: 2026-08-24 from ADR-0041 (that number collided with the
+  already-Accepted `docs/adr/0041-cross-host-embedded-registry-cache.md`)
 - Governing specs: `108-governed-runtime-workflow-composition`, `109-runtime-workflow-proposals`
 - Related issues: #865, #1089
 

--- a/docs/capability-contract-authoring-guide.md
+++ b/docs/capability-contract-authoring-guide.md
@@ -393,7 +393,8 @@ Use `"stateful"` only for capabilities that explicitly manage a persistent resou
 ## `risk` Reference (spec 109)
 
 Every contract carries an immutable `risk` classification across four
-independent dimensions (spec `109-runtime-workflow-proposals` FR-005, ADR-0041).
+independent dimensions (spec `109-runtime-workflow-proposals` FR-005, ADR-0050,
+renumbered from ADR-0041 on 2026-08-24).
 A single field never implies another dimension — declare each one deliberately.
 
 ```json

--- a/docs/decision-log.md
+++ b/docs/decision-log.md
@@ -1221,7 +1221,8 @@ Traverse maintainers, not an operator-facing signal.
   to.
 - Architecturally: a `UsageTelemetrySink` port trait lives in
   `traverse-contracts` (the existing pattern for provider-neutral ports, see
-  ADR-0029's transport-port precedent) with a no-op default. `traverse-cli`
+  ADR-0049's transport-port precedent, renumbered from ADR-0029 on
+  2026-08-24) with a no-op default. `traverse-cli`
   owns the only real adapter (config, install ID, PostHog HTTP client).
   `crates/traverse-registry` (external, `traverse-framework/registry`-owned)
   calls the port at its resolution call site but never depends on the
@@ -2221,8 +2222,8 @@ phase P0 of the existing `108` north star (not a standalone spec, since
   spec covering the same feature invites drift (cf. Decision 58's "do not
   create a parallel coverage law").
 - Accept and interpret natural-language goals in-runtime — rejected;
-  reintroduces the hosted-model dependency `109` FR-001 and ADR-0041
-  explicitly excluded.
+  reintroduces the hosted-model dependency `109` FR-001 and ADR-0050
+  (renumbered from ADR-0041 on 2026-08-24) explicitly excluded.
 
 ### Outcome
 

--- a/docs/quality-standards.md
+++ b/docs/quality-standards.md
@@ -33,7 +33,7 @@ Current phased floors:
 |---|---:|---:|---|
 | `traverse-cli` | 78% | 78.77% | [#618](https://github.com/traverse-framework/traverse/issues/618) |
 | `traverse-mcp` | 86% | 86.07% | [#617](https://github.com/traverse-framework/traverse/issues/617) |
-| `traverse-swift-host` | 78% | 78.66% | ADR-0018; raise to 100% before its next production release |
+| `traverse-swift-host` | 78% | 78.66% | ADR-0047; raise to 100% before its next production release |
 
 `traverse-swift-host` is included because it is the production, audited C-ABI
 boundary. `traverse-native-bridge` is a build-time fixture generator and

--- a/docs/workflow-proposal-lifecycle.md
+++ b/docs/workflow-proposal-lifecycle.md
@@ -1,13 +1,13 @@
 # Runtime Workflow Proposal Lifecycle (P1)
 
 Governed by spec [`109-runtime-workflow-proposals`](../specs/109-runtime-workflow-proposals/spec.md)
-and [ADR-0041](adr/0041-governed-runtime-workflow-proposal-authority.md). Tracks
-issue `#1090`.
+and [ADR-0050](adr/0050-governed-runtime-workflow-proposal-authority.md)
+(renumbered from ADR-0041 on 2026-08-24). Tracks issue `#1090`.
 
 A **workflow proposal** is an untrusted, externally-authored, ephemeral,
 manifest-bound bounded sequential DAG over already-registered capabilities.
 An MCP client (or any planner) submits one; Traverse validates, authorizes,
-and executes it — the planner is never the authority (ADR-0041).
+and executes it — the planner is never the authority (ADR-0050).
 
 ## Where the code lives
 
@@ -67,7 +67,7 @@ declared mapping (spec FR-002).
 - **`proposal_snapshot_digest`**: hashes `proposal_digest` together with the
   manifest/registry/binding/policy/budget digests supplied by the caller
   (`SnapshotDigests`). This is the digest an approval token is actually
-  scoped to (ADR-0041's "governing snapshots") — it changes if any pinned
+  scoped to (ADR-0050's "governing snapshots") — it changes if any pinned
   input changes even when the proposal JSON is byte-identical.
 
 ## Cross-validation (FR-004, FR-011)
@@ -141,7 +141,7 @@ revocation state, keyed by `jti`. Tokens are short-lived and scoped to one
 pinned snapshot, so no persistence across restarts is needed.
 
 **This repo verifies approval tokens; it does not issue them.** Per
-ADR-0041, the approving principal/service is external to Traverse — there is
+ADR-0050, the approving principal/service is external to Traverse — there is
 no token-signing code here, only verification.
 
 ## Quotas (FR-007b)

--- a/specs/530-mode-a-registry-mcp/spec.md
+++ b/specs/530-mode-a-registry-mcp/spec.md
@@ -2,7 +2,8 @@
 
 **Feature Branch**: `codex/issue-906-mode-a-mcp-spec`
 **Created**: 2026-07-30
-**Status**: Approved (2026-07-30 — approved by Enrico; ADR-0024 accepted)
+**Status**: Approved (2026-07-30 — approved by Enrico; ADR-0048 accepted,
+renumbered 2026-08-24 from ADR-0024)
 **Version**: 1.0.0
 **Input**: Traverse #865 decision records; governing ticket #906; Specs 015,
 042, 054, 055, 516, and 520.
@@ -189,5 +190,6 @@ product path after Mode A lands.
 ## Approval
 
 This immutable artifact governs implementation as approved Spec 086 after
-explicit reviewer approval, acceptance of ADR-0024, and registry evidence in
+explicit reviewer approval, acceptance of ADR-0048 (renumbered from
+ADR-0024), and registry evidence in
 `specs/governance/approved-specs.json`.

--- a/specs/governance/approved-specs.json
+++ b/specs/governance/approved-specs.json
@@ -984,7 +984,7 @@
         "contracts/examples/",
         "examples/",
         "scripts/ci/",
-        "docs/adr/0011-agent-artifact-stdout-only.md",
+        "docs/adr/0046-agent-artifact-stdout-only.md",
         "specs/516-agent-artifact-execution/"
       ]
     },
@@ -1131,7 +1131,7 @@
         "crates/traverse-embedder/",
         "packages/",
         "examples/",
-        "docs/adr/0029-hosted-datastore-transport.md",
+        "docs/adr/0049-hosted-datastore-transport.md",
         "specs/535-hosted-datastore-transport/"
       ]
     },
@@ -1144,7 +1144,7 @@
       "governs": [
         "crates/traverse-mcp/",
         "docs/mcp-stdio-server.md",
-        "docs/adr/0024-mode-a-registry-mcp-host.md",
+        "docs/adr/0048-mode-a-registry-mcp-host.md",
         "specs/530-mode-a-registry-mcp/"
       ]
     },
@@ -1428,7 +1428,7 @@
         "specs/111-durable-dynamic-orchestration/",
         "specs/112-governed-workflow-promotion/",
         "specs/113-declarative-workflow-planning/",
-        "docs/adr/0041-governed-runtime-workflow-proposal-authority.md",
+        "docs/adr/0050-governed-runtime-workflow-proposal-authority.md",
         "docs/adr/0042-phased-dynamic-orchestration-evolution.md",
         "docs/decision-log.md",
         "docs/adr/0043-declarative-workflow-planning-boundary.md"


### PR DESCRIPTION
## Governing Spec

- `070-runtime-event-sink-boundary`
- `004-spec-alignment-gate`
- `086-mode-a-registry-mcp`

## Project Item

https://github.com/traverse-framework/traverse/issues/1120

## Summary

`docs/adr/` had 6 numbers each shared by two unrelated ADRs. The
durable-trace collision (0027) was fixed in #1117/#1119. This resolves the
other 5, following the exact same pattern.

For each pair, the older ADR (by its own recorded `Date:`/`Status:` line,
falling back to git blame creation date when a file has no stated date at
all) keeps its current number; the newer one is renumbered to the next free
number (0046-0050) and gets a `Renumbered:` note pointing back to the old
number and explaining the collision, matching ADR-0045's existing precedent.

| Old number | File renumbered | New number | Kept at old number |
|---|---|---|---|
| 0011 | `agent-artifact-stdout-only.md` | 0046 | `swift-native-resource-controls.md` (2026-07-18, older) |
| 0018 | `swift-host-coverage-gate-policy.md` | 0047 | `durable-local-datastore.md` (2026-07-21, older) |
| 0024 | `mode-a-registry-mcp-host.md` | 0048 | `remote-key-value-datastore-contract.md` (git-committed 2026-07-29, older; the renumbered file's own `Date:` header read 2026-07-30 but predates its actual repo commit on 2026-08-04) |
| 0029 | `hosted-datastore-transport.md` | 0049 | `s3-compatible-remote-datastore.md` (git-committed ~20 minutes earlier the same day) |
| 0041 | `governed-runtime-workflow-proposal-authority.md` | 0050 | `cross-host-embedded-registry-cache.md` (git-committed 2026-08-17, older) |

## Cross-reference verification

Every cross-reference to a renumbered ADR was individually checked against
its surrounding context before editing — a bare `ADR-00NN` mention is
ambiguous between the two colliding files, and several documents contain
mentions of the *same* number referring to *different* ADRs:

- `docs/decision-log.md` has two separate `ADR-0024` mentions (one about
  the remote-KV-datastore ADR that keeps 0024, one — actually `ADR-0029` at
  line ~1224 — about the hosted-transport ADR that moved to 0049) and two
  separate `ADR-0029` mentions likewise split between the two 0029 files.
- `docs/adr/0030-runtime-usage-telemetry.md`'s "Extends: ADR-0029" is about
  hosted-datastore-transport (now 0049), confirmed by its own "hosted
  DataStore transport" text — not the sibling s3-compatible ADR that keeps
  0029.
- `specs/107-cross-host-embedded-registry-cache/spec.md`'s `ADR-0041`
  mention is self-referential to the ADR that *keeps* 0041 (matching its own
  topic) and was correctly left untouched, while
  `docs/adr/0043-declarative-workflow-planning-boundary.md`'s two `ADR-0041`
  mentions are about the workflow-proposal-authority ADR (now 0050).

Full updated file list: the 5 renamed ADRs themselves;
`specs/governance/approved-specs.json` (3 `governs` entries: `516-agent-
artifact-execution`, `086-mode-a-registry-mcp`, `535-hosted-datastore-
transport`, plus the already-covered `108-governed-runtime-workflow-
composition` entry); `specs/530-mode-a-registry-mcp/spec.md` (2 lines, its
own `Status`/`Approval` sections — this spec's own text says "this
immutable artifact governs implementation" but ticket #1120 explicitly
authorizes updating a stale ADR-number cross-reference as governance
hygiene, not a requirements change); `docs/quality-standards.md`,
`docs/adr/0030-runtime-usage-telemetry.md`, `docs/decision-log.md` (2 of its
~4 `ADR-00NN` mentions in this range), `docs/adr/0043-declarative-workflow-
planning-boundary.md`, `docs/workflow-proposal-lifecycle.md` (4 mentions
including one markdown link), `docs/capability-contract-authoring-guide.md`.

## Definition of Done

- [x] All 5 duplicate ADR numbers resolved to unique numbers
- [x] `ls docs/adr/ | grep -oE "^[0-9]+" | sort -n | uniq -c` shows no count
      greater than 1
- [x] Every renumbered ADR's governing spec and `approved-specs.json` entry
      updated to match

## Validation

- [x] Spec alignment checked (declared specs above cover every changed path
      — `bash scripts/ci/spec_alignment_check.sh` passes locally)
- [x] `specs/governance/approved-specs.json` is valid JSON
      (`python3 -c "import json; json.load(open(...))"`)
- [x] No remaining reference anywhere in `docs/`/`specs/` to any of the 5
      old filenames (verified via repo-wide grep)
- [x] Every remaining bare `ADR-0011`/`0018`/`0024`/`0029`/`0041` mention
      was individually re-checked post-edit and confirmed to correctly refer
      to the sibling ADR that keeps that number

Fixes #1120.
