### PR TITLE
docs: specify artifact signature materialization

### DIFF
--- a/docs/adr/0055-materialized-artifact-signatures.md
+++ b/docs/adr/0055-materialized-artifact-signatures.md
@@ -1,0 +1,53 @@
+# ADR-0055: Signature Evidence Travels Through Host-Owned Artifact State
+
+- Status: Proposed
+- Governing spec: `124-materialized-artifact-signatures` (Draft)
+- Extends: ADR-0051 and Spec 030
+- Related issues: #1203; `traverse-framework/registry` #331, #333, #334, #335
+
+## Context
+
+Spec 030 correctly requires signatures for governed artifacts, but the
+host-owned artifact-state pipeline introduced by Spec 120 only carries the
+artifact location and digest. As a result, the runtime receives no real
+signature for a published, governed capability even when the publisher has
+produced one. Registry publishing cannot mutate immutable `contract.json`
+after publication, so it publishes additive sibling signature files instead.
+
+## Decision
+
+Define a successor artifact-state schema (`1.1.0`) that carries the Ed25519
+scheme, public-key hex, and signature hex for each executable artifact. The
+existing host-run `registry materialize` command fetches, validates, and
+verifies this evidence before writing state. `serve` remains offline: it
+re-verifies the local binary digest and maps the already-validated metadata
+into `BinaryReference.signature`, leaving final execution-time verification to
+the existing Spec 030 runtime boundary.
+
+The registry contract gains only an additive signature-reference object. The
+host does not infer sibling URLs, discover keys, or accept a signature merely
+because it was downloaded; each reference must be explicit and validation must
+fail closed.
+
+## Consequences
+
+Published governed artifacts can satisfy the existing runtime trust boundary
+through the documented materialize-and-serve pipeline. Artifact-state `1.0.0`
+remains supported for its established behavior; `1.1.0` requires complete
+signature metadata. Materialization becomes responsible for network retrieval
+and cryptographic validation, while serving and runtime execution remain free
+of network side effects.
+
+## Alternatives considered
+
+- Put the signature directly in `contract.json`: rejected because published
+  registry contracts are immutable and the signature is produced after merge.
+- Fetch signature evidence in `serve` or at execution: rejected because Specs
+  115, 118, and 120 require host-prepared state and prohibit serve-owned fetch
+  or mutation.
+- Let `serve` trust state metadata without materialization-time verification:
+  rejected because unverified evidence would move the security boundary without
+  reliable failure evidence.
+- Add Sigstore in this slice: rejected as scope expansion; the registry's
+  current publishing decision is Ed25519 and the runtime already owns future
+  scheme dispatch.

