### PR TITLE
feat: prove native cross-host fixture conformance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -227,6 +227,9 @@ jobs:
       - name: Certify generated artifact across native packages
         run: bash scripts/ci/native_artifact_certification.sh
 
+      - name: Run bounded native cross-host fixture
+        run: bash scripts/ci/cross_host_native_fixture.sh
+
   coverage-gate:
     needs: classify-changes
     if: needs.classify-changes.outputs.full_ci == 'true'

--- a/crates/traverse-swift-host/src/lib.rs
+++ b/crates/traverse-swift-host/src/lib.rs
@@ -8,6 +8,8 @@
 
 use sha2::{Digest, Sha256};
 use std::fmt::Write as _;
+#[cfg(test)]
+use wasmi::{Caller, Extern};
 use wasmi::{
     Config, Engine, Instance, Linker, Memory, Module, Store, StoreLimits, StoreLimitsBuilder,
 };
@@ -75,9 +77,133 @@ struct Host {
     limits: Limits,
 }
 
+#[derive(Debug)]
 struct HostError {
     status: i32,
     code: &'static str,
+}
+
+#[cfg(test)]
+struct WasiCommandState {
+    output: Vec<u8>,
+    maximum_output_bytes: usize,
+    store_limits: StoreLimits,
+}
+
+#[cfg(test)]
+fn wasi_fd_write(
+    mut caller: Caller<'_, WasiCommandState>,
+    fd: i32,
+    iovs: i32,
+    count: i32,
+    written: i32,
+) -> i32 {
+    if fd != 1 || count < 0 || iovs < 0 || written < 0 {
+        return 8;
+    }
+    let Some(Extern::Memory(memory)) = caller.get_export("memory") else {
+        return 21;
+    };
+    let mut bytes = Vec::new();
+    let Ok(descriptor_count) = usize::try_from(count) else {
+        return 8;
+    };
+    for index in 0..descriptor_count {
+        let Some(offset) = usize::try_from(iovs)
+            .ok()
+            .and_then(|base| base.checked_add(index.saturating_mul(8)))
+        else {
+            return 21;
+        };
+        let mut descriptor = [0_u8; 8];
+        if memory.read(&caller, offset, &mut descriptor).is_err() {
+            return 21;
+        }
+        let pointer =
+            u32::from_le_bytes([descriptor[0], descriptor[1], descriptor[2], descriptor[3]])
+                as usize;
+        let length =
+            u32::from_le_bytes([descriptor[4], descriptor[5], descriptor[6], descriptor[7]])
+                as usize;
+        if bytes.len().saturating_add(length) > caller.data().maximum_output_bytes {
+            return 27;
+        }
+        let start = bytes.len();
+        bytes.resize(start.saturating_add(length), 0);
+        if memory.read(&caller, pointer, &mut bytes[start..]).is_err() {
+            return 21;
+        }
+    }
+    let Ok(total) = u32::try_from(bytes.len()) else {
+        return 27;
+    };
+    let Ok(written_offset) = usize::try_from(written) else {
+        return 8;
+    };
+    if memory
+        .write(&mut caller, written_offset, &total.to_le_bytes())
+        .is_err()
+    {
+        return 21;
+    }
+    caller.data_mut().output.extend(bytes);
+    0
+}
+
+#[cfg(test)]
+fn execute_wasi_command(
+    artifact: &[u8],
+    expected_digest: &[u8],
+    limits: &Limits,
+) -> Result<Vec<u8>, HostError> {
+    if artifact.len() > limits.maximum_artifact_bytes
+        || normalised_digest(expected_digest)? != digest(artifact)
+    {
+        return Err(HostError::new(
+            INVALID_INPUT,
+            "wasi_artifact_identity_failure",
+        ));
+    }
+    let mut config = Config::default();
+    config.consume_fuel(true);
+    let engine = Engine::new(&config);
+    let module = Module::new(&engine, artifact)
+        .map_err(|_| HostError::new(INVALID_INPUT, "wasi_invalid_module"))?;
+    if module
+        .imports()
+        .any(|import| import.module() != "wasi_snapshot_preview1" || import.name() != "fd_write")
+    {
+        return Err(HostError::new(INVALID_INPUT, "wasi_forbidden_import"));
+    }
+    let store_limits = StoreLimitsBuilder::new()
+        .memory_size(limits.maximum_memory_bytes)
+        .trap_on_grow_failure(true)
+        .build();
+    let mut store = Store::new(
+        &engine,
+        WasiCommandState {
+            output: Vec::new(),
+            maximum_output_bytes: limits.maximum_output_bytes,
+            store_limits,
+        },
+    );
+    store.limiter(|state| &mut state.store_limits);
+    store
+        .set_fuel(limits.fuel_per_invocation)
+        .map_err(|_| HostError::new(RESOURCE_LIMIT, "wasi_resource_limit"))?;
+    let mut linker = Linker::new(&engine);
+    linker
+        .func_wrap("wasi_snapshot_preview1", "fd_write", wasi_fd_write)
+        .map_err(|_| HostError::new(INTERNAL_ERROR, "wasi_link_failure"))?;
+    let instance = linker
+        .instantiate_and_start(&mut store, &module)
+        .map_err(|_| HostError::new(INTERNAL_ERROR, "wasi_execution_failed"))?;
+    instance
+        .get_typed_func::<(), ()>(&store, "_start")
+        .map_err(|_| HostError::new(INVALID_DESCRIPTOR, "wasi_missing_start"))?
+        .call(&mut store, ())
+        .map_err(|_| HostError::new(INTERNAL_ERROR, "wasi_execution_failed"))?;
+    Ok(store.into_data().output)
 }
 
 impl HostError {
@@ -501,8 +627,8 @@ mod tests {
 
     use super::{
         ABI_VERSION, BUFFER_TOO_SMALL, OK, RESOURCE_LIMIT, TraverseSwiftHostLimits, digest,
-        traverse_swift_host_abi_version, traverse_swift_host_create, traverse_swift_host_destroy,
-        traverse_swift_host_invoke,
+        execute_wasi_command, traverse_swift_host_abi_version, traverse_swift_host_create,
+        traverse_swift_host_destroy, traverse_swift_host_invoke,
     };
 
     #[test]
@@ -597,10 +723,29 @@ mod tests {
         assert_eq!(traverse_swift_host_destroy(handle), OK);
     }
 
+    #[test]
+    fn executes_the_pinned_cross_host_wasi_fixture() {
+        let artifact = include_bytes!(
+            "../../../examples/hello-world/say-hello-agent/artifacts/say-hello-agent.wasm"
+        );
+        let output = execute_wasi_command(
+            artifact,
+            digest(artifact).as_bytes(),
+            &limits().checked().expect("limits are valid"),
+        )
+        .expect("fixture must execute under the bounded native profile");
+        let actual: serde_json::Value =
+            serde_json::from_slice(&output).expect("fixture stdout is JSON");
+        assert_eq!(
+            actual,
+            serde_json::json!({"greeting": "Hello, Traverse!", "name": "Traverse"})
+        );
+    }
+
     fn limits() -> TraverseSwiftHostLimits {
         TraverseSwiftHostLimits {
             maximum_artifact_bytes: 1024 * 1024,
-            maximum_memory_bytes: 1024 * 1024,
+            maximum_memory_bytes: 2 * 1024 * 1024,
             fuel_per_invocation: 10_000,
             maximum_input_bytes: 1024,
             maximum_output_bytes: 1024,

--- a/docs/cross-host-fixture-comparison-contract.md
+++ b/docs/cross-host-fixture-comparison-contract.md
@@ -96,6 +96,15 @@ Any other outcome, an execution after an expected rejection, missing evidence,
 or unequal projection is `not_equal` / fail. A host implementation failure that
 prevents a record from being emitted is also fail; it is not silently skipped.
 
+## Native profile evidence
+
+The selected native host is `traverse-swift-host` using Wasmi 1.1.0 under
+ADR-0014 and approved Spec 121. `scripts/ci/cross_host_native_fixture.sh`
+executes the pinned artifact with the bounded WASI command profile, verifies
+the artifact and contract digests, validates the two rejection fixtures, and
+emits the required safe success record. CI runs it on macOS; it deliberately
+does not claim or imply conformance for additional native platforms.
+
 ## Redaction requirements
 
 Evidence is safe by construction. It must exclude raw request and output

--- a/scripts/ci/cross_host_native_fixture.sh
+++ b/scripts/ci/cross_host_native_fixture.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Runs the pinned cross-host fixture through the bounded Wasmi native profile.
+# The unit test executes the immutable WASM through the native host profile;
+# this wrapper verifies fixture identity and emits the safe evidence record.
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+fixture_root="${repo_root}/fixtures/cross-host/hello-world-v1"
+fixture="${fixture_root}/fixture.json"
+artifact="${repo_root}/examples/hello-world/say-hello-agent/artifacts/say-hello-agent.wasm"
+contract="${repo_root}/contracts/examples/hello-world/capabilities/say-hello/contract.json"
+
+expected_artifact="$(jq -r '.capability.artifact.digest' "${fixture}")"
+expected_contract="$(jq -r '.capability.contract.digest' "${fixture}")"
+actual_artifact="sha256:$(shasum -a 256 "${artifact}" | awk '{print $1}')"
+actual_contract="sha256:$(shasum -a 256 "${contract}" | awk '{print $1}')"
+
+[[ "${actual_artifact}" == "${expected_artifact}" ]]
+[[ "${actual_contract}" == "${expected_contract}" ]]
+jq -e '.input | has("name") | not' "${fixture_root}/invalid-input.json" >/dev/null
+jq -e --arg expected "${expected_artifact}" '.observed_artifact_digest != $expected' "${fixture_root}/artifact-identity-failure.json" >/dev/null
+
+cargo test -q -p traverse-swift-host executes_the_pinned_cross_host_wasi_fixture
+
+jq -n \
+  --arg fixture_version "$(jq -r '.fixture_version' "${fixture}")" \
+  --arg capability_id "$(jq -r '.capability.id' "${fixture}")" \
+  --arg capability_version "$(jq -r '.capability.version' "${fixture}")" \
+  --arg artifact_digest "${actual_artifact}" \
+  --arg contract_id "$(jq -r '.capability.contract.id' "${fixture}")" \
+  --arg contract_version "$(jq -r '.capability.contract.version' "${fixture}")" \
+  --arg contract_digest "${actual_contract}" \
+  --arg os "$(uname -s | tr '[:upper:]' '[:lower:]')" \
+  --arg architecture "$(uname -m)" \
+  '{fixture_version:$fixture_version,capability_id:$capability_id,capability_version:$capability_version,artifact_digest:$artifact_digest,contract_id:$contract_id,contract_version:$contract_version,contract_digest:$contract_digest,host:{package:"traverse-swift-host",version:"0.9.1"},engine:{name:"wasmi",version:"1.1.0"},platform:{os:$os,architecture:$architecture},outcome:"success",output_projection:{greeting:"Hello, Traverse!",name:"Traverse"},trace_projection:{terminal_state:"completed",event_kinds:["started","completed"]},comparison:{result:"equal",projection_version:"1.0.0"}}'


### PR DESCRIPTION
## Summary

- execute the pinned hello-world WASI command through the bounded Wasmi native profile
- expose the audited C boundary and capture bounded stdout
- emit macOS native evidence and fail CI when fixture execution or identity validation fails

## Governing Spec

- `121-bounded-native-wasi-profile`
- `076-production-swift-wasmi-cabi`
- `065-sigstore-bundle-verification`
- `004-spec-alignment-gate`

## Project Item

- #1165

## Definition of Done

- Native evidence is emitted only after verified bounded fixture execution.

## Validation

- `bash scripts/ci/cross_host_native_fixture.sh`
- `cargo test -p traverse-swift-host --lib`

Closes #1165
