### PR TITLE
chore: release v0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 ## Unreleased
 
+## v0.10.0 — 2026-08-28
+
+- Added governed runtime workflow proposals: lifecycle operations, bounded
+  deterministic parallel scheduling, declarative planning, and promotion
+  through the MCP host.
+- Added a governed browser proposal journey, verified browser capability
+  execution with receipts, and the server-side verified entrypoint endpoint.
+- Added standalone capability-package discovery and activation-time executable
+  artifact resolution, with stricter artifact-metadata validation.
+- Added universal local connector contracts, mediated connector invocation,
+  application connector bindings, and native verified-registry metadata caches.
+- Added durable orchestration controls and a durable trace journal, alongside
+  cross-host fixture evidence and browser/CLI comparison coverage.
+- Added host-owned, privacy-preserving authoring telemetry configuration and
+  aggregation, disabled by default.
+- Updated the registry dependency to 0.15.2 and refreshed selected Rust
+  dependencies.
+
 ## v0.9.1 — 2026-08-09
 
 - Capability packages can be scaffolded, inspected, validated, and published through

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,14 +16,14 @@ edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/traverse-framework/traverse"
 rust-version = "1.94"
-version = "0.9.1"
+version = "0.10.0"
 
 [workspace.dependencies]
-traverse-contracts = { path = "crates/traverse-contracts", version = "0.9.1" }
+traverse-contracts = { path = "crates/traverse-contracts", version = "0.10.0" }
 traverse-registry = { version = "=0.15.2" }
-traverse-runtime = { path = "crates/traverse-runtime", version = "0.9.1" }
-traverse-embedder = { path = "crates/traverse-embedder", version = "0.9.1" }
-traverse-mcp = { path = "crates/traverse-mcp", version = "0.9.1" }
+traverse-runtime = { path = "crates/traverse-runtime", version = "0.10.0" }
+traverse-embedder = { path = "crates/traverse-embedder", version = "0.10.0" }
+traverse-mcp = { path = "crates/traverse-mcp", version = "0.10.0" }
 
 # The published registry crate pins the current contracts release.  During
 # Traverse development, resolve that transitive dependency to this workspace's

--- a/docs/releases/v0.10.0.md
+++ b/docs/releases/v0.10.0.md
@@ -1,0 +1,43 @@
+# Traverse v0.10.0
+
+Released 2026-08-28.
+
+Traverse v0.10.0 expands the governed execution surface from individual
+capabilities into reviewable workflow proposals that can be planned, executed,
+and promoted through the runtime and MCP host. It also advances the browser
+host, application connector, registry-cache, and operational-observability
+paths.
+
+## Highlights
+
+- Runtime workflow proposals now have a governed lifecycle, bounded
+  deterministic parallel scheduling, declarative planning, and controlled
+  promotion through MCP.
+- The browser host supports the governed proposal journey and verified
+  capability execution with a receipt. `traverse-cli serve` now exposes a
+  verified entrypoint endpoint backed by required host registry state.
+- Capability activation resolves executable artifacts, standalone capability
+  packages are discoverable, and CLI metadata validation is stricter.
+- Universal local connector contracts and mediated invocation are available,
+  including application connector bindings and native verified-registry
+  metadata caches.
+- The runtime adds durable orchestration controls and durable trace-journal
+  support, with cross-host browser and native fixture evidence.
+- Authoring outcome telemetry is host-owned, privacy-preserving, and disabled
+  by default until a host explicitly configures it.
+
+## Upgrade notes
+
+This is a minor release in the pre-1.0 series. Consumers should refresh all
+Traverse Rust crates together at `0.10.0`, and use the documented browser,
+MCP, and connector entrypoints rather than depending on internal runtime
+modules. The web embedder's npm distribution follows its separate publication
+runbook and is not published by the Rust release workflow.
+
+## Further reading
+
+- [Workflow proposal lifecycle](../workflow-proposal-lifecycle.md)
+- [Governed workflow promotion](../governed-workflow-promotion.md)
+- [Browser demo governance boundary](../browser-demo-governance-boundary.md)
+- [Cross-host fixture comparison contract](../cross-host-fixture-comparison-contract.md)
+- [Capability contract authoring](../capability-contract-authoring-guide.md)


### PR DESCRIPTION
## Summary

Prepare Traverse v0.10.0 for release: publish release notes and changelog entries, then align all workspace packages to the v0.10.0 tag.

## Governing Spec

- `048-semver-publishing-pipeline`
- `060-wasm-resource-limits`
- `065-sigstore-bundle-verification`

## Project Item

Release follow-up for the accepted semver publishing pipeline.

## What Changed

- Contracts changed: none.
- Runtime behavior changed: none; this is a version/documentation release preparation.
- Compatibility impact: all published Rust workspace crates move together from 0.9.1 to 0.10.0.
- ADR needed or linked: none.

## Validation

- [x] Spec alignment checked
- [x] Contract alignment checked
- [x] Tests updated and passing
- [x] Core coverage preserved
- [x] Required validation gates passing

## Notes

The v0.10.0 git tag will be pushed only after this PR is merged and its required checks pass; that tag starts the crates.io publish workflow.