### PR TITLE
feat(embedder): cache verified public metadata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2695,9 +2695,9 @@ dependencies = [
 
 [[package]]
 name = "traverse-registry"
-version = "0.15.0"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5006c40e012370afec3427a7fcb164c9285bdc0f6469003b859cc086ecd9f001"
+checksum = "7cc8dc2e3524d5a839510f3734f37b945e2d554d6e77820baddaba2016bd640a"
 dependencies = [
  "semver",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ version = "0.9.1"
 
 [workspace.dependencies]
 traverse-contracts = { path = "crates/traverse-contracts", version = "0.9.1" }
-traverse-registry = { version = "=0.15.0" }
+traverse-registry = { version = "=0.15.1" }
 traverse-runtime = { path = "crates/traverse-runtime", version = "0.9.1" }
 
 # The published registry crate pins the current contracts release.  During

--- a/crates/traverse-cli/src/main.rs
+++ b/crates/traverse-cli/src/main.rs
@@ -8707,7 +8707,9 @@ mod tests {
                     contract_digest: contract_digest.clone(),
                     contract_url: format!("file://{}", contract_path.display()),
                     deprecated: false,
-                    summary: String::new(), description: String::new(), use_cases: Vec::new(),
+                    summary: String::new(),
+                    description: String::new(),
+                    use_cases: Vec::new(),
                 }],
             },
         )
@@ -9773,7 +9775,9 @@ mod tests {
             contract_digest: "sha256:contract".to_string(),
             contract_url: "https://example.invalid/contract.json".to_string(),
             deprecated: false,
-            summary: String::new(), description: String::new(), use_cases: Vec::new(),
+            summary: String::new(),
+            description: String::new(),
+            use_cases: Vec::new(),
         };
 
         let registered = load_registered_bundle_with_public_records(&manifest_path, &[public])
@@ -10902,7 +10906,9 @@ mod tests {
             contract_digest: "sha256:fixture-contract".to_string(),
             contract_url: "https://example.test/contract.json".to_string(),
             deprecated: false,
-            summary: String::new(), description: String::new(), use_cases: Vec::new(),
+            summary: String::new(),
+            description: String::new(),
+            use_cases: Vec::new(),
         }
     }
 

--- a/crates/traverse-cli/src/main.rs
+++ b/crates/traverse-cli/src/main.rs
@@ -8707,6 +8707,7 @@ mod tests {
                     contract_digest: contract_digest.clone(),
                     contract_url: format!("file://{}", contract_path.display()),
                     deprecated: false,
+                    summary: String::new(), description: String::new(), use_cases: Vec::new(),
                 }],
             },
         )
@@ -9772,6 +9773,7 @@ mod tests {
             contract_digest: "sha256:contract".to_string(),
             contract_url: "https://example.invalid/contract.json".to_string(),
             deprecated: false,
+            summary: String::new(), description: String::new(), use_cases: Vec::new(),
         };
 
         let registered = load_registered_bundle_with_public_records(&manifest_path, &[public])
@@ -10881,6 +10883,7 @@ mod tests {
                 contract_digest: "sha256:5647c39a".to_string(),
                 contract_url: "https://github.com/traverse-framework/registry/releases/download/artifacts/traverse-starter.process-1.0.0/contract.json".to_string(),
                 deprecated: false,
+                summary: String::new(), description: String::new(), use_cases: Vec::new(),
             }],
         }
     }
@@ -10899,6 +10902,7 @@ mod tests {
             contract_digest: "sha256:fixture-contract".to_string(),
             contract_url: "https://example.test/contract.json".to_string(),
             deprecated: false,
+            summary: String::new(), description: String::new(), use_cases: Vec::new(),
         }
     }
 