--- a/specs/124-materialized-artifact-signatures/spec.md
+++ b/specs/124-materialized-artifact-signatures/spec.md
@@ -1,0 +1,87 @@
+# Feature Specification: Materialized Artifact Signatures
+
+**Status**: Draft
+**Canonical governing ID**: `124-materialized-artifact-signatures`
+**Extends**: `030-security-identity-model`, `120-host-owned-artifact-preparation`, and ADR-0051
+**Tracks**: #1203; depends on `traverse-framework/registry` #333, #334, and #335.
+
+## Purpose
+
+Carry publisher-supplied Ed25519 verification metadata from the registry's
+additive signature sibling files through the host-owned artifact preparation
+manifest into the existing runtime artifact verifier. This makes the governed
+signature requirement in Spec 030 reachable through `registry materialize`
+and `serve --registry-state --artifact-state`, without granting `serve` any
+network, key-discovery, or state-mutation responsibility.
+
+## Ownership and boundary
+
+The registry owns publishing immutable artifact bytes, a public verification
+key, and an additive signature sibling file. The host-owned `materialize`
+step fetches and validates those inputs before writing local state. The
+artifact-state manifest is the only persisted handoff to `serve`; it remains
+separate from Spec 118's registry-bundle manifest. `serve` only reads local
+state, re-verifies the binary digest, and passes validated signature metadata
+to the runtime's existing verification boundary.
+
+## Requirements
+
+- **FR-001**: For every executable capability, `registry materialize` MUST
+  require an `artifact.signature` object in the capability contract with
+  `scheme`, `public_key_url`, and `signature_url`. Only `ed25519` is supported
+  by this slice; unknown schemes or missing/empty fields MUST fail with a
+  stable, capability-qualified error.
+- **FR-002**: `materialize` MUST fetch the public key and signature from the
+  declared URLs after digest-verifying the artifact bytes. It MUST validate
+  Ed25519 encodings and verify the signature over the exact downloaded artifact
+  bytes before writing either artifact-state entry. Invalid, unavailable, or
+  mismatched signature evidence MUST fail closed and MUST NOT create a state
+  entry for that capability.
+- **FR-003**: Each executable artifact-state entry MUST persist the additive
+  signature evidence needed by `ArtifactSignature`: `scheme`,
+  `public_key_hex`, and `signature_hex`. This spec defines artifact-state
+  schema version `1.1.0`; loaders supporting `1.0.0` MUST preserve existing
+  unsigned manifest behavior, while `1.1.0` requires complete signature
+  evidence for every executable entry.
+- **FR-004**: Before `serve` registers a capability from a `1.1.0`
+  artifact-state manifest, it MUST reject malformed or incomplete signature
+  evidence and must retain existing whole-manifest digest verification.
+- **FR-005**: On successful validation, `serve` MUST construct the resolved
+  executable binary with the artifact-state entry's `ArtifactSignature` so
+  Spec 030 governs verification at execution. It MUST NOT bypass, duplicate,
+  or weaken the runtime verifier.
+- **FR-006**: `serve` and runtime execution MUST perform no network fetch for
+  artifact signature evidence. Key rotation, Sigstore, detached provenance,
+  and workflow-level artifacts are out of scope.
+
+## Compatibility
+
+This is an additive artifact-state schema successor. Existing `1.0.0`
+manifests remain loadable with their established behavior. A `1.1.0` manifest
+is rejected by an older loader rather than silently dropping required security
+metadata. Registry-bundle contracts remain unchanged except for an additive
+`artifact.signature` object interpreted only by materialization.
+
+## Acceptance scenarios
+
+1. A registry capability with a valid Ed25519 artifact signature materializes
+   into `1.1.0` state, starts under `serve`, and executes through the verified
+   endpoint with `signature_verified` runtime evidence.
+2. A missing, malformed, unavailable, or byte-mismatched signature fails
+   materialization with a stable capability-qualified error and creates no
+   artifact-state entry for that capability.
+3. An artifact-state entry with malformed or incomplete signature metadata
+   causes `serve` startup to fail closed before listening.
+4. An existing `1.0.0` artifact-state fixture continues to load under its
+   documented behavior, and an unsupported schema version remains rejected.
+5. Altering a materialized binary after preparation causes the existing
+   startup digest check to fail before runtime signature verification.
+
+## Quality gates
+
+- Unit tests cover every accepted and rejected signature field combination,
+  encoding failure, and signature mismatch.
+- Integration tests cover materialize-to-serve-to-verified-execution with a
+  real Ed25519 test key and no runtime network access.
+- Tests preserve the `1.0.0` manifest compatibility path and fail closed for
+  invalid `1.1.0` manifests.

--- a/specs/README.md
+++ b/specs/README.md
@@ -26,6 +26,7 @@ Traverse uses split, focused governing specs instead of one giant spec file. Thi
 | Security model, trust boundaries, identity direction | `030-security-identity-model` |
 | Supply chain hardening, provenance, artifact trust | `031-supply-chain-hardening` |
 | Portable state and data access constraints | `032-universal-data-access` |
+| Materialized governed-artifact signature handoff | `124-materialized-artifact-signatures` |
 | Event delivery, replay, and missed-event recovery | `036-event-subscription-replay` |
 | Semver range matching and compatible version selection | `037-semver-range-resolution` |
 | WASI and host ABI insulation from standards churn | `038-wasi-host-insulation` |


### PR DESCRIPTION
## Summary

Define the successor artifact-state signature handoff required to make governed
Ed25519 verification reachable through the existing host-owned materialization
and serve pipeline.

## Governing Spec

Draft `124-materialized-artifact-signatures` extends approved Specs 030 and
120 without modifying their immutable records.

- `065-sigstore-bundle-verification`

## Project Item

Traverse #1203 is claimed by `agent:codex` and In Progress.

## Definition of Done

- Draft successor spec defines the schema, compatibility, ownership, and
  acceptance criteria.
- ADR records the offline host-owned signature evidence boundary.
- Spec routing identifies the owning successor.

## Validation

- `git diff --check`
- `bash scripts/ci/spec_alignment_check.sh /private/tmp/issue-1203-pr-body.md`
