### PR TITLE
feat(mcp): add verified capability search

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2678,9 +2678,11 @@ name = "traverse-mcp"
 version = "0.9.1"
 dependencies = [
  "ed25519-dalek",
+ "semver",
  "serde",
  "serde_json",
  "traverse-contracts",
+ "traverse-embedder",
  "traverse-registry",
  "traverse-runtime",
 ]
@@ -2695,9 +2697,9 @@ dependencies = [
 
 [[package]]
 name = "traverse-registry"
-version = "0.15.1"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cc8dc2e3524d5a839510f3734f37b945e2d554d6e77820baddaba2016bd640a"
+checksum = "2603a807be513d14a21a4898c3da95c88dc5c21c7a24e75784050bd59d6438bf"
 dependencies = [
  "semver",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,8 +20,9 @@ version = "0.9.1"
 
 [workspace.dependencies]
 traverse-contracts = { path = "crates/traverse-contracts", version = "0.9.1" }
-traverse-registry = { version = "=0.15.1" }
+traverse-registry = { version = "=0.15.2" }
 traverse-runtime = { path = "crates/traverse-runtime", version = "0.9.1" }
+traverse-embedder = { path = "crates/traverse-embedder", version = "0.9.1" }
 
 # The published registry crate pins the current contracts release.  During
 # Traverse development, resolve that transitive dependency to this workspace's

--- a/crates/traverse-cli/src/main.rs
+++ b/crates/traverse-cli/src/main.rs
@@ -8710,6 +8710,10 @@ mod tests {
                     summary: String::new(),
                     description: String::new(),
                     use_cases: Vec::new(),
+                    service_type: "stateless".to_string(),
+                    permitted_targets: Vec::new(),
+                    lifecycle: "active".to_string(),
+                    provenance: None,
                 }],
             },
         )
@@ -9778,6 +9782,10 @@ mod tests {
             summary: String::new(),
             description: String::new(),
             use_cases: Vec::new(),
+            service_type: "stateless".to_string(),
+            permitted_targets: Vec::new(),
+            lifecycle: "active".to_string(),
+            provenance: None,
         };
 
         let registered = load_registered_bundle_with_public_records(&manifest_path, &[public])
@@ -10888,6 +10896,8 @@ mod tests {
                 contract_url: "https://github.com/traverse-framework/registry/releases/download/artifacts/traverse-starter.process-1.0.0/contract.json".to_string(),
                 deprecated: false,
                 summary: String::new(), description: String::new(), use_cases: Vec::new(),
+                service_type: "stateless".to_string(), permitted_targets: Vec::new(),
+                lifecycle: "active".to_string(), provenance: None,
             }],
         }
     }
@@ -10909,6 +10919,10 @@ mod tests {
             summary: String::new(),
             description: String::new(),
             use_cases: Vec::new(),
+            service_type: "stateless".to_string(),
+            permitted_targets: Vec::new(),
+            lifecycle: "active".to_string(),
+            provenance: None,
         }
     }
 

--- a/crates/traverse-embedder/src/lib.rs
+++ b/crates/traverse-embedder/src/lib.rs
@@ -85,10 +85,10 @@ mod registry_cache;
 mod test_double;
 
 pub use registry_cache::{
-    HostRegistryCache, PublicCapabilityMetadata, RegistryArtifactFetcher, RegistryCacheError,
-    RegistryCacheErrorCode, RegistryPrepareEvidence, VerifiedRegistryDependency,
-    prepare as prepare_registry_dependency, publish_public_metadata, read_public_metadata,
-    resolve_component as resolve_registry_component,
+    HostRegistryCache, PublicCapabilityMetadata, PublicMetadataRead, RegistryArtifactFetcher,
+    RegistryCacheError, RegistryCacheErrorCode, RegistryPrepareEvidence,
+    VerifiedRegistryDependency, prepare as prepare_registry_dependency, publish_public_metadata,
+    read_public_metadata, resolve_component as resolve_registry_component,
     resolve_offline as resolve_registry_dependency_offline,
 };
 pub use test_double::EmbedderTestDouble;