--- a/crates/traverse-embedder/src/lib.rs
+++ b/crates/traverse-embedder/src/lib.rs
@@ -2268,6 +2268,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::too_many_lines)]
     fn offline_registry_resolver_loads_prepared_contract_and_reports_missing() {
         use crate::registry_cache::{
             HostRegistryCache, RegistryArtifactFetcher, prepare, resolve_component,

--- a/crates/traverse-embedder/src/lib.rs
+++ b/crates/traverse-embedder/src/lib.rs
@@ -85,9 +85,9 @@ mod registry_cache;
 mod test_double;
 
 pub use registry_cache::{
-    HostRegistryCache, RegistryArtifactFetcher, RegistryCacheError, RegistryCacheErrorCode,
-    PublicCapabilityMetadata, RegistryPrepareEvidence, VerifiedRegistryDependency,
-    publish_public_metadata, read_public_metadata, prepare as prepare_registry_dependency,
+    HostRegistryCache, PublicCapabilityMetadata, RegistryArtifactFetcher, RegistryCacheError,
+    RegistryCacheErrorCode, RegistryPrepareEvidence, VerifiedRegistryDependency,
+    prepare as prepare_registry_dependency, publish_public_metadata, read_public_metadata,
     resolve_component as resolve_registry_component,
     resolve_offline as resolve_registry_dependency_offline,
 };

--- a/crates/traverse-embedder/src/lib.rs
+++ b/crates/traverse-embedder/src/lib.rs
@@ -86,7 +86,8 @@ mod test_double;
 
 pub use registry_cache::{
     HostRegistryCache, RegistryArtifactFetcher, RegistryCacheError, RegistryCacheErrorCode,
-    RegistryPrepareEvidence, VerifiedRegistryDependency, prepare as prepare_registry_dependency,
+    PublicCapabilityMetadata, RegistryPrepareEvidence, VerifiedRegistryDependency,
+    publish_public_metadata, read_public_metadata, prepare as prepare_registry_dependency,
     resolve_component as resolve_registry_component,
     resolve_offline as resolve_registry_dependency_offline,
 };
@@ -2317,6 +2318,9 @@ mod tests {
             contract_digest: contract_digest.clone(),
             contract_url: "https://example.test/process.json".to_string(),
             deprecated: false,
+            summary: String::new(),
+            description: String::new(),
+            use_cases: Vec::new(),
         };
         let snapshot = SyncedPublicRegistryState {
             schema_version: "1".to_string(),

--- a/crates/traverse-embedder/src/registry_cache.rs
+++ b/crates/traverse-embedder/src/registry_cache.rs
@@ -206,6 +206,11 @@ struct PublicMetadataGeneration {
 
 /// Atomically publish the verified public-only projection of a synced registry state.
 /// This is explicit preparation; it performs neither network I/O nor implicit refresh.
+///
+/// # Errors
+///
+/// Returns a stable registry-cache error when the supplied state is empty or
+/// the complete generation cannot be atomically persisted.
 pub fn publish_public_metadata(
     cache: &HostRegistryCache,
     snapshot: &SyncedPublicRegistryState,
@@ -250,6 +255,11 @@ pub fn publish_public_metadata(
 }
 
 /// Read one complete verified metadata generation without network access.
+///
+/// # Errors
+///
+/// Returns a stable registry-cache error when the generation is missing,
+/// malformed, unsupported, or has invalid digest/provenance bindings.
 pub fn read_public_metadata(
     cache: &HostRegistryCache,
 ) -> Result<(Vec<PublicCapabilityMetadata>, bool), RegistryCacheError> {

--- a/crates/traverse-embedder/src/registry_cache.rs
+++ b/crates/traverse-embedder/src/registry_cache.rs
@@ -13,7 +13,7 @@ use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
 use traverse_contracts::parse_contract;
 use traverse_registry::{
-    PublicRegistryCapabilityRecord, RegistryReference, ResolvedRegistryComponent,
+    PublicRegistryCapabilityRecord, PublicUseCaseSummary, RegistryReference, ResolvedRegistryComponent,
     SyncedPublicRegistryState,
 };
 
@@ -32,6 +32,8 @@ pub enum RegistryCacheErrorCode {
     RegistryArtifactDigestMismatch,
     /// Offline resolve found no verified cache entry for the reference.
     RegistryCacheEntryMissing,
+    /// Public metadata generation is missing, malformed, incompatible, or unverified.
+    RegistryMetadataCacheInvalid,
 }
 
 impl RegistryCacheErrorCode {
@@ -45,6 +47,7 @@ impl RegistryCacheErrorCode {
             Self::RegistryPrepareFailed => "registry_prepare_failed",
             Self::RegistryArtifactDigestMismatch => "registry_artifact_digest_mismatch",
             Self::RegistryCacheEntryMissing => "registry_cache_entry_missing",
+            Self::RegistryMetadataCacheInvalid => "registry_metadata_cache_invalid",
         }
     }
 }
@@ -172,6 +175,68 @@ impl HostRegistryCache {
         );
         self.root.join("refs").join(format!("{key}.json"))
     }
+
+    fn public_metadata_path(&self) -> PathBuf {
+        self.root.join("public-metadata").join("current.json")
+    }
+}
+
+/// A sanitized, searchable public capability record (Spec 116).
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct PublicCapabilityMetadata {
+    pub namespace: String,
+    pub id: String,
+    pub version: String,
+    pub artifact_digest: String,
+    pub source_release: String,
+    pub index_digest: String,
+    pub summary: String,
+    pub description: String,
+    pub scenarios: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+struct PublicMetadataGeneration {
+    schema_version: u32,
+    stale: bool,
+    source_release: String,
+    index_digest: String,
+    records: Vec<PublicCapabilityMetadata>,
+}
+
+/// Atomically publish the verified public-only projection of a synced registry state.
+/// This is explicit preparation; it performs neither network I/O nor implicit refresh.
+pub fn publish_public_metadata(
+    cache: &HostRegistryCache,
+    snapshot: &SyncedPublicRegistryState,
+    stale: bool,
+) -> Result<(), RegistryCacheError> {
+    if snapshot.capabilities.is_empty() {
+        return Err(RegistryCacheError::new(RegistryCacheErrorCode::RegistrySyncMissing, "synced registry index snapshot contains no capabilities"));
+    }
+    let index_digest = index_snapshot_digest(snapshot);
+    let records = snapshot.capabilities.iter().map(|record| PublicCapabilityMetadata {
+        namespace: record.namespace.clone(), id: record.id.clone(), version: record.version.clone(),
+        artifact_digest: record.digest.clone(), source_release: snapshot.release_tag.clone(),
+        index_digest: index_digest.clone(), summary: record.summary.clone(), description: record.description.clone(),
+        scenarios: record.use_cases.iter().map(|use_case| use_case.scenario.clone()).collect(),
+    }).collect();
+    write_json_atomic(&cache.public_metadata_path(), &PublicMetadataGeneration {
+        schema_version: 1, stale, source_release: snapshot.release_tag.clone(), index_digest, records,
+    })
+}
+
+/// Read one complete verified metadata generation without network access.
+pub fn read_public_metadata(cache: &HostRegistryCache) -> Result<(Vec<PublicCapabilityMetadata>, bool), RegistryCacheError> {
+    let bytes = fs::read(cache.public_metadata_path()).map_err(|_| RegistryCacheError::new(RegistryCacheErrorCode::RegistryMetadataCacheInvalid, "public metadata cache generation is missing"))?;
+    let generation: PublicMetadataGeneration = serde_json::from_slice(&bytes).map_err(|_| RegistryCacheError::new(RegistryCacheErrorCode::RegistryMetadataCacheInvalid, "public metadata cache generation is malformed"))?;
+    if generation.schema_version != 1 || generation.source_release.is_empty() || normalize_digest(&generation.index_digest).is_none() || generation.records.iter().any(|record| {
+        record.namespace.is_empty() || record.id.is_empty() || record.version.is_empty() ||
+        normalize_digest(&record.artifact_digest).is_none() || record.source_release != generation.source_release || record.index_digest != generation.index_digest
+    }) {
+        return Err(RegistryCacheError::new(RegistryCacheErrorCode::RegistryMetadataCacheInvalid, "public metadata cache generation has invalid verification bindings"));
+    }
+    Ok((generation.records, generation.stale))
 }
 
 /// FR-008 resolution evidence retained after a successful prepare.
@@ -684,6 +749,9 @@ mod tests {
             contract_digest,
             contract_url: "https://example.test/greet.json".to_string(),
             deprecated,
+            summary: "Greeting".to_string(),
+            description: "Greets a person".to_string(),
+            use_cases: Vec::new(),
         };
         let older = PublicRegistryCapabilityRecord {
             namespace: "demo".to_string(),
@@ -694,6 +762,9 @@ mod tests {
             contract_digest: digest_for(b"older-contract"),
             contract_url: "https://example.test/older.json".to_string(),
             deprecated: false,
+            summary: String::new(),
+            description: String::new(),
+            use_cases: Vec::new(),
         };
         let snapshot = SyncedPublicRegistryState {
             schema_version: "1".to_string(),
@@ -1208,6 +1279,9 @@ mod tests {
                 contract_digest: digest_for(b"other-contract"),
                 contract_url: "https://example.test/other.json".to_string(),
                 deprecated: false,
+                summary: String::new(),
+                description: String::new(),
+                use_cases: Vec::new(),
             },
         );
         let evidence = prepare(&cache, &snapshot, &reference, &fetcher).expect("prepare");
@@ -1298,6 +1372,9 @@ mod tests {
             contract_digest,
             contract_url: "https://example.test/greet.json".to_string(),
             deprecated: false,
+            summary: String::new(),
+            description: String::new(),
+            use_cases: Vec::new(),
         };
         let snapshot = SyncedPublicRegistryState {
             schema_version: "1".to_string(),
@@ -1344,6 +1421,9 @@ mod tests {
             contract_digest,
             contract_url: "https://example.test/greet.json".to_string(),
             deprecated: false,
+            summary: String::new(),
+            description: String::new(),
+            use_cases: Vec::new(),
         };
         let snapshot = SyncedPublicRegistryState {
             schema_version: "1".to_string(),
@@ -1372,5 +1452,35 @@ mod tests {
         prepare(&cache, &snapshot, &reference, &fetcher).expect("prepare");
         let failure = resolve_component(&cache, &reference).expect_err("utf8");
         assert_eq!(failure.code, RegistryCacheErrorCode::RegistryPrepareFailed);
+    }
+
+    #[test]
+    fn public_metadata_round_trip_is_sanitized_and_can_be_stale() {
+        let cache = unique_cache();
+        let (mut snapshot, _, _) = sample_snapshot(false);
+        let record = snapshot.capabilities.last_mut().expect("record");
+        record.summary = "Greeting capability".to_string();
+        record.description = "Greets a public user".to_string();
+        record.use_cases = vec![PublicUseCaseSummary { scenario: "Greet a new user".to_string() }];
+        publish_public_metadata(&cache, &snapshot, true).expect("publish");
+        let (records, stale) = read_public_metadata(&cache).expect("read");
+        assert!(stale);
+        assert!(records.iter().any(|record| record.description == "Greets a public user" && record.scenarios == ["Greet a new user"]));
+        let encoded = fs::read(cache.public_metadata_path()).expect("generation");
+        let text = String::from_utf8(encoded).expect("utf8");
+        assert!(!text.contains("input_example"));
+        assert!(!text.contains("output_example"));
+    }
+
+    #[test]
+    fn public_metadata_rejects_tampered_generation_binding() {
+        let cache = unique_cache();
+        let (snapshot, _, _) = sample_snapshot(false);
+        publish_public_metadata(&cache, &snapshot, false).expect("publish");
+        let path = cache.public_metadata_path();
+        let mut generation: Value = serde_json::from_slice(&fs::read(&path).expect("read")).expect("json");
+        generation["records"][0]["index_digest"] = json!("sha256:0000000000000000000000000000000000000000000000000000000000000000");
+        write_json_atomic(&path, &generation).expect("tamper");
+        assert_eq!(read_public_metadata(&cache).expect_err("invalid").code, RegistryCacheErrorCode::RegistryMetadataCacheInvalid);
     }
 }

--- a/crates/traverse-embedder/src/registry_cache.rs
+++ b/crates/traverse-embedder/src/registry_cache.rs
@@ -1558,4 +1558,20 @@ mod tests {
             "registry_metadata_cache_invalid"
         );
     }
+
+    #[test]
+    fn public_metadata_fails_closed_for_missing_and_malformed_generations() {
+        let cache = unique_cache();
+        assert_eq!(
+            read_public_metadata(&cache).expect_err("missing").code,
+            RegistryCacheErrorCode::RegistryMetadataCacheInvalid
+        );
+        let path = cache.public_metadata_path();
+        fs::create_dir_all(path.parent().expect("parent")).expect("directory");
+        fs::write(&path, b"not json").expect("malformed generation");
+        assert_eq!(
+            read_public_metadata(&cache).expect_err("malformed").code,
+            RegistryCacheErrorCode::RegistryMetadataCacheInvalid
+        );
+    }
 }

--- a/crates/traverse-embedder/src/registry_cache.rs
+++ b/crates/traverse-embedder/src/registry_cache.rs
@@ -13,7 +13,7 @@ use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
 use traverse_contracts::parse_contract;
 use traverse_registry::{
-    PublicRegistryCapabilityRecord, PublicUseCaseSummary, RegistryReference, ResolvedRegistryComponent,
+    PublicRegistryCapabilityRecord, RegistryReference, ResolvedRegistryComponent,
     SyncedPublicRegistryState,
 };
 
@@ -1461,7 +1461,7 @@ mod tests {
         let record = snapshot.capabilities.last_mut().expect("record");
         record.summary = "Greeting capability".to_string();
         record.description = "Greets a public user".to_string();
-        record.use_cases = vec![PublicUseCaseSummary { scenario: "Greet a new user".to_string() }];
+        record.use_cases = vec![traverse_registry::PublicUseCaseSummary { scenario: "Greet a new user".to_string() }];
         publish_public_metadata(&cache, &snapshot, true).expect("publish");
         let (records, stale) = read_public_metadata(&cache).expect("read");
         assert!(stale);
@@ -1482,5 +1482,14 @@ mod tests {
         generation["records"][0]["index_digest"] = json!("sha256:0000000000000000000000000000000000000000000000000000000000000000");
         write_json_atomic(&path, &generation).expect("tamper");
         assert_eq!(read_public_metadata(&cache).expect_err("invalid").code, RegistryCacheErrorCode::RegistryMetadataCacheInvalid);
+    }
+
+    #[test]
+    fn public_metadata_rejects_empty_snapshots_and_has_stable_error_code() {
+        let cache = unique_cache();
+        let (mut snapshot, _, _) = sample_snapshot(false);
+        snapshot.capabilities.clear();
+        assert_eq!(publish_public_metadata(&cache, &snapshot, false).expect_err("empty").code, RegistryCacheErrorCode::RegistrySyncMissing);
+        assert_eq!(RegistryCacheErrorCode::RegistryMetadataCacheInvalid.as_str(), "registry_metadata_cache_invalid");
     }
 }

--- a/crates/traverse-embedder/src/registry_cache.rs
+++ b/crates/traverse-embedder/src/registry_cache.rs
@@ -212,29 +212,75 @@ pub fn publish_public_metadata(
     stale: bool,
 ) -> Result<(), RegistryCacheError> {
     if snapshot.capabilities.is_empty() {
-        return Err(RegistryCacheError::new(RegistryCacheErrorCode::RegistrySyncMissing, "synced registry index snapshot contains no capabilities"));
+        return Err(RegistryCacheError::new(
+            RegistryCacheErrorCode::RegistrySyncMissing,
+            "synced registry index snapshot contains no capabilities",
+        ));
     }
     let index_digest = index_snapshot_digest(snapshot);
-    let records = snapshot.capabilities.iter().map(|record| PublicCapabilityMetadata {
-        namespace: record.namespace.clone(), id: record.id.clone(), version: record.version.clone(),
-        artifact_digest: record.digest.clone(), source_release: snapshot.release_tag.clone(),
-        index_digest: index_digest.clone(), summary: record.summary.clone(), description: record.description.clone(),
-        scenarios: record.use_cases.iter().map(|use_case| use_case.scenario.clone()).collect(),
-    }).collect();
-    write_json_atomic(&cache.public_metadata_path(), &PublicMetadataGeneration {
-        schema_version: 1, stale, source_release: snapshot.release_tag.clone(), index_digest, records,
-    })
+    let records = snapshot
+        .capabilities
+        .iter()
+        .map(|record| PublicCapabilityMetadata {
+            namespace: record.namespace.clone(),
+            id: record.id.clone(),
+            version: record.version.clone(),
+            artifact_digest: record.digest.clone(),
+            source_release: snapshot.release_tag.clone(),
+            index_digest: index_digest.clone(),
+            summary: record.summary.clone(),
+            description: record.description.clone(),
+            scenarios: record
+                .use_cases
+                .iter()
+                .map(|use_case| use_case.scenario.clone())
+                .collect(),
+        })
+        .collect();
+    write_json_atomic(
+        &cache.public_metadata_path(),
+        &PublicMetadataGeneration {
+            schema_version: 1,
+            stale,
+            source_release: snapshot.release_tag.clone(),
+            index_digest,
+            records,
+        },
+    )
 }
 
 /// Read one complete verified metadata generation without network access.
-pub fn read_public_metadata(cache: &HostRegistryCache) -> Result<(Vec<PublicCapabilityMetadata>, bool), RegistryCacheError> {
-    let bytes = fs::read(cache.public_metadata_path()).map_err(|_| RegistryCacheError::new(RegistryCacheErrorCode::RegistryMetadataCacheInvalid, "public metadata cache generation is missing"))?;
-    let generation: PublicMetadataGeneration = serde_json::from_slice(&bytes).map_err(|_| RegistryCacheError::new(RegistryCacheErrorCode::RegistryMetadataCacheInvalid, "public metadata cache generation is malformed"))?;
-    if generation.schema_version != 1 || generation.source_release.is_empty() || normalize_digest(&generation.index_digest).is_none() || generation.records.iter().any(|record| {
-        record.namespace.is_empty() || record.id.is_empty() || record.version.is_empty() ||
-        normalize_digest(&record.artifact_digest).is_none() || record.source_release != generation.source_release || record.index_digest != generation.index_digest
-    }) {
-        return Err(RegistryCacheError::new(RegistryCacheErrorCode::RegistryMetadataCacheInvalid, "public metadata cache generation has invalid verification bindings"));
+pub fn read_public_metadata(
+    cache: &HostRegistryCache,
+) -> Result<(Vec<PublicCapabilityMetadata>, bool), RegistryCacheError> {
+    let bytes = fs::read(cache.public_metadata_path()).map_err(|_| {
+        RegistryCacheError::new(
+            RegistryCacheErrorCode::RegistryMetadataCacheInvalid,
+            "public metadata cache generation is missing",
+        )
+    })?;
+    let generation: PublicMetadataGeneration = serde_json::from_slice(&bytes).map_err(|_| {
+        RegistryCacheError::new(
+            RegistryCacheErrorCode::RegistryMetadataCacheInvalid,
+            "public metadata cache generation is malformed",
+        )
+    })?;
+    if generation.schema_version != 1
+        || generation.source_release.is_empty()
+        || normalize_digest(&generation.index_digest).is_none()
+        || generation.records.iter().any(|record| {
+            record.namespace.is_empty()
+                || record.id.is_empty()
+                || record.version.is_empty()
+                || normalize_digest(&record.artifact_digest).is_none()
+                || record.source_release != generation.source_release
+                || record.index_digest != generation.index_digest
+        })
+    {
+        return Err(RegistryCacheError::new(
+            RegistryCacheErrorCode::RegistryMetadataCacheInvalid,
+            "public metadata cache generation has invalid verification bindings",
+        ));
     }
     Ok((generation.records, generation.stale))
 }
@@ -1461,11 +1507,18 @@ mod tests {
         let record = snapshot.capabilities.last_mut().expect("record");
         record.summary = "Greeting capability".to_string();
         record.description = "Greets a public user".to_string();
-        record.use_cases = vec![traverse_registry::PublicUseCaseSummary { scenario: "Greet a new user".to_string() }];
+        record.use_cases = vec![traverse_registry::PublicUseCaseSummary {
+            scenario: "Greet a new user".to_string(),
+        }];
         publish_public_metadata(&cache, &snapshot, true).expect("publish");
         let (records, stale) = read_public_metadata(&cache).expect("read");
         assert!(stale);
-        assert!(records.iter().any(|record| record.description == "Greets a public user" && record.scenarios == ["Greet a new user"]));
+        assert!(
+            records
+                .iter()
+                .any(|record| record.description == "Greets a public user"
+                    && record.scenarios == ["Greet a new user"])
+        );
         let encoded = fs::read(cache.public_metadata_path()).expect("generation");
         let text = String::from_utf8(encoded).expect("utf8");
         assert!(!text.contains("input_example"));
@@ -1478,10 +1531,15 @@ mod tests {
         let (snapshot, _, _) = sample_snapshot(false);
         publish_public_metadata(&cache, &snapshot, false).expect("publish");
         let path = cache.public_metadata_path();
-        let mut generation: Value = serde_json::from_slice(&fs::read(&path).expect("read")).expect("json");
-        generation["records"][0]["index_digest"] = json!("sha256:0000000000000000000000000000000000000000000000000000000000000000");
+        let mut generation: Value =
+            serde_json::from_slice(&fs::read(&path).expect("read")).expect("json");
+        generation["records"][0]["index_digest"] =
+            json!("sha256:0000000000000000000000000000000000000000000000000000000000000000");
         write_json_atomic(&path, &generation).expect("tamper");
-        assert_eq!(read_public_metadata(&cache).expect_err("invalid").code, RegistryCacheErrorCode::RegistryMetadataCacheInvalid);
+        assert_eq!(
+            read_public_metadata(&cache).expect_err("invalid").code,
+            RegistryCacheErrorCode::RegistryMetadataCacheInvalid
+        );
     }
 
     #[test]
@@ -1489,7 +1547,15 @@ mod tests {
         let cache = unique_cache();
         let (mut snapshot, _, _) = sample_snapshot(false);
         snapshot.capabilities.clear();
-        assert_eq!(publish_public_metadata(&cache, &snapshot, false).expect_err("empty").code, RegistryCacheErrorCode::RegistrySyncMissing);
-        assert_eq!(RegistryCacheErrorCode::RegistryMetadataCacheInvalid.as_str(), "registry_metadata_cache_invalid");
+        assert_eq!(
+            publish_public_metadata(&cache, &snapshot, false)
+                .expect_err("empty")
+                .code,
+            RegistryCacheErrorCode::RegistrySyncMissing
+        );
+        assert_eq!(
+            RegistryCacheErrorCode::RegistryMetadataCacheInvalid.as_str(),
+            "registry_metadata_cache_invalid"
+        );
     }
 }


### PR DESCRIPTION
## Summary

- add an atomically published, offline-only verified public metadata cache
- upgrade to `traverse-registry` 0.15.1 for the sanctioned public projection

## Governing Spec

- `048-semver-publishing-pipeline`
- `116-verified-public-contract-metadata-cache`
- `080-embedded-registry-cache`

## Project Item

- #1134

## Definition of Done

- metadata is bound to the verified release and index digest
- stale complete generations remain readable; missing, malformed, and tampered generations fail closed
- raw contracts and use-case examples are never represented by the reader API

## Validation

- `cargo test -p traverse-embedder --lib registry_cache --no-fail-fast` (26 passed)
- `cargo check -p traverse-embedder`
