### PR TITLE
docs(governance): spec 120 + ADR-0051 — host-owned artifact preparation

### DIFF
--- a/docs/adr/0051-host-owned-artifact-preparation.md
+++ b/docs/adr/0051-host-owned-artifact-preparation.md
@@ -1,0 +1,79 @@
+# ADR-0051: Host-Owned Artifact Preparation as a Separate, Cross-Referenced Manifest
+
+- Status: Accepted
+- Governing specs: `120-host-owned-artifact-preparation`; related `115-browser-verified-entrypoint-execution`, `118-host-supplied-serve-registry-state`
+- Related issues: #1153
+
+## Context
+
+`serve --registry-state` (spec 118) always fabricates a synthetic
+`bundled://{id}/{version}/module.wasm` artifact location for every
+registered capability, since the registry-bundle manifest carries only a
+`contract.json` path, never a real WASM location. `#1153` proposed fixing
+this inside `serve` itself (fetch the contract's `artifact.url`, verify the
+digest, at load or request time), but that directly violates spec 115
+FR-004 and spec 118 FR-004/FR-006, which require `serve` to consume only
+already-prepared, already-verified host state and forbid any fetch, sync,
+or state mutation during startup or execution.
+
+## Decision
+
+Real artifact preparation becomes a separate, host-run step, governed by a
+new spec (`120`) rather than a modification to the already-Approved,
+immutable spec 118:
+
+1. A new, first-party `traverse-cli registry materialize` subcommand
+   fetches each capability's real WASM artifact, verifies it against the
+   contract's declared digest, and writes a new `artifact-state.json`
+   manifest — kept entirely separate from spec 118's registry-bundle
+   manifest, cross-referenced only via a new, independent `serve
+   --artifact-state <path>` flag (never embedded in or auto-discovered
+   from spec 118's own schema, and never a default/conventional location).
+2. `serve` re-verifies every artifact's on-disk digest against the
+   declared digest at startup, rather than trusting `materialize`'s prior
+   verification alone — defense in depth, consistent with the
+   artifact-verification-gate posture the rest of this lineage already
+   holds.
+3. Failure is whole-manifest fail-closed: a missing or mismatched artifact
+   for any declared capability refuses the entire `serve` startup, never a
+   silently reduced subset — matching spec 118 FR-004's existing
+   "partial... state MUST never become executable."
+4. Scope is capabilities only; workflows compose already-covered
+   capability artifacts and carry no artifact of their own.
+
+## Consequences
+
+`#1153` is unblocked once spec 120 lands: it becomes "implement `registry
+materialize` and `serve --artifact-state` per spec 120" rather than a
+design question. Hosting a real, publicly-reachable `serve` instance
+against the live registry (the motivating discover.html use case) still
+requires someone to actually run `materialize` and operate the resulting
+artifacts directory, and re-run it on whatever cadence they choose to pick
+up new registry publishes — that operational question is explicitly out of
+this spec's scope.
+
+## Alternatives considered
+
+- Extend spec 118's manifest schema directly with artifact-location/digest
+  fields: rejected — spec 118 is Approved and immutable; this org's own
+  precedent (ADR-0043 adding a new phase to spec 108 rather than modifying
+  spec 109) favors a new governing artifact over amending an approved one,
+  and spec 118 FR-002's strict unknown-field rejection means even one
+  additive field requires a formal successor version regardless.
+- Fixed-name sibling file discovered by convention next to
+  `--registry-state`, no new flag: rejected — spec 118's own Ownership
+  section already explicitly forbids `serve` inventing a default state
+  location; a convention-based second file repeats exactly the pattern
+  this lineage has consistently rejected.
+- Keep artifact fetch+verification an external, host-authored script
+  (matching how the registry-state manifest generator itself stayed
+  external): rejected — unlike manifest generation (filtering/reshaping
+  already-public metadata), digest verification is the actual security
+  boundary stopping a tampered or wrong binary from executing; leaving it
+  to per-host reimplementation risks a subtly wrong verification nobody
+  audits, versus shipping it once as tested, first-party code.
+- Trust `materialize`'s verification without startup re-verification in
+  `serve`: rejected — no protection against anything mutating the
+  artifacts directory in the window between `materialize` running and
+  `serve` starting, which is a real assumption for a public-facing host to
+  carry unchecked.

--- a/docs/decision-log.md
+++ b/docs/decision-log.md
@@ -2637,3 +2637,75 @@ and kept only as historical record of a design that was considered and
 abandoned; spec `532` is removed from `specs/governance/approved-specs.json`.
 No open ticket depends on this decision — `#879` was already closed
 (2026-08-05) against the superseding spec, before this approval happened.
+
+## Decision 66: Host-Owned Artifact Preparation as a Separate, Cross-Referenced Manifest (Spec 120)
+
+- **Date**: 2026-08-26
+- **Status**: Accepted; Spec 120 Approved 2026-08-26
+- **Governing spec**: `120-host-owned-artifact-preparation`; related `115-browser-verified-entrypoint-execution`, `118-host-supplied-serve-registry-state`; ADR-0051
+- **Related issues**: `#1153`
+- **Origin**: `#1153` (found while investigating a real, publicly-hosted `serve` for traverse-framework.com/discover.html — same lineage as `#1097`-`#1100`, `#1105`, specs 113-119) proposed fixing `serve`'s fabricated `bundled://` artifact locations by having `serve` fetch and verify the real artifact itself. A review comment on the ticket established that violates spec 115 FR-004 and spec 118 FR-004/FR-006 (`serve` MUST NOT fetch/sync/mutate during startup or execution), moving the ticket to `needs-spec`/Blocked and requesting this brainstorm.
+
+### Context
+
+`serve --registry-state` (spec 118) registers capabilities from a
+registry-bundle manifest whose entries carry only a `contract.json` path —
+never a real WASM location. `build_capability_artifact` therefore always
+synthesizes `bundled://{id}/{version}/module.wasm`, which `ArtifactRouter`
+can never resolve, so no capability loaded this way can actually execute.
+Fixing this by having `serve` fetch the artifact itself was ruled out as a
+governing-spec violation before this brainstorm started.
+
+### Decision
+
+Real artifact preparation becomes a separate, host-run step, governed by a
+new spec (`120`) rather than a modification to the already-Approved,
+immutable spec 118:
+
+1. **Manifest shape**: a new, separate `artifact-state.json` (new spec),
+   not new fields on spec 118's own manifest.
+2. **Discovery**: a new, independent `serve --artifact-state <path>` flag —
+   never embedded in spec 118's schema, never a default/conventional
+   location.
+3. **Materialized-binary location**: an explicit per-entry `path` field in
+   `artifact-state.json`, not a directory convention.
+4. **Who prepares it**: a new, first-party `traverse-cli registry
+   materialize` subcommand — not an external host script — since digest
+   verification is a real security boundary, not just metadata reshaping.
+5. **Startup verification**: `serve` re-verifies every on-disk artifact's
+   digest against the declared digest before listening; it does not trust
+   `materialize`'s prior verification alone.
+6. **Failure semantics**: whole-manifest fail-closed — any missing or
+   mismatched artifact refuses the entire `serve` startup, never a
+   silently reduced subset.
+7. **Scope**: capabilities only; workflows carry no artifact of their own.
+
+### Alternatives Considered
+
+- Extend spec 118's manifest schema directly — rejected; spec 118 is
+  Approved/immutable, and this org's own precedent (Decision 59/ADR-0043
+  adding a new phase to `108` rather than modifying `109`) favors a new
+  governing artifact over amending an approved one. Spec 118 FR-002's
+  strict unknown-field rejection means even one additive field would
+  require a formal successor version regardless.
+- Fixed-name sibling file discovered by convention, no new flag —
+  rejected; spec 118's own Ownership section already forbids `serve`
+  inventing a default state location.
+- Keep artifact fetch+verification an external, host-authored script
+  (matching how the registry-state manifest generator itself stayed
+  external) — rejected; unlike manifest generation, digest verification is
+  the actual security boundary stopping a tampered/wrong binary from
+  executing, and per-host reimplementation risks a subtly wrong
+  verification nobody audits.
+- Trust `materialize`'s verification without startup re-verification —
+  rejected; no protection against anything mutating the artifacts
+  directory between `materialize` running and `serve` starting.
+
+### Outcome
+
+Spec `120` drafted and Approved same-day; ADR-0051 recorded. `#1153` can
+be rescoped from a design question to "implement `registry materialize`
+and `serve --artifact-state` per spec 120." Hosting a real, live `serve`
+instance for discover.html still needs someone to actually run
+`materialize` and operate the resulting artifacts directory on an ongoing
+basis — an operational decision this spec deliberately leaves open.

