### PR TITLE
feat(browser): execute verified capability with receipt

### DIFF
--- a/crates/traverse-cli/src/http_api.rs
+++ b/crates/traverse-cli/src/http_api.rs
@@ -8010,6 +8010,47 @@ mod tests {
         test_state_with_output(id, version, json!({"result": "ok"}))
     }
 
+    fn test_system_state_with(id: &str, version: &str) -> ApiState<TestExecutor> {
+        let mut registration = test_registration(id, version);
+        registration.scope = RegistryScope::Public;
+        let mut registry = CapabilityRegistry::new();
+        registry
+            .register(registration)
+            .expect("public test registration must succeed");
+
+        let executor = TestExecutor::ok(json!({"result": "ok"}));
+        let registry_root = test_registry_root();
+        std::fs::create_dir_all(&registry_root).expect("registry root must be created");
+        persist_test_workspace(&registry_root, SYSTEM_WORKSPACE_ID, "admin-user");
+        let mut workspaces = HashMap::new();
+        workspaces.insert(
+            SYSTEM_WORKSPACE_ID.to_string(),
+            new_workspace_state(
+                registry,
+                executor.clone(),
+                WorkflowRegistry::new(),
+                RuntimeSecurityConfig::development(),
+                true,
+            )
+            .expect("test system workspace must construct an app event broker"),
+        );
+
+        ApiState {
+            auth_mode: "dev-loopback".to_string(),
+            allow_unauthenticated: true,
+            allowed_origins: Vec::new(),
+            registry_root,
+            executor,
+            workspaces: Mutex::new(workspaces),
+            idempotency_records: Mutex::new(HashMap::new()),
+            idempotency_retention_seconds: DEFAULT_IDEMPOTENCY_RETENTION_SECONDS,
+            jwt_verification_key: Some(
+                parse_ed25519_verifying_key(&test_jwt_verifying_key_hex())
+                    .expect("test verification key must parse"),
+            ),
+        }
+    }
+
     fn test_state_with_output(id: &str, version: &str, output: Value) -> ApiState<TestExecutor> {
         let mut registry = CapabilityRegistry::new();
         registry
@@ -9365,6 +9406,69 @@ mod tests {
         assert_eq!(resp["status"], "completed");
         assert!(resp["trace"].is_object(), "trace must be an object");
         assert_eq!(resp["request_id"], "test-req-001");
+    }
+
+    #[test]
+    fn verified_entrypoint_execute_returns_a_public_trace_receipt() {
+        let request: Value =
+            serde_json::from_slice(&make_runtime_request_body("test.api.do-something"))
+                .expect("test runtime request must be JSON");
+        let body = json!({
+            "entrypoint_kind": "capability",
+            "id": "test.api.do-something",
+            "version": "1.0.0",
+            "request": request,
+        })
+        .to_string()
+        .into_bytes();
+        let state = test_system_state_with("test.api.do-something", "1.0.0");
+        let req = with_bearer(
+            make_http_request("POST", "/v1/entrypoints/execute", body),
+            &make_jwt("admin-user", future_exp(), true),
+        );
+
+        let mut out = Vec::new();
+        handle_verified_entrypoint_execute(&mut out, &req, &state, true)
+            .expect("verified entrypoint execution must write a response");
+
+        let resp = parse_response_body(&out);
+        assert_eq!(response_status(&out), 200);
+        assert_eq!(resp["status"], "completed");
+        assert_eq!(resp["output"]["result"], "ok");
+        assert!(resp["trace"]["spans"].is_array());
+        assert!(
+            resp.get("otel_trace").is_none(),
+            "internal trace stays private"
+        );
+    }
+
+    #[test]
+    fn verified_entrypoint_execute_rejects_a_non_exact_runtime_identity() {
+        let request: Value = serde_json::from_slice(&make_runtime_request_body("other.capability"))
+            .expect("test runtime request must be JSON");
+        let body = json!({
+            "entrypoint_kind": "capability",
+            "id": "test.api.do-something",
+            "version": "1.0.0",
+            "request": request,
+        })
+        .to_string()
+        .into_bytes();
+        let state = test_system_state_with("test.api.do-something", "1.0.0");
+        let req = with_bearer(
+            make_http_request("POST", "/v1/entrypoints/execute", body),
+            &make_jwt("admin-user", future_exp(), true),
+        );
+
+        let mut out = Vec::new();
+        handle_verified_entrypoint_execute(&mut out, &req, &state, true)
+            .expect("verified entrypoint rejection must write a response");
+
+        assert_eq!(response_status(&out), 422);
+        assert_eq!(
+            parse_response_body(&out)["traverse_code"],
+            "entrypoint_identity_mismatch"
+        );
     }
 
     #[test]

--- a/crates/traverse-cli/src/http_api.rs
+++ b/crates/traverse-cli/src/http_api.rs
@@ -5064,7 +5064,7 @@ fn handle_verified_entrypoint_execute<W: Write, E: LocalExecutor + Clone>(
         ))
     });
     match outcome {
-        Ok(outcome) => match serialize_outcome(&outcome) {
+        Ok(outcome) => match serialize_verified_entrypoint_outcome(&outcome) {
             Ok(body) => write_json_raw(w, 200, "OK", &body),
             Err(error) => write_json(
                 w,
@@ -7185,6 +7185,30 @@ fn serialize_outcome(outcome: &RuntimeExecutionOutcome) -> Result<String, String
     });
 
     serde_json::to_string(&response).map_err(|e| format!("failed to serialize outcome: {e}"))
+}
+
+/// Spec 115 exposes a browser-safe receipt, never the internal RuntimeTrace.
+fn serialize_verified_entrypoint_outcome(
+    outcome: &RuntimeExecutionOutcome,
+) -> Result<String, String> {
+    let status = if outcome.result.status == RuntimeResultStatus::Error {
+        "error"
+    } else {
+        "completed"
+    };
+    serde_json::to_string(&json!({
+        "status": status,
+        "request_id": outcome.result.request_id,
+        "execution_id": outcome.result.execution_id,
+        "trace_ref": outcome.result.trace_ref,
+        "output": outcome.result.output,
+        "error": outcome.result.error.as_ref().map(|error| json!({
+            "code": format!("{:?}", error.code).to_lowercase(),
+            "message": error.message,
+        })),
+        "trace": public_trace_envelope(SYSTEM_WORKSPACE_ID, &outcome.trace),
+    }))
+    .map_err(|error| format!("failed to serialize verified entrypoint outcome: {error}"))
 }
 
 pub(crate) fn error_envelope(code: &str, message: &str) -> Value {

--- a/packages/web/TraverseEmbedder/examples/verified-entrypoint/README.md
+++ b/packages/web/TraverseEmbedder/examples/verified-entrypoint/README.md
@@ -1,0 +1,30 @@
+# Verified entrypoint browser demo
+
+This is the browser proof for issue #1158. It invokes one exact published
+capability only through `POST /v1/entrypoints/execute` (Spec 115). The page
+does not download, accept, or execute an artifact; the separately started
+server must already be configured with verified registry state and verified
+materialized artifact state (Specs 118 and 120).
+
+Build the package and serve this page:
+
+```bash
+npm run build
+node examples/verified-entrypoint/server.mjs
+```
+
+Open `http://127.0.0.1:4176`, enter the exact public capability id/version,
+and paste its matching `RuntimeRequest` JSON. The result panel displays the
+server's result and trace receipt. Verification failures and invalid input are
+rendered as safe error envelopes.
+
+The host must be started independently with its explicit verified state, for
+example:
+
+```bash
+traverse-cli serve --registry-state /srv/traverse/registry-state.json \
+  --artifact-state /srv/traverse/artifact-state.json
+```
+
+This example intentionally remains separate from `react-integration/`, which
+is the existing no-sidecar bundled-WebAssembly proof governed by Spec 068.

--- a/packages/web/TraverseEmbedder/examples/verified-entrypoint/index.html
+++ b/packages/web/TraverseEmbedder/examples/verified-entrypoint/index.html
@@ -1,0 +1,32 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Traverse verified capability execution</title>
+    <link rel="stylesheet" href="./styles.css" />
+  </head>
+  <body>
+    <main>
+      <h1>Verified published capability</h1>
+      <p>
+        This page sends an exact capability identity to a separately started
+        <code>traverse-cli serve</code> host. That host must already have
+        verified registry and artifact state; the browser never supplies or
+        executes arbitrary artifact bytes.
+      </p>
+      <form id="execute-form">
+        <label>Server URL <input id="server-url" value="http://127.0.0.1:8787" required /></label>
+        <label>Capability ID <input id="capability-id" required /></label>
+        <label>Version <input id="capability-version" required /></label>
+        <label>RuntimeRequest JSON <textarea id="runtime-request" rows="14" required></textarea></label>
+        <button type="submit">Execute verified capability</button>
+      </form>
+      <section aria-live="polite">
+        <h2>Result and redacted trace receipt</h2>
+        <pre id="result">No execution has been requested.</pre>
+      </section>
+    </main>
+    <script type="module" src="./main.js"></script>
+  </body>
+</html>

--- a/packages/web/TraverseEmbedder/examples/verified-entrypoint/main.js
+++ b/packages/web/TraverseEmbedder/examples/verified-entrypoint/main.js
@@ -1,0 +1,26 @@
+import { executeVerifiedEntrypoint, VerifiedEntrypointError } from "/pkg/verifiedEntrypoint.js";
+
+const form = document.querySelector("#execute-form");
+const result = document.querySelector("#result");
+const capabilityId = document.querySelector("#capability-id");
+const capabilityVersion = document.querySelector("#capability-version");
+const serverUrl = document.querySelector("#server-url");
+const runtimeRequest = document.querySelector("#runtime-request");
+
+form.addEventListener("submit", async (event) => {
+  event.preventDefault();
+  try {
+    const request = JSON.parse(runtimeRequest.value);
+    const response = await executeVerifiedEntrypoint(fetch, serverUrl.value, {
+      id: capabilityId.value,
+      version: capabilityVersion.value,
+      request,
+    });
+    result.textContent = JSON.stringify(response, null, 2);
+  } catch (error) {
+    const safe = error instanceof VerifiedEntrypointError
+      ? { code: error.code, message: error.message }
+      : { code: "invalid_browser_request", message: "RuntimeRequest must be valid JSON." };
+    result.textContent = JSON.stringify({ status: "error", error: safe }, null, 2);
+  }
+});

--- a/packages/web/TraverseEmbedder/examples/verified-entrypoint/server.mjs
+++ b/packages/web/TraverseEmbedder/examples/verified-entrypoint/server.mjs
@@ -1,0 +1,33 @@
+#!/usr/bin/env node
+import { createServer } from "node:http";
+import { readFile } from "node:fs/promises";
+import { extname, join, normalize } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const exampleRoot = fileURLToPath(new URL(".", import.meta.url));
+const repoRoot = fileURLToPath(new URL("../../../../../", import.meta.url));
+const packageDist = join(repoRoot, "packages/web/TraverseEmbedder/dist");
+const port = Number(process.env.PORT ?? "4176");
+
+createServer(async (request, response) => {
+  const path = request.url?.split("?")[0] ?? "/";
+  const root = path.startsWith("/pkg/") ? packageDist : exampleRoot;
+  const relative = path.startsWith("/pkg/") ? path.slice(5) : path === "/" ? "index.html" : path.slice(1);
+  const filePath = join(root, normalize(relative).replace(/^([.][.][/\\])+/, ""));
+  try {
+    response.setHeader("Content-Type", contentType(filePath));
+    response.end(await readFile(filePath));
+  } catch {
+    response.statusCode = 404;
+    response.end("Not found");
+  }
+}).listen(port, "127.0.0.1", () => {
+  console.log(`Verified-entrypoint browser demo: http://127.0.0.1:${port}`);
+});
+
+function contentType(filePath) {
+  return extname(filePath) === ".html" ? "text/html; charset=utf-8"
+    : extname(filePath) === ".js" ? "text/javascript; charset=utf-8"
+    : extname(filePath) === ".css" ? "text/css; charset=utf-8"
+    : "application/octet-stream";
+}

--- a/packages/web/TraverseEmbedder/examples/verified-entrypoint/styles.css
+++ b/packages/web/TraverseEmbedder/examples/verified-entrypoint/styles.css
@@ -1,0 +1,5 @@
+body { font-family: system-ui, sans-serif; color: #17212b; margin: 2rem auto; max-width: 760px; padding: 0 1rem; }
+label { display: block; font-weight: 600; margin: 1rem 0; }
+input, textarea { box-sizing: border-box; display: block; font: inherit; margin-top: .35rem; padding: .5rem; width: 100%; }
+button { font: inherit; padding: .55rem .9rem; }
+pre { background: #f4f6f8; border-radius: .4rem; overflow-x: auto; padding: 1rem; white-space: pre-wrap; }

--- a/packages/web/TraverseEmbedder/package.json
+++ b/packages/web/TraverseEmbedder/package.json
@@ -25,7 +25,7 @@
   "scripts": {
     "build": "tsc",
     "prepublishOnly": "npm run build",
-    "test": "npm run build && node --test tests/embedder.test.mjs tests/bundleEmbedder.test.mjs tests/registryCache.test.mjs tests/indexedDbDataStore.test.mjs"
+    "test": "npm run build && node --test tests/embedder.test.mjs tests/bundleEmbedder.test.mjs tests/registryCache.test.mjs tests/indexedDbDataStore.test.mjs tests/verifiedEntrypoint.test.mjs"
   },
   "devDependencies": {
     "@types/node": "^22.20.1",

--- a/packages/web/TraverseEmbedder/src/index.ts
+++ b/packages/web/TraverseEmbedder/src/index.ts
@@ -100,3 +100,10 @@ export {
   findUnauthorizedImport,
 } from "./hostAbi.js";
 export type { HostAbiImport } from "./hostAbi.js";
+
+export { executeVerifiedEntrypoint, VerifiedEntrypointError } from "./verifiedEntrypoint.js";
+export type {
+  VerifiedEntrypointFetch,
+  VerifiedEntrypointRequest,
+  VerifiedEntrypointResponse,
+} from "./verifiedEntrypoint.js";

--- a/packages/web/TraverseEmbedder/src/verifiedEntrypoint.ts
+++ b/packages/web/TraverseEmbedder/src/verifiedEntrypoint.ts
@@ -1,0 +1,74 @@
+/**
+ * Browser client for the Spec 115 verified-entrypoint HTTP boundary.
+ *
+ * The server owns registry synchronization, artifact materialization, digest
+ * verification, and execution. This client deliberately sends only an exact
+ * identity and a RuntimeRequest; it never accepts an artifact URL or bytes.
+ */
+
+export interface VerifiedEntrypointRequest {
+  readonly id: string;
+  readonly version: string;
+  readonly request: Record<string, unknown>;
+}
+
+export interface VerifiedEntrypointResponse {
+  readonly status: "completed" | "error";
+  readonly request_id: string;
+  readonly execution_id: string;
+  readonly trace_ref: string;
+  readonly output: unknown;
+  readonly error: { readonly code: string; readonly message: string } | null;
+  readonly trace: unknown;
+}
+
+export class VerifiedEntrypointError extends Error {
+  readonly code: string;
+
+  constructor(code: string, message: string) {
+    super(message);
+    this.name = "VerifiedEntrypointError";
+    this.code = code;
+  }
+}
+
+export type VerifiedEntrypointFetch = (
+  input: string,
+  init: RequestInit,
+) => Promise<Response>;
+
+function exact(value: string, label: string): string {
+  const normalized = value.trim();
+  if (normalized.length === 0) {
+    throw new VerifiedEntrypointError("invalid_entrypoint_request", `${label} is required`);
+  }
+  return normalized;
+}
+
+function endpointFor(serverUrl: string): string {
+  return `${exact(serverUrl, "server URL").replace(/\/+$/, "")}/v1/entrypoints/execute`;
+}
+
+/** Execute one capability whose artifact was verified by the serving host. */
+export async function executeVerifiedEntrypoint(
+  fetcher: VerifiedEntrypointFetch,
+  serverUrl: string,
+  request: VerifiedEntrypointRequest,
+): Promise<VerifiedEntrypointResponse> {
+  const id = exact(request.id, "capability id");
+  const version = exact(request.version, "capability version");
+  const response = await fetcher(endpointFor(serverUrl), {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ entrypoint_kind: "capability", id, version, request: request.request }),
+  });
+  const body: unknown = await response.json();
+  if (!response.ok) {
+    const problem = body as { traverse_code?: unknown; detail?: unknown };
+    throw new VerifiedEntrypointError(
+      typeof problem.traverse_code === "string" ? problem.traverse_code : "entrypoint_execute_failed",
+      typeof problem.detail === "string" ? problem.detail : `verified entrypoint request failed: HTTP ${response.status}`,
+    );
+  }
+  return body as VerifiedEntrypointResponse;
+}

--- a/packages/web/TraverseEmbedder/tests/verifiedEntrypoint.test.mjs
+++ b/packages/web/TraverseEmbedder/tests/verifiedEntrypoint.test.mjs
@@ -1,0 +1,39 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { executeVerifiedEntrypoint, VerifiedEntrypointError } from "../dist/verifiedEntrypoint.js";
+
+const runtimeRequest = {
+  kind: "runtime_request",
+  schema_version: "1.0.0",
+  request_id: "browser-demo-001",
+  intent: { capability_id: "demo.greet", capability_version: "1.0.0" },
+  input: { name: "Ada" },
+  lookup: { scope: "public_only", allow_ambiguity: false },
+  context: { requested_target: "local" },
+  governing_spec: "006-runtime-request-execution",
+};
+
+test("executes an exact capability through the verified-entrypoint boundary", async () => {
+  let observed;
+  const response = await executeVerifiedEntrypoint(async (url, init) => {
+    observed = { url, init };
+    return new Response(JSON.stringify({ status: "completed", request_id: "browser-demo-001", execution_id: "exec-001", trace_ref: "trace-001", output: { greeting: "hello" }, error: null, trace: { status: "completed" } }), { status: 200 });
+  }, "http://127.0.0.1:8787/", { id: "demo.greet", version: "1.0.0", request: runtimeRequest });
+  assert.equal(observed.url, "http://127.0.0.1:8787/v1/entrypoints/execute");
+  assert.deepEqual(JSON.parse(observed.init.body), { entrypoint_kind: "capability", id: "demo.greet", version: "1.0.0", request: runtimeRequest });
+  assert.equal(response.trace_ref, "trace-001");
+});
+
+test("surfaces the server's safe verification failure", async () => {
+  await assert.rejects(
+    () => executeVerifiedEntrypoint(async () => new Response(JSON.stringify({ traverse_code: "verified_entrypoint_not_found", detail: "no verified entrypoint matches" }), { status: 404 }), "http://localhost:8787", { id: "demo.greet", version: "1.0.0", request: runtimeRequest }),
+    (error) => error instanceof VerifiedEntrypointError && error.code === "verified_entrypoint_not_found",
+  );
+});
+
+test("rejects a missing exact identity before making a request", async () => {
+  await assert.rejects(
+    () => executeVerifiedEntrypoint(async () => { throw new Error("must not fetch"); }, "http://localhost:8787", { id: "", version: "1.0.0", request: runtimeRequest }),
+    (error) => error instanceof VerifiedEntrypointError && error.code === "invalid_entrypoint_request",
+  );
+});


### PR DESCRIPTION
## Summary

Add a browser client and standalone demo for executing one exact capability through the existing verified-entrypoint HTTP boundary. The endpoint now returns the public, redacted trace receipt instead of its internal runtime trace.

## Governing Spec

- `115-browser-verified-entrypoint-execution`
- `068-public-platform-embedder-packages`

Specs 118 and 120 remain the host-owned verified registry and artifact-preparation boundaries; the browser supplies neither artifact URLs nor bytes.

## Project Item

Closes #1158.

## Definition of Done

- Browser code sends only an exact capability id, version, and RuntimeRequest to `POST /v1/entrypoints/execute`.
- A separate static browser demo displays runtime result plus the public trace receipt without changing the existing no-sidecar bundle demo.
- Verification and invalid-identity failures are surfaced as safe errors.
- Verified-entrypoint execution serializes the redacted public trace envelope.

## Validation

- `npm test` in `packages/web/TraverseEmbedder` (45 passing tests)
- `cargo test -p traverse-cli-rs http_api` (174 passing tests)
- `cargo fmt --check`
- `bash scripts/ci/spec_alignment_check.sh /private/tmp/issue-1158-pr-body.md`
