### PR TITLE
feat: add default-off authoring telemetry host config

### DIFF
--- a/crates/traverse-cli/src/authoring_telemetry.rs
+++ b/crates/traverse-cli/src/authoring_telemetry.rs
@@ -112,11 +112,65 @@ pub struct AnalyticsAccessAuditRecord {
     pub allowed: bool,
 }
 
+/// Host-owned switch for authoring telemetry. It is independent of generic
+/// usage telemetry and defaults to disabled on every read failure.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AuthoringTelemetryHostConfig {
+    #[serde(default)]
+    pub enabled: bool,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum AuthoringTelemetryError {
     EmptyTicket,
     UnpublishedBucket,
     Io(String),
+}
+
+#[must_use]
+pub fn load_host_config(path: &Path) -> AuthoringTelemetryHostConfig {
+    std::fs::read_to_string(path)
+        .ok()
+        .and_then(|contents| serde_json::from_str(&contents).ok())
+        .unwrap_or_default()
+}
+
+/// # Errors
+///
+/// Returns [`AuthoringTelemetryError::Io`] when host configuration cannot be persisted.
+pub fn save_host_config(
+    path: &Path,
+    config: &AuthoringTelemetryHostConfig,
+) -> Result<(), AuthoringTelemetryError> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .map_err(|error| AuthoringTelemetryError::Io(error.to_string()))?;
+    }
+    let value = serde_json::to_string_pretty(config)
+        .map_err(|error| AuthoringTelemetryError::Io(error.to_string()))?;
+    std::fs::write(path, format!("{value}\n"))
+        .map_err(|error| AuthoringTelemetryError::Io(error.to_string()))
+}
+
+/// Stable host entry point: disabled or unreadable configuration performs no
+/// collection and leaves the supplied aggregate bucket unchanged.
+///
+/// # Errors
+///
+/// Returns [`AuthoringTelemetryError::EmptyTicket`] only when explicit host
+/// opt-in is enabled but the trusted host supplies no opaque ticket.
+pub fn record_from_host_config(
+    config: &AuthoringTelemetryHostConfig,
+    bucket: &mut Option<AuthoringAggregateBucket>,
+    opaque_ticket: &str,
+    event: &AuthoringOutcomeEvent,
+    now: DateTime<Utc>,
+) -> Result<(), AuthoringTelemetryError> {
+    if !config.enabled {
+        return Ok(());
+    }
+    let active = bucket.get_or_insert_with(|| AuthoringAggregateBucket::new(now));
+    active.record(opaque_ticket, event)
 }
 
 impl AuthoringAggregateBucket {
@@ -341,6 +395,39 @@ mod tests {
         append_analytics_access_audit(&path, &record).expect("audit append");
         let line = fs::read_to_string(&path).expect("audit read");
         assert!(line.contains("traverse-analytics"));
+        let _ = fs::remove_file(path);
+    }
+
+    #[test]
+    fn host_config_defaults_off_and_records_only_after_explicit_opt_in() {
+        let path = std::env::temp_dir().join("traverse-authoring-telemetry-config-test.json");
+        let _ = fs::remove_file(&path);
+        assert_eq!(
+            load_host_config(&path),
+            AuthoringTelemetryHostConfig::default()
+        );
+        let now = Utc::now();
+        let mut bucket = None;
+        record_from_host_config(
+            &AuthoringTelemetryHostConfig::default(),
+            &mut bucket,
+            "ticket",
+            &event(),
+            now,
+        )
+        .expect("disabled record");
+        assert_eq!(bucket, None);
+        let enabled = AuthoringTelemetryHostConfig { enabled: true };
+        save_host_config(&path, &enabled).expect("save config");
+        record_from_host_config(
+            &load_host_config(&path),
+            &mut bucket,
+            "ticket",
+            &event(),
+            now,
+        )
+        .expect("enabled record");
+        assert!(bucket.is_some());
         let _ = fs::remove_file(path);
     }
 }

--- a/docs/pilots/authoring-telemetry-local-pilot.md
+++ b/docs/pilots/authoring-telemetry-local-pilot.md
@@ -1,0 +1,23 @@
+# Local Authoring Telemetry Pilot
+
+Date: 2026-08-28
+
+This bounded, non-exporting pilot exercises Spec 123’s aggregate-only threshold
+path with 20 synthetic opaque contributor tickets. It uses no network
+destination, real contributor, source, prompt, repository path, review text,
+or personal identifier.
+
+## Evidence
+
+- Nineteen distinct ticket hashes are rejected for export.
+- Twenty distinct ticket hashes produce only the bounded aggregate payload.
+- Ticket hashes and raw events are absent from that payload.
+- An unpublished bucket is removed on opt-out and expires at 90 days.
+
+## Limits
+
+This is a deterministic local integration pilot, not a production deployment.
+It has complete selection bias because tickets are synthetic; it provides no
+claim about authoring success rates, contributor behavior, or external
+collector reliability. A later opt-in production pilot requires a named host,
+explicit participant consent, and the analytics-role access configuration.


### PR DESCRIPTION
## Summary

Adds default-off host configuration and local pilot evidence for authoring telemetry.

## Governing Spec

- `123-host-owned-authoring-telemetry-aggregation`
- `122-manifest-governed-authoring-outcome-telemetry`

## Project Item

Closes #1192.

## Definition of Done

- [x] Host configuration defaults off and fails closed.
- [x] Explicit opt-in records only aggregate bucket state through the host entry point.
- [x] Local pilot documents threshold, retention, opt-out, and disclosure limits.

## Validation

- `cargo test -p traverse-cli-rs authoring_telemetry` (8 passing)
- `cargo clippy -p traverse-cli-rs -- -D warnings`