--- a/specs/120-host-owned-artifact-preparation/spec.md
+++ b/specs/120-host-owned-artifact-preparation/spec.md
@@ -1,0 +1,111 @@
+# Host-Owned Artifact Preparation for `serve`
+
+**Status**: Approved (2026-08-26)
+**Canonical governing ID**: `120-host-owned-artifact-preparation`
+**Version**: 0.1.0
+**Input**: Traverse #1153; unblocks #1153.
+
+## Purpose
+
+Define a host-owned artifact-preparation manifest and the `traverse-cli
+registry materialize` command that produces it, so `traverse-cli serve
+--registry-state` (spec 118) can resolve and execute a capability's real
+WASM artifact instead of a fabricated `bundled://` path — without `serve`
+itself ever fetching, syncing, or mutating state during startup or
+execution (spec 115 FR-004, spec 118 FR-004/FR-006).
+
+## Ownership and boundary
+
+Spec 118's registry-bundle manifest (identity/scope of what's registered)
+is governed and untouched by this spec. This spec governs a separate,
+cross-referenced artifact-preparation manifest (`artifact-state.json`)
+describing where each capability's real, digest-verified WASM binary was
+materialized. `serve` discovers it via a new, independent `--artifact-state
+<path>` flag — never a default location, never embedded in spec 118's own
+schema.
+
+`traverse-cli registry materialize` is the sole sanctioned way to produce
+this file: it fetches each capability's `contract.artifact.url`, verifies
+the downloaded bytes against `contract.artifact.digest`, writes verified
+bytes to a host-chosen output directory, and emits the artifact-state
+manifest. `serve` never fetches; it only re-verifies and reads.
+
+## Requirements
+
+- **FR-001**: `traverse-cli registry materialize --registry-state <path>
+  --out <dir>` MUST fetch, for every capability listed in the given
+  spec-118 registry-bundle manifest, the artifact named by that
+  capability's contract's `artifact.url`.
+- **FR-002**: `materialize` MUST verify each fetched artifact's digest
+  against the contract's declared `artifact.digest` before writing it to
+  `--out`. A mismatch MUST abort materialization for that entry with a
+  stable, actionable error; it MUST NOT write unverified bytes.
+- **FR-003**: `materialize` MUST emit a versioned `artifact-state.json`
+  binding, for each successfully materialized capability, its exact `id`,
+  `version`, real local `path` (relative to the artifact-state manifest),
+  verified `digest`, `source_url`, and `materialized_at` timestamp.
+- **FR-004**: `serve` MUST accept an explicit, independent `--artifact-state
+  <path>` flag. It MUST NOT invent a default location, and this spec's
+  manifest MUST NOT be embedded into or discovered via spec 118's
+  registry-bundle manifest.
+- **FR-005**: Before listening, `serve` MUST re-verify every referenced
+  artifact's on-disk digest against `artifact-state.json`'s declared
+  digest. It MUST NOT trust `materialize`'s prior verification as
+  sufficient on its own.
+- **FR-006**: If any capability declared in the `--registry-state` manifest
+  has no corresponding, verifying entry in `--artifact-state`, `serve` MUST
+  fail closed for the entire startup — no subset of verified capabilities
+  may be served while others are silently excluded.
+- **FR-007**: This spec applies only to `capabilities[]` entries. Workflow
+  entrypoints compose already-covered capability artifacts and carry no
+  artifact of their own.
+- **FR-008**: `artifact-state.json` MUST be a versioned JSON document;
+  migration MUST be explicit, matching spec 118's existing FR-008
+  convention.
+
+## Acceptance scenarios
+
+1. Given a spec-118 registry-bundle manifest naming 5 real, published
+   capabilities, `materialize --out ./artifacts` fetches and
+   digest-verifies all 5 and emits an `artifact-state.json` with 5 entries.
+2. Given one capability's downloaded bytes don't match its declared digest,
+   `materialize` aborts with a stable error naming that capability and does
+   not write partial/tampered bytes for it.
+3. Given `serve --registry-state <m> --artifact-state <a>` where `<a>`
+   covers every capability in `<m>` and all on-disk digests re-verify,
+   `serve` starts and can execute any of them via the verified-entrypoint
+   endpoint (spec 115).
+4. Given `<a>` is missing an entry for one capability declared in `<m>`,
+   `serve` refuses to start at all — not a partial server.
+5. Given an on-disk artifact's bytes have changed since `materialize` ran
+   (tampering, stale reuse, filesystem corruption), `serve`'s startup
+   re-verification catches the mismatch and refuses to start.
+
+## Validation
+
+- `materialize` fixtures: successful fetch+verify, digest mismatch abort,
+  network failure, malformed contract artifact fields.
+- `serve` startup fixtures: complete matching state (success), missing
+  artifact-state entry (fail closed), tampered on-disk binary (fail
+  closed), unsupported artifact-state schema version (fail closed).
+- Integration: real end-to-end run against a live, non-deprecated registry
+  capability, executed through the verified-entrypoint HTTP endpoint.
+
+## Compatibility
+
+Additive to spec 118 and spec 115: no existing field, flag, or behavior of
+either changes. `serve` without `--artifact-state` behaves exactly as it
+does today (verified-entrypoint execution unavailable, per spec 118's
+existing "unavailable until the host opts in" framing) — this spec adds a
+second, independent opt-in, not a replacement.
+
+## Non-goals
+
+- Modifying spec 118's registry-bundle manifest schema.
+- A generic/live artifact cache with request-time refresh — materialization
+  is a discrete, host-run, pre-serve step, not a `serve`-owned or
+  per-request mechanism.
+- Workflow-level artifacts.
+- Automatic re-materialization on a schedule; when/how often to re-run
+  `materialize` is an operational decision for whoever hosts `serve`, out
+  of scope here.

