### PR TITLE
docs: add cross-host hello-world fixture corpus

### DIFF
--- a/fixtures/cross-host/hello-world-v1/README.md
+++ b/fixtures/cross-host/hello-world-v1/README.md
@@ -1,0 +1,34 @@
+# Cross-host hello-world fixture v1
+
+This offline, repository-controlled fixture is the shared corpus for the
+browser, CLI/Node, and native conformance runners. It implements the comparison
+boundary in [`docs/cross-host-fixture-comparison-contract.md`](../../../docs/cross-host-fixture-comparison-contract.md).
+
+## Pinned sources
+
+The fixture uses the deterministic `hello.world.say-hello` capability. The
+source artifact and contract are checked into this repository and are identified
+by the SHA-256 digests in `fixture.json`; a runner must verify them before it
+uses either source. Rebuild the artifact locally with:
+
+```bash
+bash examples/hello-world/say-hello-agent/build-fixture.sh
+shasum -a 256 examples/hello-world/say-hello-agent/artifacts/say-hello-agent.wasm
+```
+
+The artifact uses no network, filesystem, or host API access. Its output is
+deterministic and contains only the supplied public fixture value, making it
+suitable for public CI.
+
+## Cases
+
+- `valid-execution.json` verifies the canonical result and lifecycle
+  projections for one successful invocation.
+- `invalid-input.json` omits the contract-required `name`; a runner must reject
+  it before successful capability execution.
+- `artifact-identity-failure.json` deliberately supplies a non-matching
+  observed digest; a runner must reject it before execution.
+
+The files contain only fixture inputs and expected safe projections. Runners
+must not place raw input or output payloads, credentials, headers, local paths,
+or opaque trace data in their evidence records.

--- a/fixtures/cross-host/hello-world-v1/artifact-identity-failure.json
+++ b/fixtures/cross-host/hello-world-v1/artifact-identity-failure.json
@@ -1,0 +1,15 @@
+{
+  "input_id": "artifact-digest-mismatch",
+  "expected_outcome": "artifact_identity_failure",
+  "input": { "name": "Traverse" },
+  "observed_artifact_digest": "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+  "expected_output_projection": {
+    "reason_code": "ARTIFACT_DIGEST_MISMATCH",
+    "status": "rejected"
+  },
+  "expected_trace_projection": {
+    "event_kinds": ["rejected"],
+    "failure_category": "artifact_identity_failure",
+    "terminal_state": "rejected"
+  }
+}

--- a/fixtures/cross-host/hello-world-v1/fixture.json
+++ b/fixtures/cross-host/hello-world-v1/fixture.json
@@ -1,0 +1,24 @@
+{
+  "fixture_version": "1.0.0",
+  "capability": {
+    "id": "hello.world.say-hello",
+    "version": "1.0.0",
+    "contract": {
+      "id": "hello.world.say-hello",
+      "version": "1.0.0",
+      "digest": "sha256:42fa0111aa735bc4cfbfbb2bbba413856c409329124ed8872693fc08d076779f",
+      "source": "contracts/examples/hello-world/capabilities/say-hello/contract.json"
+    },
+    "artifact": {
+      "digest": "sha256:79804d32fc2ee77266c85c1fe243bfd0c8f27bb444245a6e1782acf1bd237d40",
+      "source": "examples/hello-world/say-hello-agent/artifacts/say-hello-agent.wasm",
+      "build_command": "bash examples/hello-world/say-hello-agent/build-fixture.sh"
+    }
+  },
+  "expected_projection_version": "1.0.0",
+  "cases": [
+    "valid-execution.json",
+    "invalid-input.json",
+    "artifact-identity-failure.json"
+  ]
+}

--- a/fixtures/cross-host/hello-world-v1/invalid-input.json
+++ b/fixtures/cross-host/hello-world-v1/invalid-input.json
@@ -1,0 +1,14 @@
+{
+  "input_id": "missing-required-name",
+  "expected_outcome": "invalid_input",
+  "input": {},
+  "expected_output_projection": {
+    "reason_code": "CONTRACT_INPUT_INVALID",
+    "status": "rejected"
+  },
+  "expected_trace_projection": {
+    "event_kinds": ["rejected"],
+    "failure_category": "invalid_input",
+    "terminal_state": "rejected"
+  }
+}

--- a/fixtures/cross-host/hello-world-v1/valid-execution.json
+++ b/fixtures/cross-host/hello-world-v1/valid-execution.json
@@ -1,0 +1,13 @@
+{
+  "input_id": "valid-traverse-name",
+  "expected_outcome": "success",
+  "input": { "name": "Traverse" },
+  "expected_output_projection": {
+    "greeting": "Hello, Traverse!",
+    "name": "Traverse"
+  },
+  "expected_trace_projection": {
+    "event_kinds": ["started", "completed"],
+    "terminal_state": "completed"
+  }
+}


### PR DESCRIPTION
## Summary

Adds the versioned, offline hello-world fixture corpus for the browser, CLI/Node, and native cross-host runners.

## Governing Spec

Cross-host fixture comparison contract (#1161); no new public contract or runtime behavior.

## Project Item

Closes #1162.

## Definition of Done

- Pinned contract and WASM artifact digests
- Valid execution, invalid-input, and artifact-identity-failure cases
- Canonical output and redacted trace projections

## Validation

- Verified SHA-256 values against the checked-in contract and WASM artifact
- `git diff --check origin/main...HEAD`