@@ -2322,6 +2322,10 @@ mod tests {
             summary: String::new(),
             description: String::new(),
             use_cases: Vec::new(),
+            service_type: String::new(),
+            permitted_targets: Vec::new(),
+            lifecycle: String::new(),
+            provenance: None,
         };
         let snapshot = SyncedPublicRegistryState {
             schema_version: "1".to_string(),

--- a/crates/traverse-embedder/src/registry_cache.rs
+++ b/crates/traverse-embedder/src/registry_cache.rs
@@ -193,6 +193,22 @@ pub struct PublicCapabilityMetadata {
     pub summary: String,
     pub description: String,
     pub scenarios: Vec<String>,
+    pub service_type: String,
+    pub permitted_targets: Vec<String>,
+    pub lifecycle: String,
+    pub provenance: Option<Value>,
+}
+
+/// One complete, verified public metadata generation.
+///
+/// The generation-level provenance is retained even when a consumer's query
+/// matches no individual capability records.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct PublicMetadataRead {
+    pub records: Vec<PublicCapabilityMetadata>,
+    pub stale: bool,
+    pub source_release: String,
+    pub index_digest: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
@@ -240,6 +256,10 @@ pub fn publish_public_metadata(
                 .iter()
                 .map(|use_case| use_case.scenario.clone())
                 .collect(),
+            service_type: record.service_type.clone(),
+            permitted_targets: record.permitted_targets.clone(),
+            lifecycle: record.lifecycle.clone(),
+            provenance: record.provenance.clone(),
         })
         .collect();
     write_json_atomic(
@@ -262,10 +282,10 @@ pub fn publish_public_metadata(
 /// malformed, unsupported, or has invalid digest/provenance bindings.
 pub fn read_public_metadata(
     cache: &HostRegistryCache,
-) -> Result<(Vec<PublicCapabilityMetadata>, bool), RegistryCacheError> {
+) -> Result<PublicMetadataRead, RegistryCacheError> {
     let bytes = fs::read(cache.public_metadata_path()).map_err(|_| {
         RegistryCacheError::new(
-            RegistryCacheErrorCode::RegistryMetadataCacheInvalid,
+            RegistryCacheErrorCode::RegistrySyncMissing,
             "public metadata cache generation is missing",
         )
     })?;
@@ -285,6 +305,8 @@ pub fn read_public_metadata(
                 || normalize_digest(&record.artifact_digest).is_none()
                 || record.source_release != generation.source_release
                 || record.index_digest != generation.index_digest
+                || record.service_type.is_empty()
+                || record.lifecycle.is_empty()
         })
     {
         return Err(RegistryCacheError::new(
@@ -292,7 +314,12 @@ pub fn read_public_metadata(
             "public metadata cache generation has invalid verification bindings",
         ));
     }
-    Ok((generation.records, generation.stale))
+    Ok(PublicMetadataRead {
+        records: generation.records,
+        stale: generation.stale,
+        source_release: generation.source_release,
+        index_digest: generation.index_digest,
+    })
 }
 
 /// FR-008 resolution evidence retained after a successful prepare.
@@ -808,6 +835,10 @@ mod tests {
             summary: "Greeting".to_string(),
             description: "Greets a person".to_string(),
             use_cases: Vec::new(),
+            service_type: "stateless".to_string(),
+            permitted_targets: Vec::new(),
+            lifecycle: "active".to_string(),
+            provenance: None,
         };
         let older = PublicRegistryCapabilityRecord {
             namespace: "demo".to_string(),
@@ -821,6 +852,10 @@ mod tests {
             summary: String::new(),
             description: String::new(),
             use_cases: Vec::new(),
+            service_type: "stateless".to_string(),
+            permitted_targets: Vec::new(),
+            lifecycle: "active".to_string(),
+            provenance: None,
         };
         let snapshot = SyncedPublicRegistryState {
             schema_version: "1".to_string(),
@@ -1338,6 +1373,10 @@ mod tests {
                 summary: String::new(),
                 description: String::new(),
                 use_cases: Vec::new(),
+                service_type: String::new(),
+                permitted_targets: Vec::new(),
+                lifecycle: String::new(),
+                provenance: None,
             },
         );
         let evidence = prepare(&cache, &snapshot, &reference, &fetcher).expect("prepare");
@@ -1431,6 +1470,10 @@ mod tests {
             summary: String::new(),
             description: String::new(),
             use_cases: Vec::new(),
+            service_type: String::new(),
+            permitted_targets: Vec::new(),
+            lifecycle: String::new(),
+            provenance: None,
         };
         let snapshot = SyncedPublicRegistryState {
             schema_version: "1".to_string(),
@@ -1480,6 +1523,10 @@ mod tests {
             summary: String::new(),
             description: String::new(),
             use_cases: Vec::new(),
+            service_type: String::new(),
+            permitted_targets: Vec::new(),
+            lifecycle: String::new(),
+            provenance: None,
         };
         let snapshot = SyncedPublicRegistryState {
             schema_version: "1".to_string(),
@@ -1521,10 +1568,13 @@ mod tests {
             scenario: "Greet a new user".to_string(),
         }];
         publish_public_metadata(&cache, &snapshot, true).expect("publish");
-        let (records, stale) = read_public_metadata(&cache).expect("read");
-        assert!(stale);
+        let generation = read_public_metadata(&cache).expect("read");
+        assert!(generation.stale);
+        assert_eq!(generation.source_release, snapshot.release_tag);
+        assert!(!generation.index_digest.is_empty());
         assert!(
-            records
+            generation
+                .records
                 .iter()
                 .any(|record| record.description == "Greets a public user"
                     && record.scenarios == ["Greet a new user"])
@@ -1574,7 +1624,7 @@ mod tests {
         let cache = unique_cache();
         assert_eq!(
             read_public_metadata(&cache).expect_err("missing").code,
-            RegistryCacheErrorCode::RegistryMetadataCacheInvalid
+            RegistryCacheErrorCode::RegistrySyncMissing
         );
         let path = cache.public_metadata_path();
         fs::create_dir_all(path.parent().expect("parent")).expect("directory");

--- a/crates/traverse-mcp/Cargo.toml
+++ b/crates/traverse-mcp/Cargo.toml
@@ -15,8 +15,10 @@ path = "src/main.rs"
 ed25519-dalek = "3.0.0"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+semver = "1"
 traverse-contracts = { workspace = true }
 traverse-registry = { workspace = true }
+traverse-embedder = { workspace = true }
 traverse-runtime = { workspace = true }
 
 [lints]

--- a/crates/traverse-mcp/src/stdio_server.rs
+++ b/crates/traverse-mcp/src/stdio_server.rs
@@ -10,6 +10,7 @@ use std::fmt;
 use std::fs;
 use std::io::{self, BufRead, Write};
 use std::path::{Path, PathBuf};
+use traverse_embedder::HostRegistryCache;
 use traverse_registry::{
     BinaryFormat as RegistryBinaryFormat, BinaryReference, CapabilityArtifactRecord,
     CapabilityRegistration, CapabilityRegistry, ComposabilityMetadata, CompositionKind,
@@ -28,6 +29,7 @@ const SUPPORTING_COMMANDS: &[&str] = &[
     "list_content_groups",
     "describe_content_group",
     "list_entrypoints",
+    "search_capabilities",
     "describe_entrypoint",
     "validate_entrypoint",
     "execute_entrypoint",
@@ -52,6 +54,8 @@ struct StdioCommandEnvelope {
     version: Option<String>,
     #[serde(default)]
     request_path: Option<String>,
+    #[serde(default)]
+    query: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -303,6 +307,7 @@ impl CanonicalExecutionContext {
 pub struct TraverseMcpStdioServer<'a, E> {
     mcp: &'a TraverseMcp<'a, E>,
     catalog: &'a McpDiscoveryCatalog,
+    public_metadata_cache: Option<HostRegistryCache>,
 }
 
 impl<'a, E> TraverseMcpStdioServer<'a, E>
@@ -311,7 +316,31 @@ where
 {
     #[must_use]
     pub fn new(mcp: &'a TraverseMcp<'a, E>, catalog: &'a McpDiscoveryCatalog) -> Self {
-        Self { mcp, catalog }
+        Self {
+            mcp,
+            catalog,
+            public_metadata_cache: None,
+        }
+    }
+
+    #[must_use]
+    pub fn with_public_metadata_cache(mut self, cache: HostRegistryCache) -> Self {
+        self.public_metadata_cache = Some(cache);
+        self
+    }
+
+    fn search_capabilities_envelope(&self, query: &str) -> Result<Value, StdioServerFailure> {
+        let cache = self.public_metadata_cache.as_ref().ok_or_else(|| {
+            StdioServerFailure::new(
+                "registry_sync_missing",
+                "search requires verified public registry state.",
+            )
+        })?;
+        let result = crate::tools::capabilities::search_capabilities(cache, query)
+            .map_err(|error| StdioServerFailure::new(&error.message, &error.message))?;
+        Ok(
+            json!({"kind":"mcp_capability_search", "records": result.records, "stale": result.stale}),
+        )
     }
 
     #[must_use]
@@ -832,6 +861,29 @@ where
                             )
                         },
                     )?;
+                }
+                "search_capabilities" => {
+                    let Some(query) = command.query.as_deref() else {
+                        let failure = StdioServerFailure::new(
+                            "invalid_query",
+                            "search_capabilities requires query.",
+                        );
+                        let _ = write_json_line(stderr, &failure.envelope());
+                        return Err(failure);
+                    };
+                    let envelope = match self.search_capabilities_envelope(query) {
+                        Ok(envelope) => envelope,
+                        Err(failure) => {
+                            let _ = write_json_line(stderr, &failure.envelope());
+                            return Err(failure);
+                        }
+                    };
+                    write_json_line(stdout, &envelope).map_err(|error| {
+                        StdioServerFailure::new(
+                            "io_error",
+                            format!("Failed to write search envelope: {error}"),
+                        )
+                    })?;
                 }
                 "describe_entrypoint" => {
                     let Some(entrypoint_kind) = command.entrypoint_kind.as_deref() else {
@@ -1809,6 +1861,36 @@ mod tests {
         assert!(output.contains("\"status\":\"rendered\""));
         assert!(output.contains("\"kind\":\"mcp_stdio_server_shutdown\""));
         assert!(stderr.is_empty());
+    }
+
+    #[test]
+    fn search_command_requires_query_and_verified_public_metadata() {
+        let server = build_test_server();
+        let missing = server
+            .search_capabilities_envelope("catalog")
+            .expect_err("server without cache must fail closed");
+        assert_eq!(missing.code, "registry_sync_missing");
+
+        let cache = HostRegistryCache::new(
+            std::env::temp_dir().join(format!("traverse-mcp-stdio-search-{}", std::process::id())),
+        );
+        let server = build_test_server().with_public_metadata_cache(cache);
+        let input = std::io::Cursor::new(
+            br#"{"command":"search_capabilities"}
+{"command":"search_capabilities","query":"catalog"}
+"#,
+        );
+        let mut stdout = Vec::new();
+        let mut stderr = Vec::new();
+        let error = server
+            .run_stdio(input, &mut stdout, &mut stderr, false)
+            .expect_err("missing query must fail");
+        assert_eq!(error.code, "invalid_query");
+        assert!(
+            String::from_utf8(stderr)
+                .expect("stderr utf8")
+                .contains("invalid_query")
+        );
     }
 
     #[test]

--- a/crates/traverse-mcp/src/tools/capabilities.rs
+++ b/crates/traverse-mcp/src/tools/capabilities.rs
@@ -2,6 +2,7 @@
 //!
 //! Governed by spec 015-capability-discovery-mcp
 
+use semver::Version;
 use serde::{Deserialize, Serialize};
 use traverse_contracts::{
     DeterminismClass, EffectClass, EgressPolicy, ExecutionTarget, ReliabilityMetadata, ServiceType,
@@ -12,6 +13,63 @@ use traverse_registry::{
 };
 
 use crate::{McpError, McpErrorCode};
+use traverse_embedder::{HostRegistryCache, PublicCapabilityMetadata, read_public_metadata};
+
+/// Search result from the host-supplied verified public registry cache.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PublicCapabilitySearchResult {
+    pub records: Vec<PublicCapabilityMetadata>,
+    pub stale: bool,
+    pub source_release: String,
+    pub index_digest: String,
+}
+
+/// Search public capability descriptions and declared scenario text offline.
+///
+/// # Errors
+///
+/// Returns stable errors for invalid queries and unavailable verified cache state.
+pub fn search_capabilities(
+    cache: &HostRegistryCache,
+    query: &str,
+) -> Result<PublicCapabilitySearchResult, McpError> {
+    let tokens = query
+        .split_whitespace()
+        .map(str::to_lowercase)
+        .collect::<Vec<_>>();
+    if tokens.is_empty() {
+        return Err(McpError {
+            code: McpErrorCode::InvalidRequest,
+            message: "invalid_query".to_string(),
+        });
+    }
+    let generation = read_public_metadata(cache).map_err(|error| McpError {
+        code: McpErrorCode::InvalidRequest,
+        message: error.code.as_str().to_string(),
+    })?;
+    let mut records = generation.records;
+    records.retain(|record| {
+        let text = format!("{} {}", record.description, record.scenarios.join(" ")).to_lowercase();
+        tokens.iter().all(|token| text.contains(token))
+    });
+    records.sort_by(|left, right| {
+        left.id.cmp(&right.id).then_with(|| {
+            match (
+                Version::parse(&left.version),
+                Version::parse(&right.version),
+            ) {
+                (Ok(left), Ok(right)) => right.cmp(&left),
+                _ => right.version.cmp(&left.version),
+            }
+        })
+    });
+    Ok(PublicCapabilitySearchResult {
+        records,
+        stale: generation.stale,
+        source_release: generation.source_release,
+        index_digest: generation.index_digest,
+    })
+}
 
 /// Optional filter for [`list_capabilities`].
 #[derive(Debug, Clone, Default)]
@@ -159,4 +217,104 @@ pub fn get_capability(
         code: McpErrorCode::InvalidRequest,
         message: e.to_string(),
     })
+}
+
+#[cfg(test)]
+mod search_tests {
+    #![allow(clippy::expect_used)]
+
+    use super::*;
+    use std::sync::atomic::{AtomicU64, Ordering};
+    use traverse_embedder::publish_public_metadata;
+    use traverse_registry::{
+        PublicRegistryCapabilityRecord, PublicUseCaseSummary, SyncedPublicRegistryState,
+    };
+
+    static CACHE_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+    fn cache() -> HostRegistryCache {
+        let sequence = CACHE_COUNTER.fetch_add(1, Ordering::Relaxed);
+        HostRegistryCache::new(std::env::temp_dir().join(format!(
+            "traverse-mcp-search-{}-{sequence}",
+            std::process::id()
+        )))
+    }
+
+    fn record(id: &str, version: &str, description: &str) -> PublicRegistryCapabilityRecord {
+        PublicRegistryCapabilityRecord {
+            namespace: "demo".to_string(),
+            id: id.to_string(),
+            version: version.to_string(),
+            digest: format!("sha256:{}", "a".repeat(64)),
+            artifact_url: format!("https://example.test/{id}.wasm"),
+            contract_digest: format!("sha256:{}", "b".repeat(64)),
+            contract_url: format!("https://example.test/{id}.json"),
+            deprecated: false,
+            summary: format!("{id} summary"),
+            description: description.to_string(),
+            use_cases: vec![PublicUseCaseSummary {
+                scenario: "Find a public capability".to_string(),
+            }],
+            service_type: "stateless".to_string(),
+            permitted_targets: vec!["wasm".to_string()],
+            lifecycle: "active".to_string(),
+            provenance: None,
+        }
+    }
+
+    fn publish(cache: &HostRegistryCache) {
+        let snapshot = SyncedPublicRegistryState {
+            schema_version: "1".to_string(),
+            workspace_id: "workspace".to_string(),
+            state_scope: "public".to_string(),
+            source_repo: "traverse-framework/registry".to_string(),
+            release_tag: "index-v200".to_string(),
+            index_version: 200,
+            generated_at: "2026-08-25T00:00:00Z".to_string(),
+            source_commit: None,
+            synced_at: "2026-08-25T00:00:00Z".to_string(),
+            record_count: 3,
+            validation_status: "valid".to_string(),
+            governing_spec: "114-capability-search".to_string(),
+            capabilities: vec![
+                record("search", "2.0.0", "Search public catalog entries"),
+                record("search", "10.0.0", "Search public catalog entries"),
+                record("alpha", "1.0.0", "Search public catalog entries"),
+            ],
+        };
+        publish_public_metadata(cache, &snapshot, true).expect("publish metadata");
+    }
+
+    #[test]
+    fn search_requires_query_and_fails_closed_without_a_generation() {
+        let cache = cache();
+        let error = search_capabilities(&cache, "   ").expect_err("empty query");
+        assert_eq!(error.message, "invalid_query");
+        let error = search_capabilities(&cache, "catalog").expect_err("missing generation");
+        assert_eq!(error.message, "registry_sync_missing");
+    }
+
+    #[test]
+    fn search_matches_public_text_sorts_semver_and_preserves_provenance() {
+        let cache = cache();
+        publish(&cache);
+        let result = search_capabilities(&cache, "PUBLIC catalog").expect("search");
+        assert!(result.stale);
+        assert_eq!(result.source_release, "index-v200");
+        assert!(result.index_digest.starts_with("sha256:"));
+        assert_eq!(result.records.len(), 3);
+        assert_eq!(result.records[0].id, "alpha");
+        assert_eq!(result.records[1].version, "10.0.0");
+        assert_eq!(result.records[2].version, "2.0.0");
+        assert_eq!(result.records[0].permitted_targets, ["wasm"]);
+    }
+
+    #[test]
+    fn search_keeps_generation_provenance_when_nothing_matches() {
+        let cache = cache();
+        publish(&cache);
+        let result = search_capabilities(&cache, "not-present").expect("search");
+        assert!(result.records.is_empty());
+        assert_eq!(result.source_release, "index-v200");
+    }
 }


### PR DESCRIPTION
## Summary

Implements offline public capability search backed exclusively by the host-supplied, verified Registry metadata cache. The MCP stdio surface now exposes `search_capabilities`, returns stable errors when the cache or query is unavailable, and preserves cache generation provenance even for empty result sets.

## Governing Spec

Spec 114 (capability search) and Spec 116 (verified public registry metadata cache).

## Project Item

Closes #876.

## Definition of Done

- Uses `traverse-registry` 0.15.2 public metadata fields.
- Searches descriptions and declared use cases offline with deterministic semantic-version ordering.
- Fails closed with `registry_sync_missing` and emits structured stdio errors.
- Returns stale state and generation-level release/index provenance.

## Validation

- `cargo test -p traverse-embedder --lib --no-fail-fast`
- `cargo test -p traverse-mcp --lib --no-fail-fast`
- `bash scripts/ci/rust_checks.sh`
- `bash scripts/ci/spec_alignment_check.sh`
- `bash scripts/ci/coverage_gate.sh`