--- a/specs/governance/approved-specs.json
+++ b/specs/governance/approved-specs.json
@@ -1579,6 +1579,19 @@
         "crates/traverse-mcp/",
         "specs/119-verified-registry-mcp-mode-a/"
       ]
+    },
+    {
+      "id": "120-host-owned-artifact-preparation",
+      "version": "0.1.0",
+      "status": "approved",
+      "immutable": true,
+      "path": "specs/120-host-owned-artifact-preparation/spec.md",
+      "governs": [
+        "crates/traverse-cli/",
+        "specs/120-host-owned-artifact-preparation/",
+        "docs/adr/0051-host-owned-artifact-preparation.md",
+        "docs/decision-log.md"
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary

`#1153` found that `serve --registry-state` (spec 118) always fabricates a fake `bundled://` artifact location instead of resolving a capability's real WASM, so no capability can actually execute. Fixing this inside `serve` (fetch + verify the artifact at load/request time) was ruled out as a violation of spec 115 FR-004 / spec 118 FR-004/FR-006 (`serve` MUST NOT fetch/sync/mutate state during startup or execution). This PR records the brainstormed resolution: a new spec (`120`) governing a separate, host-run `traverse-cli registry materialize` step and a cross-referenced `artifact-state.json` manifest, discovered by `serve` via a new independent `--artifact-state` flag — spec 118 itself stays untouched.

## Governing Spec

- `120-host-owned-artifact-preparation`
- `004-spec-alignment-gate`

## Project Item

- traverse#1153

## Validation

- `python3 -c "import json; json.load(open('specs/governance/approved-specs.json'))"` — valid JSON, spec count 123 → 124 (one new entry).
- Manually reviewed spec 120, ADR-0051, and the Decision 66 log entry against house format (spec 118/ADR-0044, Decision 65).
- `BASE_SHA=$(git merge-base HEAD origin/main) HEAD_SHA=$(git rev-parse HEAD) bash scripts/ci/spec_alignment_check.sh pr-body-1154.md`
- `bash scripts/ci/pr_body_check.sh pr-body-1154.md`
