### PR TITLE
chore(governance): resolve 5 remaining duplicate ADR numbers

### DIFF
--- a/crates/traverse-contracts/src/lib.rs
+++ b/crates/traverse-contracts/src/lib.rs
@@ -77,7 +77,7 @@ pub struct CapabilityContract {
 }
 
 /// Portable, immutable capability authority metadata across four independent
-/// dimensions (ADR-0041). A capability's own contract is the only place these
+/// dimensions (ADR-0050). A capability's own contract is the only place these
 /// values may be declared; an application manifest may narrow how a capability
 /// is actually wired (for example connector selection) but can never override
 /// or weaken these classifications.

--- a/crates/traverse-contracts/src/proposal.rs
+++ b/crates/traverse-contracts/src/proposal.rs
@@ -1,6 +1,6 @@
 //! Runtime workflow proposal types, canonicalization, and digesting.
 //!
-//! Governed by spec `109-runtime-workflow-proposals` (P1) and ADR-0041. A
+//! Governed by spec `109-runtime-workflow-proposals` (P1) and ADR-0050. A
 //! proposal is an untrusted, externally-authored, ephemeral bounded sequential
 //! DAG over already-registered capabilities. This module owns the portable
 //! parts of the lifecycle that need no manifest or registry access: the wire
@@ -39,7 +39,7 @@ pub struct WorkflowProposal {
 }
 
 /// Identifies the exact, already-registered application manifest version a
