### PR TITLE
fix(ci): clear stale coverage artifacts before measuring

### DIFF
--- a/crates/traverse-cli/src/main.rs
+++ b/crates/traverse-cli/src/main.rs
@@ -6978,7 +6978,7 @@ mod tests {
     use std::path::{Path, PathBuf};
     use std::process::Command as ProcessCommand;
     use std::sync::atomic::{AtomicU64, Ordering};
-    use std::sync::{Arc, Mutex};
+    use std::sync::{Arc, Mutex, OnceLock};
     use std::time::{SystemTime, UNIX_EPOCH};
     use traverse_contracts::parse_contract;
     use traverse_contracts::{UsageEvent, UsageEventKind, UsageTelemetrySink};
@@ -11162,7 +11162,16 @@ mod tests {
         manifest_path: PathBuf,
     }
 
+    // Fixture scripts invoke `rustup rustc` and write committed example artifacts.
+    // Serialise those shared external operations so the parallel test runner cannot
+    // contend on rustup's toolchain state or an artifact file.
+    static CAPABILITY_PACKAGE_BUILD_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+
     fn build_real_capability_package_artifact(manifest_path: &Path) {
+        let _build_lock = CAPABILITY_PACKAGE_BUILD_LOCK
+            .get_or_init(|| Mutex::new(()))
+            .lock()
+            .expect("capability package build lock should not be poisoned");
         let package_dir = manifest_path
             .parent()
             .expect("real capability package manifest must have a package directory");

--- a/docs/quality-standards.md
+++ b/docs/quality-standards.md
@@ -31,8 +31,11 @@ Current phased floors:
 
 | Crate | Gate floor | Measured baseline | Follow-up |
 |---|---:|---:|---|
-| `traverse-cli` | 78% | 78.77% | [#618](https://github.com/traverse-framework/traverse/issues/618) |
-| `traverse-mcp` | 86% | 86.07% | [#617](https://github.com/traverse-framework/traverse/issues/617) |
+| `traverse-contracts` | 100% | 100.00% | Keep the protected floor |
+| `traverse-runtime` | 100% | 100.00% | [#1126](https://github.com/traverse-framework/traverse/issues/1126) — isolated gate cleanup |
+| `traverse-cli` | 87% | 87.57% | [#618](https://github.com/traverse-framework/traverse/issues/618) |
+| `traverse-embedder` | 100% | 100.00% | Keep the protected floor |
+| `traverse-mcp` | 98% | 99.11% | [#617](https://github.com/traverse-framework/traverse/issues/617) |
 | `traverse-swift-host` | 78% | 78.66% | ADR-0047; raise to 100% before its next production release |
 
 `traverse-swift-host` is included because it is the production, audited C-ABI

--- a/scripts/ci/coverage_gate.sh
+++ b/scripts/ci/coverage_gate.sh
@@ -40,6 +40,10 @@ if [[ -z "${LLVM_COV:-}" || -z "${LLVM_PROFDATA:-}" ]]; then
   fi
 fi
 
+# Do not aggregate stale instrumentation from an earlier coverage invocation.
+# Each crate below must be measured against its own current test execution.
+cargo llvm-cov clean --workspace
+
 failed=0
 
 for entry in "${targets[@]}"; do


### PR DESCRIPTION
## Summary

- clear stale LLVM coverage artifacts before measuring protected crates
- serialize shared capability-fixture builds in the parallel CLI test suite
- correct the documented coverage-floor baseline table

## Governing Spec

- `001-foundation-v0-1`
- `004-spec-alignment-gate`

Coverage-ratchet precedent: ADR-0047.

## Project Item

- Closes #1126

## Definition of Done

- [x] Protected crates are measured from clean coverage artifacts
- [x] Existing configured floors remain enforced
- [x] Coverage gate passes deterministically

## Validation

- `bash scripts/ci/coverage_gate.sh`
