### PR TITLE
test: restore CLI coverage baseline

### DIFF
--- a/crates/traverse-cli/src/main.rs
+++ b/crates/traverse-cli/src/main.rs
@@ -7349,6 +7349,31 @@ mod tests {
     };
 
     #[test]
+    fn cli_error_messages_and_display_cover_every_exit_class() {
+        let cases = [
+            (
+                CliError::ExecutionFailed("execution".to_string()),
+                "execution",
+            ),
+            (
+                CliError::ValidationFailed("validation".to_string()),
+                "validation",
+            ),
+            (
+                CliError::RegistrationConflict("registration".to_string()),
+                "registration",
+            ),
+            (CliError::IoError("io".to_string()), "io"),
+            (CliError::UsageError("usage".to_string()), "usage"),
+        ];
+
+        for (error, expected) in cases {
+            assert_eq!(error.message(), expected);
+            assert_eq!(error.to_string(), expected);
+        }
+    }
+
+    #[test]
     fn parse_command_accepts_supported_inspect_commands() {
         let bundle = vec![
             "traverse-cli".to_string(),


### PR DESCRIPTION
## Summary

Restore the CLI coverage baseline by testing every `CliError` message and
display variant.

## Governing Spec

- `030-security-identity-model`

## Project Item

Traverse #1205.

## Definition of Done

- Preserve the 87% `traverse-cli-rs` threshold.
- Cover every stable CLI error exit class.

## Validation

- `cargo fmt --all --check`
- `cargo test -p traverse-cli-rs tests::cli_error_messages_and_display_cover_every_exit_class -- --exact`
- Rust 1.94 `cargo llvm-cov --package traverse-cli-rs`: 87.05% (20,451/23,493)
