### PR TITLE
CI: scope heavy PR checks to code changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,33 @@ on:
   pull_request:
 
 jobs:
+  classify-changes:
+    runs-on: ubuntu-latest
+    outputs:
+      full_ci: ${{ steps.classify.outputs.full_ci }}
+      reason: ${{ steps.classify.outputs.reason }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Classify validation scope
+        id: classify
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          GITHUB_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          GITHUB_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          if [[ "${EVENT_NAME}" != "pull_request" ]]; then
+            echo "full_ci=true" >> "$GITHUB_OUTPUT"
+            echo "reason=non-PR events always run full validation" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          bash scripts/ci/pr_change_classification.sh >> "$GITHUB_OUTPUT"
+
   version-guard:
     runs-on: ubuntu-latest
 
@@ -53,6 +80,8 @@ jobs:
           echo "Cargo.toml workspace version ${workspace_version} matches ${tag_name}."
 
   repository-checks:
+    needs: classify-changes
+    if: needs.classify-changes.outputs.full_ci == 'true'
     runs-on: ubuntu-latest
 
     steps:
@@ -154,6 +183,8 @@ jobs:
         run: bash scripts/ci/embedder_conformance/rust_package.sh
 
   web-embedder-package:
+    needs: classify-changes
+    if: needs.classify-changes.outputs.full_ci == 'true'
     runs-on: ubuntu-latest
 
     steps:
@@ -169,6 +200,8 @@ jobs:
         run: bash scripts/ci/embedder_conformance/web_package.sh
 
   native-artifact-certification:
+    needs: classify-changes
+    if: needs.classify-changes.outputs.full_ci == 'true'
     runs-on: macos-latest
 
     steps:
@@ -195,6 +228,8 @@ jobs:
         run: bash scripts/ci/native_artifact_certification.sh
 
   coverage-gate:
+    needs: classify-changes
+    if: needs.classify-changes.outputs.full_ci == 'true'
     runs-on: ubuntu-latest
 
     steps:
@@ -220,6 +255,8 @@ jobs:
         run: bash scripts/ci/coverage_gate.sh
 
   stress-test:
+    needs: classify-changes
+    if: needs.classify-changes.outputs.full_ci == 'true'
     name: ThreadPoolExecutor stress (${{ matrix.target }})
     runs-on: ${{ matrix.os }}
     timeout-minutes: 20

--- a/docs/quality-standards.md
+++ b/docs/quality-standards.md
@@ -20,6 +20,22 @@ The coverage gate is merge-safe even before core logic exists. It passes when no
 The gate runs crate tests with `--test-threads=1` so coverage instrumentation is
 measured against deterministic package-local state.
 
+## Pull Request Validation Scope
+
+All pull requests run the org governance and CLA workflows, PR-body hygiene,
+and spec-alignment. The heavyweight runtime, coverage, native-artifact,
+embedder, and platform-stress jobs run only when the changed paths require
+them.
+
+The allowlist for documentation-only pull requests is deliberately narrow:
+`docs/**`, `adr/**`, non-governing `specs/**`, and the repository's top-level
+documentation files. Any other path — including contracts, examples, Cargo
+files, CI scripts, GitHub workflows, and `specs/governance/**` — runs full CI.
+This conservative default means a new artifact type cannot silently bypass
+validation. The classifier and its executable checks live in
+`scripts/ci/pr_change_classification.sh` and
+`scripts/ci/pr_change_classification_test.sh`.
+
 ### Phased Coverage Floors
 
 The constitution target for core logic remains 100% line coverage. When a crate

--- a/scripts/ci/pr_change_classification.sh
+++ b/scripts/ci/pr_change_classification.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# Classify a PR as documentation-only only when every changed path is explicitly
+# allowlisted. Unknown paths deliberately require full validation.
+readonly DOCS_ONLY_PATHS=(
+  'README.md'
+  'CONTRIBUTING.md'
+  'CODE_OF_CONDUCT.md'
+  'SECURITY.md'
+  'SUPPORT.md'
+  'quickstart.md'
+)
+
+is_docs_only_path() {
+  local path="$1"
+
+  case "$path" in
+    docs/*|adr/*)
+      return 0
+      ;;
+    specs/governance/*)
+      # This registry determines the scope of the spec-alignment gate.
+      return 1
+      ;;
+    specs/*)
+      return 0
+      ;;
+  esac
+
+  local allowed
+  for allowed in "${DOCS_ONLY_PATHS[@]}"; do
+    [[ "$path" == "$allowed" ]] && return 0
+  done
+
+  return 1
+}
+
+read_changed_paths() {
+  if [[ "${1:-}" == "--paths-stdin" ]]; then
+    cat
+    return
+  fi
+
+  local base_sha="${1:-${GITHUB_BASE_SHA:-}}"
+  local head_sha="${2:-${GITHUB_HEAD_SHA:-HEAD}}"
+  [[ -n "$base_sha" ]] || {
+    echo "Usage: $0 <base-sha> [head-sha], or --paths-stdin" >&2
+    exit 1
+  }
+  git diff --name-only "${base_sha}...${head_sha}"
+}
+
+full_ci=false
+reason="documentation-only change"
+paths=()
+
+while IFS= read -r path; do
+  [[ -z "$path" ]] && continue
+  paths+=("$path")
+  if ! is_docs_only_path "$path"; then
+    full_ci=true
+    reason="full validation required by ${path}"
+    break
+  fi
+done < <(read_changed_paths "$@")
+
+if [[ ${#paths[@]} -eq 0 ]]; then
+  full_ci=true
+  reason="no changed paths were available"
+fi
+
+printf 'full_ci=%s\n' "$full_ci"
+printf 'reason=%s\n' "$reason"

--- a/scripts/ci/pr_change_classification_test.sh
+++ b/scripts/ci/pr_change_classification_test.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+classifier="$(cd "$(dirname "$0")" && pwd)/pr_change_classification.sh"
+
+assert_classification() {
+  local expected="$1"
+  shift
+  local actual
+  actual="$(printf '%s\n' "$@" | "$classifier" --paths-stdin | awk -F= '/^full_ci=/{print $2}')"
+  [[ "$actual" == "$expected" ]] || {
+    echo "expected full_ci=${expected}, got ${actual}" >&2
+    exit 1
+  }
+}
+
+assert_classification false docs/getting-started.md docs/adr/0051-risk-based-ci.md specs/105-example/spec.md
+assert_classification true specs/governance/approved-specs.json
+assert_classification true crates/traverse-runtime/src/lib.rs
+assert_classification true .github/workflows/ci.yml
+assert_classification true scripts/ci/rust_checks.sh
+
+echo "PR change classification tests passed."


### PR DESCRIPTION
## Summary

Use a conservative changed-path classifier so documentation-only pull requests do not run unrelated heavyweight runtime validation.

Closes #1136

## Governing Spec

- `004-spec-alignment-gate`
- `031-supply-chain-hardening`
- `062-runtime-target-matrix`
- `065-sigstore-bundle-verification`

## Project Item

- https://github.com/orgs/traverse-framework/projects/1/

## What Changed

- Contracts changed: No.
- Runtime behavior changed: No; pull-request validation selection is now path-aware.
- Compatibility impact: None.
- ADR needed or linked: No; this is a CI policy implementation under the existing governance and quality standards.

## Validation

- [x] Spec alignment checked
- [x] Contract alignment checked
- [x] Tests updated and passing
- [x] Core coverage preserved
- [x] Required validation gates passing

## Notes

Unknown paths default to full CI. Existing required job names remain in the workflow, so branch protection records skipped heavyweight jobs as successful for documentation-only PRs.
