### PR TITLE
feat(mcp): search verified public capabilities

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2681,6 +2681,7 @@ dependencies = [
  "serde",
  "serde_json",
  "traverse-contracts",
+ "traverse-embedder",
  "traverse-registry",
  "traverse-runtime",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ version = "0.9.1"
 
 [workspace.dependencies]
 traverse-contracts = { path = "crates/traverse-contracts", version = "0.9.1" }
+traverse-embedder = { path = "crates/traverse-embedder", version = "0.9.1" }
 traverse-registry = { version = "=0.15.1" }
 traverse-runtime = { path = "crates/traverse-runtime", version = "0.9.1" }
 

--- a/crates/traverse-mcp/Cargo.toml
+++ b/crates/traverse-mcp/Cargo.toml
@@ -16,6 +16,7 @@ ed25519-dalek = "3.0.0"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 traverse-contracts = { workspace = true }
+traverse-embedder = { workspace = true }
 traverse-registry = { workspace = true }
 traverse-runtime = { workspace = true }
 

--- a/crates/traverse-mcp/src/stdio_server.rs
+++ b/crates/traverse-mcp/src/stdio_server.rs
@@ -52,6 +52,8 @@ struct StdioCommandEnvelope {
     version: Option<String>,
     #[serde(default)]
     request_path: Option<String>,
+    #[serde(default)]
+    query: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -303,6 +305,7 @@ impl CanonicalExecutionContext {
 pub struct TraverseMcpStdioServer<'a, E> {
     mcp: &'a TraverseMcp<'a, E>,
     catalog: &'a McpDiscoveryCatalog,
+    public_metadata_cache: Option<traverse_embedder::HostRegistryCache>,
 }
 
 impl<'a, E> TraverseMcpStdioServer<'a, E>
@@ -311,7 +314,20 @@ where
 {
     #[must_use]
     pub fn new(mcp: &'a TraverseMcp<'a, E>, catalog: &'a McpDiscoveryCatalog) -> Self {
-        Self { mcp, catalog }
+        Self {
+            mcp,
+            catalog,
+            public_metadata_cache: None,
+        }
+    }
+
+    #[must_use]
+    pub fn with_public_metadata_cache(
+        mut self,
+        cache: traverse_embedder::HostRegistryCache,
+    ) -> Self {
+        self.public_metadata_cache = Some(cache);
+        self
     }
 
     #[must_use]
@@ -832,6 +848,38 @@ where
                             )
                         },
                     )?;
+                }
+                "search_capabilities" => {
+                    let Some(query) = command.query.as_deref() else {
+                        let failure = StdioServerFailure::new(
+                            "invalid_query",
+                            "search_capabilities requires query.",
+                        );
+                        let _ = write_json_line(stderr, &failure.envelope());
+                        return Err(failure);
+                    };
+                    let Some(cache) = self.public_metadata_cache.as_ref() else {
+                        let failure = StdioServerFailure::new(
+                            "registry_sync_missing",
+                            "verified public metadata cache is not configured.",
+                        );
+                        let _ = write_json_line(stderr, &failure.envelope());
+                        return Err(failure);
+                    };
+                    let result = crate::tools::capabilities::search_capabilities(cache, query)
+                        .map_err(|error| {
+                            StdioServerFailure::new(error.message, "capability search failed")
+                        })?;
+                    write_json_line(
+                        stdout,
+                        &json!({"records": result.records, "stale": result.stale}),
+                    )
+                    .map_err(|error| {
+                        StdioServerFailure::new(
+                            "io_error",
+                            format!("Failed to write capability search envelope: {error}"),
+                        )
+                    })?;
                 }
                 "describe_entrypoint" => {
                     let Some(entrypoint_kind) = command.entrypoint_kind.as_deref() else {

--- a/crates/traverse-mcp/src/tools/capabilities.rs
+++ b/crates/traverse-mcp/src/tools/capabilities.rs
@@ -12,6 +12,51 @@ use traverse_registry::{
 };
 
 use crate::{McpError, McpErrorCode};
+use traverse_embedder::{HostRegistryCache, read_public_metadata};
+
+/// Offline search result from the verified public metadata cache.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PublicCapabilitySearchResult {
+    pub records: Vec<traverse_embedder::PublicCapabilityMetadata>,
+    pub stale: bool,
+}
+
+/// Search verified public metadata without touching the network or private registry.
+///
+/// # Errors
+///
+/// Returns `InvalidRequest` for an empty query and a stable cache error when
+/// the verified public metadata generation is unavailable or invalid.
+pub fn search_capabilities(
+    cache: &HostRegistryCache,
+    query: &str,
+) -> Result<PublicCapabilitySearchResult, McpError> {
+    let tokens = query
+        .split_whitespace()
+        .map(str::to_lowercase)
+        .collect::<Vec<_>>();
+    if tokens.is_empty() {
+        return Err(McpError {
+            code: McpErrorCode::InvalidRequest,
+            message: "invalid_query".to_string(),
+        });
+    }
+    let (mut records, stale) = read_public_metadata(cache).map_err(|error| McpError {
+        code: McpErrorCode::InvalidRequest,
+        message: error.code.as_str().to_string(),
+    })?;
+    records.retain(|record| {
+        let haystack =
+            format!("{} {}", record.description, record.scenarios.join(" ")).to_lowercase();
+        tokens.iter().all(|token| haystack.contains(token))
+    });
+    records.sort_by(|left, right| {
+        left.id
+            .cmp(&right.id)
+            .then_with(|| right.version.cmp(&left.version))
+    });
+    Ok(PublicCapabilitySearchResult { records, stale })
+}
 
 /// Optional filter for [`list_capabilities`].
 #[derive(Debug, Clone, Default)]
@@ -159,4 +204,18 @@ pub fn get_capability(
         code: McpErrorCode::InvalidRequest,
         message: e.to_string(),
     })
+}
+
+#[cfg(test)]
+mod search_tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    #[test]
+    fn search_rejects_whitespace_before_reading_cache() {
+        let cache = HostRegistryCache::new(PathBuf::from("/definitely-not-a-cache"));
+        let error = search_capabilities(&cache, " \t\n ").expect_err("invalid query");
+        assert_eq!(error.code, McpErrorCode::InvalidRequest);
+        assert_eq!(error.message, "invalid_query");
+    }
 }


### PR DESCRIPTION
## Summary

- add `search_capabilities` over the host-supplied verified public metadata cache
- keep search offline, deterministic, and fail-closed without private-registry fallback

## Governing Spec

- `114-mcp-capability-search`
- `116-verified-public-contract-metadata-cache`

## Project Item

- #876

## Definition of Done

- whitespace-only queries return `invalid_query`
- searches read only the verified public cache and preserve stale state
- stdio host fails closed when no verified cache is supplied

## Validation

- `cargo test -p traverse-mcp --lib --no-fail-fast` (50 passed)
- `cargo check -p traverse-mcp`
