### PR TITLE
docs: approve authoring telemetry specification

### DIFF
--- a/docs/adr/0052-privacy-preserving-authoring-outcome-telemetry.md
+++ b/docs/adr/0052-privacy-preserving-authoring-outcome-telemetry.md
@@ -1,7 +1,7 @@
 # ADR-0052: Privacy-Preserving Authoring Outcome Telemetry
 
-- Status: Proposed — approval required
-- Governing spec: `1183-privacy-preserving-authoring-telemetry` (Draft)
+- Status: Accepted
+- Governing spec: `1183-privacy-preserving-authoring-telemetry`
 - Decision evidence: Traverse #1169
 
 ## Context
@@ -26,8 +26,7 @@ quarterly.
 ## Consequences
 
 This permits carefully bounded aggregate evidence while prohibiting content and
-identity collection. The collector retention period and access-control owner
-remain explicit approval prerequisites, not implementation assumptions.
+identity collection.
 
 ## Alternatives Considered
 

--- a/specs/1183-privacy-preserving-authoring-telemetry/spec.md
+++ b/specs/1183-privacy-preserving-authoring-telemetry/spec.md
@@ -1,6 +1,6 @@
 # Feature Specification: Privacy-Preserving Authoring Outcome Telemetry
 
-**Status**: Draft — approval required before implementation
+**Status**: Approved
 **Canonical governing ID**: `1183-privacy-preserving-authoring-telemetry`
 **Extends**: `088-runtime-usage-telemetry` only for its default-off,
 provider-neutral collection precedent; it does not extend runtime usage fields.

--- a/specs/governance/approved-specs.json
+++ b/specs/governance/approved-specs.json
@@ -1604,6 +1604,17 @@
         "scripts/ci/",
         "specs/121-bounded-native-wasi-profile/"
       ]
+    },
+    {
+      "id": "1183-privacy-preserving-authoring-telemetry",
+      "version": "1.0.0",
+      "status": "approved",
+      "immutable": true,
+      "path": "specs/1183-privacy-preserving-authoring-telemetry/spec.md",
+      "governs": [
+        "specs/1183-privacy-preserving-authoring-telemetry/",
+        "docs/adr/0052-privacy-preserving-authoring-outcome-telemetry.md"
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary

Records Enrico's formal approval of the privacy-preserving authoring outcome telemetry specification and ADR.

## Governing Spec

- `1183-privacy-preserving-authoring-telemetry`

## Project Item

Closes #1183.

## Definition of Done

- [x] Spec status is Approved.
- [x] ADR-0052 status is Accepted.
- [x] Immutable approved-spec registry entry is present.
- [x] Decision evidence is recorded on #1169.

## Validation

- `jq empty specs/governance/approved-specs.json`
- `git diff --check`
