### PR TITLE
fix(cli): serialize capability-package fixture builds to stop parallel-test rustc race

### DIFF
--- a/crates/traverse-cli/src/main.rs
+++ b/crates/traverse-cli/src/main.rs
@@ -11163,9 +11163,32 @@ mod tests {
     }
 
     fn build_real_capability_package_artifact(manifest_path: &Path) {
+        use std::collections::HashSet;
+        use std::sync::OnceLock;
+
+        // build-fixture.sh shells out to `rustc` directly and writes to a
+        // fixed path under the fixture's own artifacts/ directory. When two
+        // tests build the same fixture, running their rustc invocations
+        // concurrently races on that shared output path (rustc stages
+        // intermediate .rcgu.o codegen-unit objects alongside it). Since the
+        // resulting artifact is deterministic for a given source, serialize
+        // all fixture builds through one lock and skip rebuilding a fixture
+        // that's already been built this test run.
+        static BUILT_FIXTURES: OnceLock<Mutex<HashSet<PathBuf>>> = OnceLock::new();
+        let built_fixtures = BUILT_FIXTURES.get_or_init(|| Mutex::new(HashSet::new()));
+
         let package_dir = manifest_path
             .parent()
-            .expect("real capability package manifest must have a package directory");
+            .expect("real capability package manifest must have a package directory")
+            .to_path_buf();
+
+        let mut built = built_fixtures
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        if built.contains(&package_dir) {
+            return;
+        }
+
         let status = ProcessCommand::new("bash")
             .arg(package_dir.join("build-fixture.sh"))
             .status()
@@ -11174,6 +11197,7 @@ mod tests {
             status.success(),
             "real capability package fixture builder should succeed"
         );
+        built.insert(package_dir);
     }
 
     fn create_interpret_expedition_intent_capability_fixture() -> CapabilityPackageFixture {


### PR DESCRIPTION
## Summary
- Fix a flaky-test race in traverse-cli-rs's test suite: two tests each build the same real WASM capability-package fixture (expedition-intent-agent, team-readiness-agent) via `build_real_capability_package_artifact`, which shells out to `build-fixture.sh` and invokes `rustc` directly against a fixed output path under the fixture's `artifacts/` dir.
- Under cargo test's default parallelism these concurrent rustc invocations can race on that shared output path, intermittently failing the linker with `cannot open .../interpret-expedition-intent-agent.agent.<hash>-cgu.0.rcgu.o: No such file or directory` (observed twice on PR #1118's CI, always on the redundant push-triggered run, resolved by a plain re-run both times).
- `build_real_capability_package_artifact` now serializes all fixture builds through a single lock and skips rebuilding a fixture already built during the current test run, since the artifact is deterministic for a given source.
- Test-infrastructure only: no capability logic or governed contract changed.

## Test plan
- [x] `cargo test -p traverse-cli-rs --bin traverse-cli` x10 with default parallelism — 399/399 pass every run, each racing fixture builds exactly once per run
- [x] `cargo test --workspace` — all crates pass
- [x] `cargo clippy -p traverse-cli-rs --tests -- -D warnings` — clean
- [x] `cargo fmt -p traverse-cli-rs -- --check` — clean
- [x] `BASE_SHA=origin/main bash scripts/ci/local_preflight.sh --pr-body <this file>` — full local preflight (repository checks, Rust/WASM checks, coverage gate, spec alignment, web embedder conformance) passed

## Governing Spec
- `105-standalone-capability-packages`
