### PR TITLE
docs: add manifest-governed telemetry successor

### DIFF
--- a/docs/adr/0053-manifest-governed-authoring-outcome-telemetry.md
+++ b/docs/adr/0053-manifest-governed-authoring-outcome-telemetry.md
@@ -1,0 +1,25 @@
+# ADR-0053: Manifest-Governed Authoring Outcome Telemetry
+
+- Status: Accepted
+- Governing spec: `122-manifest-governed-authoring-outcome-telemetry`
+- Supersedes: ADR-0052 for the manifest/host configuration boundary
+
+## Decision
+
+Manifests declare only an eligibility profile and a closed allowlist of
+non-identifying authoring-outcome categories. The host exclusively owns consent,
+collector endpoint and credentials, transport, aggregation, retention, and
+report access.
+
+## Rationale
+
+This follows the useful part of mobile privacy-manifest design: an app or SDK
+declares what data category and purpose it requires, while the platform enforces
+the permitted shape. It avoids allowing a content manifest to become an
+exfiltration mechanism by supplying a destination or privacy override.
+
+## Consequences
+
+Applications and capabilities can be measured consistently, but cannot broaden
+collection or choose where it is sent. Host configuration is the sole trusted
+boundary for remote publication.

--- a/specs/122-manifest-governed-authoring-outcome-telemetry/spec.md
+++ b/specs/122-manifest-governed-authoring-outcome-telemetry/spec.md
@@ -1,0 +1,52 @@
+# Feature Specification: Manifest-Governed Authoring Outcome Telemetry
+
+**Status**: Approved
+**Canonical governing ID**: `122-manifest-governed-authoring-outcome-telemetry`
+**Supersedes**: `1183-privacy-preserving-authoring-telemetry`
+**Decision evidence**: Traverse #1169 and #1186.
+
+## Purpose
+
+Allow an application or capability manifest to declare eligibility for
+privacy-preserving authoring outcome telemetry without granting that manifest
+control of consent, collection transport, or privacy limits.
+
+## Requirements
+
+- **FR-001**: A manifest MAY declare `authoring_outcome_telemetry` with only
+  `eligible`, `profile`, and the approved `allowed_fields` allowlist.
+- **FR-002**: The only supported profile is `aggregate-v1`; unknown profiles,
+  unrecognized fields, duplicate fields, and prohibited fields MUST be rejected
+  before collection.
+- **FR-003**: The `aggregate-v1` allowlist is limited to `authoring_route`,
+  `terminal_outcome`, `revision_count_bucket`, `elapsed_time_bucket`, and
+  `finding_category_counts`.
+- **FR-004**: Collector endpoint, credentials, consent state, transport,
+  aggregation threshold, retention, analytics-role authorization, and access
+  logging are host-owned configuration. A manifest MUST NOT set or override
+  any of them.
+- **FR-005**: Collection remains default-off and requires explicit host-owned
+  opt-in. Disabled, malformed, or unavailable configuration fails closed and
+  cannot affect authoring, review, build, or publication.
+- **FR-006**: Remote publication remains limited to aggregates of at least 20
+  distinct opted-in contributors, retained for no more than 90 days, and
+  accessible only by the named least-privilege analytics role with logged,
+  quarterly reviewed access.
+
+## Acceptance Scenarios
+
+1. A manifest declaring `aggregate-v1` and only allowed fields is eligible but
+   produces no collection without host-owned opt-in.
+2. A manifest declaring a collector URL, credentials, threshold, retention, or
+   an unknown field is rejected before collection.
+3. A host uses its configured collector only after validating the manifest;
+   the manifest cannot redirect the transport or expand the field set.
+4. An eligible manifest with 19 contributors produces no remote report; 20
+   contributors produce the bounded aggregate only.
+
+## Quality Gates
+
+- Contract tests cover allowed manifest declarations and every prohibited
+  host-owned override.
+- Evidence records contain only the approved aggregate fields.
+- Implementation preserves the default-off, fail-closed behavior in Spec 1183.

--- a/specs/governance/approved-specs.json
+++ b/specs/governance/approved-specs.json
@@ -1615,6 +1615,17 @@
         "specs/1183-privacy-preserving-authoring-telemetry/",
         "docs/adr/0052-privacy-preserving-authoring-outcome-telemetry.md"
       ]
+    },
+    {
+      "id": "122-manifest-governed-authoring-outcome-telemetry",
+      "version": "1.0.0",
+      "status": "approved",
+      "immutable": true,
+      "path": "specs/122-manifest-governed-authoring-outcome-telemetry/spec.md",
+      "governs": [
+        "specs/122-manifest-governed-authoring-outcome-telemetry/",
+        "docs/adr/0053-manifest-governed-authoring-outcome-telemetry.md"
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary

Adds approved Spec 122 and ADR-0053, superseding Spec 1183 for the manifest-versus-host telemetry configuration boundary.

## Governing Spec

- `122-manifest-governed-authoring-outcome-telemetry`

## Project Item

Closes #1186.

## Definition of Done

- [x] Manifests declare only an eligibility profile and closed field allowlist.
- [x] Consent, endpoint, credentials, transport, privacy limits, and access remain host-owned.
- [x] Unknown/prohibited declarations fail closed.
- [x] Immutable approved-spec registry entry and accepted ADR are present.

## Validation

- `jq empty specs/governance/approved-specs.json`
- `git diff --check`