-/// proposal is bounded by (spec 109 FR-002, ADR-0041: "a proposal is
+/// proposal is bounded by (spec 109 FR-002, ADR-0050: "a proposal is
 /// constrained by its versioned application manifest").
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ManifestReference {
@@ -610,7 +610,7 @@ pub fn proposal_digest(proposal: &WorkflowProposal) -> String {
 /// Binds a proposal digest to the pinned snapshot digests it was validated
 /// against (spec 109 FR-003: "bind its digest to pinned manifest, registry,
 /// binding, policy, and budget snapshots"). This is the digest an approval
-/// token is scoped to (ADR-0041, FR-006a) — it changes if any governing
+/// token is scoped to (ADR-0050, FR-006a) — it changes if any governing
 /// snapshot changes even when the proposal JSON is byte-identical.
 #[must_use]
 pub fn proposal_snapshot_digest(proposal_digest: &str, snapshots: &SnapshotDigests) -> String {

--- a/crates/traverse-mcp/src/tools/workflow_plan.rs
+++ b/crates/traverse-mcp/src/tools/workflow_plan.rs
@@ -56,7 +56,7 @@ pub struct PlanRequest<'a> {
     pub starting_facts: &'a Value,
     pub manifest: &'a ApplicationBundleManifest,
     /// The exact, already-registered application manifest reference every
-    /// returned candidate is bound to (spec 109 FR-002, ADR-0041). The
+    /// returned candidate is bound to (spec 109 FR-002, ADR-0050). The
     /// planner does not compute this itself -- the caller already holds it
     /// from resolving `manifest` against the application registry.
     pub app_manifest: &'a ManifestReference,

--- a/docs/adr/0030-runtime-usage-telemetry.md
+++ b/docs/adr/0030-runtime-usage-telemetry.md
@@ -5,7 +5,7 @@
 - Governing spec: `536-runtime-usage-telemetry` / `088-runtime-usage-telemetry`
 - Decision evidence: `docs/decision-log.md` Decision 42, originating in
   `traverse-framework/registry`'s Decision 47 (registry#134)
-- Extends: ADR-0029 (provider-neutral port precedent)
+- Extends: ADR-0049 (provider-neutral port precedent)
 
 ## Context
 
@@ -24,7 +24,7 @@ its own portability and that repo's inherited-governance boundary
 ## Decision
 
 Add a `UsageTelemetrySink` port trait to `traverse-contracts`, with a no-op
-default — the same provider-neutral-port pattern ADR-0029 established for
+default — the same provider-neutral-port pattern ADR-0049 established for
 hosted DataStore transport. `traverse-cli` owns the only real
 implementation: a persistent, prompt-free opt-in config command, a locally
 generated anonymous install ID, and an HTTPS client to a purpose-built

--- a/docs/adr/0043-declarative-workflow-planning-boundary.md
+++ b/docs/adr/0043-declarative-workflow-planning-boundary.md
@@ -42,7 +42,7 @@ chain from capability names, namespaces, or any other signal, and never
 operates on a capability pair with no structural match. When more than one
 capability could satisfy a need, the planner enumerates every resulting
 complete candidate plan rather than choosing one — ambiguity resolution is
-a caller/reviewer decision, never a runtime one, consistent with ADR-0041
+a caller/reviewer decision, never a runtime one, consistent with ADR-0050
 treating the planner-adjacent surface as untrusted and this runtime's
 everywhere-else stance against silent inference. Search is bounded by
 fixed, small, non-configurable limits in v1. Field-level JSON-path mappings
@@ -79,7 +79,7 @@ this risk; nothing a planner proposes ever executes unreviewed.
   runtime decision `109`'s explicit-mapping requirement exists to prevent.
 - Accept natural-language goals and interpret them in-runtime: rejected —
   reintroduces exactly the hosted-model dependency `109` FR-001 and
-  ADR-0041 explicitly excluded.
+  ADR-0050 explicitly excluded.
 - Loosen registry's FR-020 inventory criterion instead, keep `consumes`/
   `emits` as the sole signal: rejected — would require ~26 capabilities to
   carry full governed-event ceremony (privacy field classification,

--- a/docs/adr/0046-agent-artifact-stdout-only.md
+++ b/docs/adr/0046-agent-artifact-stdout-only.md
@@ -1,6 +1,8 @@
-# ADR 0011: Constrained stdout-only agent artifact output
+# ADR-0046: Constrained stdout-only agent artifact output
 
 **Status:** Approved (2026-07-21)
+**Renumbered:** 2026-08-24 from ADR-0011 (that number collided with the
+already-Accepted `docs/adr/0011-swift-native-resource-controls.md`)
 
 ## Context
 

--- a/docs/adr/0047-swift-host-coverage-gate-policy.md
+++ b/docs/adr/0047-swift-host-coverage-gate-policy.md
@@ -1,7 +1,9 @@
-# ADR-0018: Protect the Production Swift Host with a Measured Coverage Ratchet
+# ADR-0047: Protect the Production Swift Host with a Measured Coverage Ratchet
 
 - Status: Accepted
 - Date: 2026-07-22
+- Renumbered: 2026-08-24 from ADR-0018 (that number collided with the
+  already-Accepted `docs/adr/0018-durable-local-datastore.md`)
 - Governing specs: `001-foundation-v0-1`, `076-production-swift-wasmi-cabi`
 - Owner: Traverse maintainers
 - Review by: 2026-10-22

--- a/docs/adr/0048-mode-a-registry-mcp-host.md
+++ b/docs/adr/0048-mode-a-registry-mcp-host.md
@@ -1,7 +1,9 @@
-# ADR-0024: Mode A as a Local Registry-Backed Stdio MCP Host
+# ADR-0048: Mode A as a Local Registry-Backed Stdio MCP Host
 
 - Status: Accepted
 - Date: 2026-07-30
+- Renumbered: 2026-08-24 from ADR-0024 (that number collided with the
+  already-Accepted `docs/adr/0024-remote-key-value-datastore-contract.md`)
 - Governing spec: Approved `086-mode-a-registry-mcp` / `530-mode-a-registry-mcp`
 - Decided in: Traverse #865; governed by #906
 

--- a/docs/adr/0049-hosted-datastore-transport.md
+++ b/docs/adr/0049-hosted-datastore-transport.md
@@ -1,7 +1,9 @@
-# ADR-0029: Managed Hosted Transport Behind a Provider-Neutral Boundary
+# ADR-0049: Managed Hosted Transport Behind a Provider-Neutral Boundary
 
 - Status: Accepted
 - Date: 2026-07-30
+- Renumbered: 2026-08-24 from ADR-0029 (that number collided with the
+  already-Accepted `docs/adr/0029-s3-compatible-remote-datastore.md`)
 - Governing spec: `535-hosted-datastore-transport` / `087-hosted-datastore-transport`
 - Decision evidence: Traverse #887
 - Extends: ADR-0025, ADR-0028

--- a/docs/adr/0050-governed-runtime-workflow-proposal-authority.md
+++ b/docs/adr/0050-governed-runtime-workflow-proposal-authority.md
@@ -1,6 +1,8 @@
-# ADR-0041: Govern Runtime Workflow Proposals as Untrusted, Manifest-Bounded Snapshots
+# ADR-0050: Govern Runtime Workflow Proposals as Untrusted, Manifest-Bounded Snapshots
 
 - Status: Accepted
+- Renumbered: 2026-08-24 from ADR-0041 (that number collided with the
+  already-Accepted `docs/adr/0041-cross-host-embedded-registry-cache.md`)
 - Governing specs: `108-governed-runtime-workflow-composition`, `109-runtime-workflow-proposals`
 - Related issues: #865, #1089
 

--- a/docs/capability-contract-authoring-guide.md
+++ b/docs/capability-contract-authoring-guide.md
@@ -393,7 +393,7 @@ Use `"stateful"` only for capabilities that explicitly manage a persistent resou
 ## `risk` Reference (spec 109)
 
 Every contract carries an immutable `risk` classification across four
-independent dimensions (spec `109-runtime-workflow-proposals` FR-005, ADR-0041).
+independent dimensions (spec `109-runtime-workflow-proposals` FR-005, ADR-0050).
 A single field never implies another dimension — declare each one deliberately.
 
 ```json

--- a/docs/decision-log.md
+++ b/docs/decision-log.md
@@ -1221,7 +1221,7 @@ Traverse maintainers, not an operator-facing signal.
   to.
 - Architecturally: a `UsageTelemetrySink` port trait lives in
   `traverse-contracts` (the existing pattern for provider-neutral ports, see
-  ADR-0029's transport-port precedent) with a no-op default. `traverse-cli`
+  ADR-0049's transport-port precedent) with a no-op default. `traverse-cli`
   owns the only real adapter (config, install ID, PostHog HTTP client).
   `crates/traverse-registry` (external, `traverse-framework/registry`-owned)
   calls the port at its resolution call site but never depends on the
@@ -2221,7 +2221,7 @@ phase P0 of the existing `108` north star (not a standalone spec, since
   spec covering the same feature invites drift (cf. Decision 58's "do not
   create a parallel coverage law").
 - Accept and interpret natural-language goals in-runtime — rejected;
-  reintroduces the hosted-model dependency `109` FR-001 and ADR-0041
+  reintroduces the hosted-model dependency `109` FR-001 and ADR-0050
   explicitly excluded.
 
 ### Outcome

--- a/docs/quality-standards.md
+++ b/docs/quality-standards.md
@@ -33,7 +33,7 @@ Current phased floors:
 |---|---:|---:|---|
 | `traverse-cli` | 78% | 78.77% | [#618](https://github.com/traverse-framework/traverse/issues/618) |
 | `traverse-mcp` | 86% | 86.07% | [#617](https://github.com/traverse-framework/traverse/issues/617) |
-| `traverse-swift-host` | 78% | 78.66% | ADR-0018; raise to 100% before its next production release |
+| `traverse-swift-host` | 78% | 78.66% | ADR-0047; raise to 100% before its next production release |
 
 `traverse-swift-host` is included because it is the production, audited C-ABI
 boundary. `traverse-native-bridge` is a build-time fixture generator and

--- a/docs/workflow-proposal-lifecycle.md
+++ b/docs/workflow-proposal-lifecycle.md
@@ -1,13 +1,13 @@
 # Runtime Workflow Proposal Lifecycle (P1)
 
 Governed by spec [`109-runtime-workflow-proposals`](../specs/109-runtime-workflow-proposals/spec.md)
-and [ADR-0041](adr/0041-governed-runtime-workflow-proposal-authority.md). Tracks
+and [ADR-0050](adr/0050-governed-runtime-workflow-proposal-authority.md). Tracks
 issue `#1090`.
 
 A **workflow proposal** is an untrusted, externally-authored, ephemeral,
 manifest-bound bounded sequential DAG over already-registered capabilities.
 An MCP client (or any planner) submits one; Traverse validates, authorizes,
-and executes it — the planner is never the authority (ADR-0041).
+and executes it — the planner is never the authority (ADR-0050).
 
 ## Where the code lives
 
@@ -67,7 +67,7 @@ declared mapping (spec FR-002).
 - **`proposal_snapshot_digest`**: hashes `proposal_digest` together with the
   manifest/registry/binding/policy/budget digests supplied by the caller
   (`SnapshotDigests`). This is the digest an approval token is actually
-  scoped to (ADR-0041's "governing snapshots") — it changes if any pinned
+  scoped to (ADR-0050's "governing snapshots") — it changes if any pinned
   input changes even when the proposal JSON is byte-identical.
 
 ## Cross-validation (FR-004, FR-011)
@@ -141,7 +141,7 @@ revocation state, keyed by `jti`. Tokens are short-lived and scoped to one
 pinned snapshot, so no persistence across restarts is needed.
 
 **This repo verifies approval tokens; it does not issue them.** Per
-ADR-0041, the approving principal/service is external to Traverse — there is
+ADR-0050, the approving principal/service is external to Traverse — there is
 no token-signing code here, only verification.
 
 ## Quotas (FR-007b)

--- a/specs/530-mode-a-registry-mcp/spec.md
+++ b/specs/530-mode-a-registry-mcp/spec.md
@@ -2,7 +2,7 @@
 
 **Feature Branch**: `codex/issue-906-mode-a-mcp-spec`
 **Created**: 2026-07-30
-**Status**: Approved (2026-07-30 — approved by Enrico; ADR-0024 accepted)
+**Status**: Approved (2026-07-30 — approved by Enrico; ADR-0048 accepted)
 **Version**: 1.0.0
 **Input**: Traverse #865 decision records; governing ticket #906; Specs 015,
 042, 054, 055, 516, and 520.
@@ -189,5 +189,5 @@ product path after Mode A lands.
 ## Approval
 
 This immutable artifact governs implementation as approved Spec 086 after
-explicit reviewer approval, acceptance of ADR-0024, and registry evidence in
+explicit reviewer approval, acceptance of ADR-0048, and registry evidence in
 `specs/governance/approved-specs.json`.

--- a/specs/governance/approved-specs.json
+++ b/specs/governance/approved-specs.json
@@ -984,7 +984,7 @@
         "contracts/examples/",
         "examples/",
         "scripts/ci/",
-        "docs/adr/0011-agent-artifact-stdout-only.md",
+        "docs/adr/0046-agent-artifact-stdout-only.md",
         "specs/516-agent-artifact-execution/"
       ]
     },
@@ -1131,7 +1131,7 @@
         "crates/traverse-embedder/",
         "packages/",
         "examples/",
-        "docs/adr/0029-hosted-datastore-transport.md",
+        "docs/adr/0049-hosted-datastore-transport.md",
         "specs/535-hosted-datastore-transport/"
       ]
     },
@@ -1144,7 +1144,7 @@
       "governs": [
         "crates/traverse-mcp/",
         "docs/mcp-stdio-server.md",
-        "docs/adr/0024-mode-a-registry-mcp-host.md",
+        "docs/adr/0048-mode-a-registry-mcp-host.md",
         "specs/530-mode-a-registry-mcp/"
       ]
     },
@@ -1428,7 +1428,7 @@
         "specs/111-durable-dynamic-orchestration/",
         "specs/112-governed-workflow-promotion/",
         "specs/113-declarative-workflow-planning/",
-        "docs/adr/0041-governed-runtime-workflow-proposal-authority.md",
+        "docs/adr/0050-governed-runtime-workflow-proposal-authority.md",
         "docs/adr/0042-phased-dynamic-orchestration-evolution.md",
         "docs/decision-log.md",
         "docs/adr/0043-declarative-workflow-planning-boundary.md"


### PR DESCRIPTION
## Governing Spec

- 065-sigstore-bundle-verification
- 004-spec-alignment-gate
- 516-agent-artifact-execution
- 086-mode-a-registry-mcp
- 087-hosted-datastore-transport
- 108-governed-runtime-workflow-composition
- 109-runtime-workflow-proposals
- 102-contract-surface-coverage
- 001-foundation-v0-1

N/A per the issue itself: "this is a documentation/governance hygiene fix,
not new product scope." The IDs above are the pre-existing approved specs
whose `governs` prefixes cover the changed files (docs/, the specific ADR's
governing spec, and `specs/governance/approved-specs.json`), declared per
`004-spec-alignment-gate`'s per-file at-least-one-declared-spec rule.

## Project Item

https://github.com/traverse-framework/traverse/issues/1120

## Summary

Resolves the 5 remaining ADR filename number collisions that were deferred
per an explicit brainstorm decision (2026-08-24, same session as #1119)
while fixing the ADR-0027->0045 durable-trace collision.

For each pair, keeps the older ADR (by its own recorded date where the file
has one; otherwise by git first-commit timestamp / issue number, since
neither file had an explicit date) at its current number, and renumbers the
newer one to the next free number (0046-0050):

- `0011-agent-artifact-stdout-only.md` -> `0046` (collided with
  `0011-swift-native-resource-controls.md`, dated 2026-07-18 vs. this ADR's
  own 2026-07-21)
- `0018-swift-host-coverage-gate-policy.md` -> `0047` (collided with
  `0018-durable-local-datastore.md`, dated 2026-07-21 vs. this ADR's own
  2026-07-22)
- `0024-mode-a-registry-mcp-host.md` -> `0048` (collided with
  `0024-remote-key-value-datastore-contract.md`; neither has an in-file
  date, first commit 2026-07-29 vs. this ADR's 2026-08-04)
- `0029-hosted-datastore-transport.md` -> `0049` (collided with
  `0029-s3-compatible-remote-datastore.md`; neither has an in-file date,
  issue #901 committed ~20 minutes before this ADR's issue #904, both on
  2026-07-30)
- `0041-governed-runtime-workflow-proposal-authority.md` -> `0050`
  (collided with `0041-cross-host-embedded-registry-cache.md`; neither has
  an in-file date, first commit 2026-08-17 vs. this ADR's 2026-08-21)

## Changes

- Each renumbered file: header updated to the new `# ADR-00NN:` number, plus
  a `Renumbered` note in the same style established by ADR-0027->0045
  (#1119), citing the collision and the ADR that kept the old number.
- `specs/governance/approved-specs.json`: updated the `governs` entry to the
  new filename for every spec that referenced a renumbered ADR by path
  (`516-agent-artifact-execution`, `087-hosted-datastore-transport`,
  `086-mode-a-registry-mcp`, `108-governed-runtime-workflow-composition`).
  `0018-swift-host-coverage-gate-policy.md` had no `governs` entry
  referencing it, so nothing to update there.
- `specs/530-mode-a-registry-mcp/spec.md`: both `ADR-0024` mentions ->
  `ADR-0048`.
- Every other cross-reference found by searching `docs/`, `specs/`, and
  `crates/` for the old filenames and for bare `ADR-00NN` mentions whose
  surrounding context matched the renumbered ADR's topic (not its
  same-numbered sibling's):
  - `docs/quality-standards.md` (swift-host coverage row)
  - `docs/decision-log.md` (`ADR-0029`'s transport-port precedent; the
    `109`/`ADR-0041` workflow-proposal mention)
  - `docs/adr/0030-runtime-usage-telemetry.md` (`Extends: ADR-0029`, and the
    "same provider-neutral-port pattern ADR-0029 established for hosted
    DataStore transport" prose)
  - `docs/workflow-proposal-lifecycle.md` (4 mentions, including the
    ADR link)
  - `docs/capability-contract-authoring-guide.md`
  - `docs/adr/0043-declarative-workflow-planning-boundary.md` (2 mentions)
  - `crates/traverse-contracts/src/proposal.rs` (3 doc comments),
    `crates/traverse-contracts/src/lib.rs`,
    `crates/traverse-mcp/src/tools/workflow_plan.rs`

Confirmed every remaining bare `ADR-0011`/`0018`/`0024`/`0029`/`0041` mention
in the repo still correctly names the ADR that kept that number (not the one
renumbered away) before considering this complete.

## Validation

- [x] Spec alignment checked (`bash scripts/ci/spec_alignment_check.sh` —
      passing locally against this branch)
- [x] `ls docs/adr/ | grep -oE "^[0-9]+" | sort -n | uniq -c` — no count
      greater than 1 (no remaining duplicate ADR numbers)
- [x] No remaining stale references to any of the 5 old filenames anywhere
      in `docs/`, `specs/`, or `crates/`
- [x] `cargo build` (workspace) after editing the 3 Rust doc-comment-only
      files — comment-only changes, no behavior change
