### PR TITLE
feat: validate authoring telemetry manifest policy

### DIFF
--- a/crates/traverse-cli/src/main.rs
+++ b/crates/traverse-cli/src/main.rs
@@ -5060,6 +5060,9 @@ fn validate_app_manifest_metadata_for_cli(
     if let Some(error) = find_private_manifest_field(&manifest, "$") {
         return Ok(Some(error));
     }
+    if let Some(error) = validate_authoring_outcome_telemetry_for_cli("$", &manifest) {
+        return Ok(Some(error));
+    }
 
     let manifest_dir = manifest_path.parent().unwrap_or_else(|| Path::new(""));
     let Some(components) = manifest.get("components").and_then(Value::as_array) else {
@@ -5089,6 +5092,11 @@ fn validate_app_manifest_metadata_for_cli(
         if let Some(error) = find_private_manifest_field(&component_manifest, "$.components[]") {
             return Ok(Some(error));
         }
+        if let Some(error) =
+            validate_authoring_outcome_telemetry_for_cli("$.components[]", &component_manifest)
+        {
+            return Ok(Some(error));
+        }
         if let Some(digest) = component_manifest
             .get("wasm_digest")
             .and_then(Value::as_str)
@@ -5109,6 +5117,71 @@ fn validate_app_manifest_metadata_for_cli(
     }
 
     Ok(None)
+}
+
+/// Spec 122: manifests may declare only a closed authoring-outcome telemetry
+/// policy. Collection transport, consent, and privacy controls are host-owned.
+fn validate_authoring_outcome_telemetry_for_cli(
+    path: &str,
+    manifest: &Value,
+) -> Option<AppValidationError> {
+    let policy = manifest.get("authoring_outcome_telemetry")?;
+    let Some(object) = policy.as_object() else {
+        return Some(AppValidationError {
+            code: "authoring_telemetry_invalid_profile".to_string(),
+            path: format!("{path}.authoring_outcome_telemetry"),
+            message: "authoring telemetry must be a policy object".to_string(),
+        });
+    };
+    const KEYS: &[&str] = &["eligible", "profile", "allowed_fields"];
+    const FIELDS: &[&str] = &[
+        "authoring_route",
+        "terminal_outcome",
+        "revision_count_bucket",
+        "elapsed_time_bucket",
+        "finding_category_counts",
+    ];
+    if object.keys().any(|key| !KEYS.contains(&key.as_str())) {
+        return Some(AppValidationError {
+            code: "authoring_telemetry_host_override".to_string(),
+            path: format!("{path}.authoring_outcome_telemetry"),
+            message: "authoring telemetry collector, consent, transport, and privacy controls are host-owned".to_string(),
+        });
+    }
+    if object.get("eligible").and_then(Value::as_bool) != Some(true)
+        || object.get("profile").and_then(Value::as_str) != Some("aggregate-v1")
+    {
+        return Some(AppValidationError {
+            code: "authoring_telemetry_invalid_profile".to_string(),
+            path: format!("{path}.authoring_outcome_telemetry"),
+            message: "authoring telemetry requires eligible: true and profile: aggregate-v1"
+                .to_string(),
+        });
+    }
+    let Some(fields) = object.get("allowed_fields").and_then(Value::as_array) else {
+        return Some(AppValidationError {
+            code: "authoring_telemetry_prohibited_field".to_string(),
+            path: format!("{path}.authoring_outcome_telemetry.allowed_fields"),
+            message: "authoring telemetry requires a non-empty aggregate-v1 field allowlist"
+                .to_string(),
+        });
+    };
+    let mut seen = std::collections::BTreeSet::new();
+    if fields.is_empty()
+        || fields.iter().any(|field| {
+            let Some(field) = field.as_str() else {
+                return true;
+            };
+            !FIELDS.contains(&field) || !seen.insert(field)
+        })
+    {
+        return Some(AppValidationError {
+            code: "authoring_telemetry_prohibited_field".to_string(),
+            path: format!("{path}.authoring_outcome_telemetry.allowed_fields"),
+            message: "authoring telemetry fields must be a non-empty unique subset of the aggregate-v1 allowlist".to_string(),
+        });
+    }
+    None
 }
 
 /// Spec 109 FR-005: a component manifest may declare `risk_policy` to narrow

--- a/crates/traverse-cli/src/main.rs
+++ b/crates/traverse-cli/src/main.rs
@@ -17,7 +17,7 @@ use semver::Version;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use sha2::{Digest, Sha256};
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::env;
 use std::fmt::Write as FmtWrite;
 use std::fs;
@@ -50,6 +50,15 @@ use traverse_runtime::{
     LocalExecutor, Runtime, RuntimeExecutionOutcome, RuntimeRequest, RuntimeResultStatus,
     RuntimeTrace, parse_runtime_request,
 };
+
+const AUTHORING_OUTCOME_TELEMETRY_POLICY_KEYS: &[&str] = &["eligible", "profile", "allowed_fields"];
+const AUTHORING_OUTCOME_TELEMETRY_AGGREGATE_V1_FIELDS: &[&str] = &[
+    "authoring_route",
+    "terminal_outcome",
+    "revision_count_bucket",
+    "elapsed_time_bucket",
+    "finding_category_counts",
+];
 
 #[derive(Debug)]
 enum Command {
@@ -5133,15 +5142,10 @@ fn validate_authoring_outcome_telemetry_for_cli(
             message: "authoring telemetry must be a policy object".to_string(),
         });
     };
-    const KEYS: &[&str] = &["eligible", "profile", "allowed_fields"];
-    const FIELDS: &[&str] = &[
-        "authoring_route",
-        "terminal_outcome",
-        "revision_count_bucket",
-        "elapsed_time_bucket",
-        "finding_category_counts",
-    ];
-    if object.keys().any(|key| !KEYS.contains(&key.as_str())) {
+    if object
+        .keys()
+        .any(|key| !AUTHORING_OUTCOME_TELEMETRY_POLICY_KEYS.contains(&key.as_str()))
+    {
         return Some(AppValidationError {
             code: "authoring_telemetry_host_override".to_string(),
             path: format!("{path}.authoring_outcome_telemetry"),
@@ -5166,13 +5170,13 @@ fn validate_authoring_outcome_telemetry_for_cli(
                 .to_string(),
         });
     };
-    let mut seen = std::collections::BTreeSet::new();
+    let mut seen = BTreeSet::new();
     if fields.is_empty()
         || fields.iter().any(|field| {
             let Some(field) = field.as_str() else {
                 return true;
             };
-            !FIELDS.contains(&field) || !seen.insert(field)
+            !AUTHORING_OUTCOME_TELEMETRY_AGGREGATE_V1_FIELDS.contains(&field) || !seen.insert(field)
         })
     {
         return Some(AppValidationError {
@@ -7324,8 +7328,8 @@ mod tests {
         reject_private_contract_scope, run_command, run_serve, safe_artifact_path_component,
         sha256_hex, surface_coverage_gap_messages, telemetry, uncovered_action_enum_values,
         unresolved_persona_refs, use_case_smoke_coverage_gaps,
-        use_case_smoke_coverage_gaps_for_package, validate_component_risk_policy_for_cli,
-        validate_registry_path_segment,
+        use_case_smoke_coverage_gaps_for_package, validate_authoring_outcome_telemetry_for_cli,
+        validate_component_risk_policy_for_cli, validate_registry_path_segment,
     };
     use crate::capability_packages::fnv1a64;
     use serde_json::Value;
@@ -11140,6 +11144,61 @@ mod tests {
         );
 
         let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn authoring_telemetry_accepts_the_closed_aggregate_v1_policy() {
+        let manifest = serde_json::json!({
+            "authoring_outcome_telemetry": {
+                "eligible": true,
+                "profile": "aggregate-v1",
+                "allowed_fields": ["authoring_route", "terminal_outcome"]
+            }
+        });
+
+        assert_eq!(
+            validate_authoring_outcome_telemetry_for_cli("$", &manifest),
+            None
+        );
+    }
+
+    #[test]
+    fn authoring_telemetry_rejects_host_owned_overrides() {
+        let manifest = serde_json::json!({
+            "authoring_outcome_telemetry": {
+                "eligible": true,
+                "profile": "aggregate-v1",
+                "allowed_fields": ["authoring_route"],
+                "endpoint": "https://metrics.example.test"
+            }
+        });
+
+        let result = validate_authoring_outcome_telemetry_for_cli("$", &manifest);
+        assert_eq!(
+            result.as_ref().map(|error| error.code.as_str()),
+            Some("authoring_telemetry_host_override")
+        );
+    }
+
+    #[test]
+    fn authoring_telemetry_rejects_prohibited_and_duplicate_fields() {
+        for allowed_fields in [
+            serde_json::json!(["authoring_route", "actor_id"]),
+            serde_json::json!(["authoring_route", "authoring_route"]),
+        ] {
+            let manifest = serde_json::json!({
+                "authoring_outcome_telemetry": {
+                    "eligible": true,
+                    "profile": "aggregate-v1",
+                    "allowed_fields": allowed_fields
+                }
+            });
+            let result = validate_authoring_outcome_telemetry_for_cli("$", &manifest);
+            assert_eq!(
+                result.as_ref().map(|error| error.code.as_str()),
+                Some("authoring_telemetry_prohibited_field")
+            );
+        }
     }
 
     fn unique_temp_dir() -> PathBuf {


### PR DESCRIPTION
## Summary

Enforces the approved manifest policy boundary for privacy-preserving authoring outcome telemetry.

## Governing Spec

- `122-manifest-governed-authoring-outcome-telemetry`
- `044-application-bundle-manifest`

## Project Item

Part of #1169.

## Definition of Done

- [x] App and component manifests accept only the closed `aggregate-v1` policy shape.
- [x] Host-owned collector, consent, transport, threshold, retention, and access controls cannot be overridden.
- [x] Invalid profiles and prohibited fields fail validation.

## Validation

- `cargo test -p traverse-cli-rs authoring_telemetry` (3 passing)
- `bash scripts/ci/rust_checks.sh` (411 CLI tests passing)
- `cargo fmt --all --check`
