### PR TITLE
feat: add governed browser proposal journey

### DIFF
--- a/packages/web/TraverseEmbedder/examples/react-integration/README.md
+++ b/packages/web/TraverseEmbedder/examples/react-integration/README.md
@@ -50,3 +50,14 @@ here with zero code changes to this example.
 A doc-approval integration will be added once the `doc-approval.pipeline`
 workflow (traverse-framework/Traverse#555) lands on `main`, to demonstrate
 the multi-node case end to end as well.
+
+## Governed proposal review
+
+The page also includes a deliberately planner-free review panel for the
+browser-reachable host endpoint at `http://127.0.0.1:8787`. Start a registered
+`traverse-cli serve` host for `local-default` before using it. The browser only
+submits immutable proposal JSON for validation, authorization review, or a
+separately requested execution. It never sends prompts, credentials, catalog
+mutations, or a runtime mutation request. Validation feedback makes rejected
+or ambiguous candidates visible; mappings are not treated as confirmed until
+the runtime accepts them. Execution output is the host's redacted evidence.

--- a/packages/web/TraverseEmbedder/examples/react-integration/src/main.js
+++ b/packages/web/TraverseEmbedder/examples/react-integration/src/main.js
@@ -4,6 +4,7 @@ const { createElement: h, useEffect, useState } = React;
 
 const MANIFEST_PATH = "/repo/examples/applications/traverse-starter/app.manifest.json";
 const CAPABILITY_ID = "traverse-starter.process";
+const PROPOSAL_ENDPOINT = "http://127.0.0.1:8787/v1/workspaces/local-default/apps/traverse-starter/proposals";
 
 function eventList(events) {
   if (events.length === 0) {
@@ -30,6 +31,19 @@ function App() {
   const [events, setEvents] = useState([]);
   const [note, setNote] = useState("hello from React, no sidecar");
   const [evidence, setEvidence] = useState(null);
+  const [proposalText, setProposalText] = useState(JSON.stringify({
+    kind: "workflow_proposal", schema_version: "1.0.0", proposal_id: "review-me",
+    workspace_id: "local-default", app_manifest: { app_id: "traverse-starter", app_version: "1.0.0", manifest_digest: "host-pinned" },
+    nodes: [], edges: [], mappings: [], initial_input: {},
+  }, null, 2));
+  const [proposalResult, setProposalResult] = useState(null);
+
+  const reviewProposal = async (action) => {
+    let proposal;
+    try { proposal = JSON.parse(proposalText); } catch (_) { setProposalResult({ status: "invalid JSON — nothing submitted" }); return; }
+    const response = await fetch(PROPOSAL_ENDPOINT, { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ action, proposal }) });
+    setProposalResult(await response.json());
+  };
 
   useEffect(() => {
     let cancelled = false;
@@ -76,6 +90,16 @@ function App() {
         "from the repository over static HTTP and executes its bundled WASM capability " +
         "in this browser tab via BundleEmbedder — there is no traverse-cli serve process " +
         "involved.",
+    ),
+    h("div", { className: "card" },
+      h("h2", null, "Governed multi-capability proposal"),
+      h("p", null, "This page does not host a planner. Review every node, edge, and mapping below; mappings remain unconfirmed until the runtime validates them. Submission never executes automatically."),
+      h("textarea", { value: proposalText, onChange: (event) => setProposalText(event.target.value), rows: 14 }),
+      h("p", null, "Candidate ambiguity is a validation outcome: choose or correct a proposal explicitly; this UI never auto-selects a catalog candidate."),
+      h("button", { onClick: () => reviewProposal("validate") }, "Validate and review"), " ",
+      h("button", { onClick: () => reviewProposal("submit") }, "Submit for authorization"), " ",
+      h("button", { onClick: () => reviewProposal("execute") }, "Execute only if authorized"),
+      proposalResult !== null && h("pre", null, JSON.stringify(proposalResult, null, 2)),
     ),
     initError !== null &&
       h("div", { className: "card status-error" }, h("strong", null, "init failed: "), initError),

--- a/packages/web/TraverseEmbedder/examples/react-integration/src/styles.css
+++ b/packages/web/TraverseEmbedder/examples/react-integration/src/styles.css
@@ -43,3 +43,5 @@ input {
   padding: 0.4rem;
   width: 60%;
 }
+
+textarea { width: 100%; font-family: ui-monospace, monospace; margin-bottom: 0.75rem; }


### PR DESCRIPTION
## Summary

- add a planner-free browser review panel for immutable workflow proposals
- make validation, authorization submission, and execution explicit separate actions
- render only host-provided, redacted proposal evidence

## Governing Spec

- `109-runtime-workflow-proposals`
- `115-browser-verified-entrypoint-execution`

## Project Item

- Closes #1159

## Definition of Done

- [x] Browser UI submits immutable proposals through the governed host boundary.
- [x] Mappings and ambiguity are explicit; no candidate is silently selected.
- [x] Execution remains a separate authorized action and displays redacted evidence.
- [x] No hosted planner, prompts, credentials, catalog mutation, or runtime mutation is added.

## Validation

- `node --check packages/web/TraverseEmbedder/examples/react-integration/src/main.js`
- `git diff --check`