### PR TITLE
spec(124): FR-001/FR-002 read the registry signature.json sibling, not contract URLs

### DIFF
--- a/specs/124-materialized-artifact-signatures/spec.md
+++ b/specs/124-materialized-artifact-signatures/spec.md
@@ -27,16 +27,25 @@ to the runtime's existing verification boundary.
 ## Requirements
 
 - **FR-001**: For every executable capability, `registry materialize` MUST
-  require an `artifact.signature` object in the capability contract with
-  `scheme`, `public_key_url`, and `signature_url`. Only `ed25519` is supported
-  by this slice; unknown schemes or missing/empty fields MUST fail with a
-  stable, capability-qualified error.
-- **FR-002**: `materialize` MUST fetch the public key and signature from the
-  declared URLs after digest-verifying the artifact bytes. It MUST validate
-  Ed25519 encodings and verify the signature over the exact downloaded artifact
-  bytes before writing either artifact-state entry. Invalid, unavailable, or
-  mismatched signature evidence MUST fail closed and MUST NOT create a state
-  entry for that capability.
+  locate the registry's additive signature sibling file, `signature.json`, in
+  the same directory as the capability's `contract.json`, and require a
+  `scheme` of `ed25519`, a 64-hex-character `public_key_hex`, and a
+  128-hex-character `signature_hex`. Only `ed25519` is supported by this
+  slice; a missing sibling file, an unknown scheme, or any missing, empty, or
+  malformed field MUST fail with a stable, capability-qualified error. The
+  signature values are inline hex, not URLs -- this matches
+  `traverse-framework/registry` Spec 007 v1.1.0, which publishes
+  `signature.json` (fields `scheme`, `public_key_hex`, `signature_hex`,
+  `sigstore_bundle_ref`, `signed_at`) as an immutable additive sibling because
+  `contract.json` is frozen at merge time, before signing occurs.
+- **FR-002**: After digest-verifying the artifact bytes, `materialize` MUST
+  verify the Ed25519 `signature_hex` over those exact bytes using
+  `public_key_hex`. The signature material is read inline from `signature.json`
+  -- no network fetch for signature evidence. `materialize` MAY additionally
+  pin `public_key_hex` against the registry's published well-known key
+  (`signing-key.pub` on the catalog site) on first use. Invalid encodings, a
+  byte-mismatched signature, or a public key that fails an enabled pin check
+  MUST fail closed and MUST NOT create a state entry for that capability.
 - **FR-003**: Each executable artifact-state entry MUST persist the additive
   signature evidence needed by `ArtifactSignature`: `scheme`,
   `public_key_hex`, and `signature_hex`. This spec defines artifact-state
@@ -59,15 +68,16 @@ to the runtime's existing verification boundary.
 This is an additive artifact-state schema successor. Existing `1.0.0`
 manifests remain loadable with their established behavior. A `1.1.0` manifest
 is rejected by an older loader rather than silently dropping required security
-metadata. Registry-bundle contracts remain unchanged except for an additive
-`artifact.signature` object interpreted only by materialization.
+metadata. Registry `contract.json` files remain byte-for-byte unchanged: the
+signature travels in the sibling `signature.json`, read only by
+materialization.
 
 ## Acceptance scenarios
 
 1. A registry capability with a valid Ed25519 artifact signature materializes
    into `1.1.0` state, starts under `serve`, and executes through the verified
    endpoint with `signature_verified` runtime evidence.
-2. A missing, malformed, unavailable, or byte-mismatched signature fails
+2. A missing sibling file, or a malformed or byte-mismatched signature, fails
    materialization with a stable capability-qualified error and creates no
    artifact-state entry for that capability.
 3. An artifact-state entry with malformed or incomplete signature metadata


### PR DESCRIPTION
## Summary

`traverse#1203` is Blocked on Spec 124 approval, but **FR-001/FR-002 as drafted cannot be satisfied by what `traverse-framework/registry` actually publishes** — approving them as-is breaks interop the moment `#1203` is implemented.

- **FR-001 (draft):** `artifact.signature` object *in the capability contract* with `public_key_url` / `signature_url`.
- **What registry publishes** (its Spec 007 v1.1.0, approved + shipped across all 83 capabilities, CI-enforced): an additive sibling `signature.json` next to `contract.json`:
  ```json
  { "scheme": "ed25519", "public_key_hex": "…", "signature_hex": "…", "sigstore_bundle_ref": null, "signed_at": "…" }
  ```
  `contract.json` is immutable at merge and signing is post-merge, so the signature is **never** in the contract, and the values are **inline hex, not URLs**.

### What changed

- **FR-001** → locate the `signature.json` sibling of `contract.json`; require `scheme: ed25519`, 64-hex `public_key_hex`, 128-hex `signature_hex`; missing sibling / unknown scheme / malformed field → stable capability-qualified error.
- **FR-002** → verify the inline Ed25519 `signature_hex` over the digest-verified bytes with `public_key_hex`; no network fetch for signature material; optional trust-on-first-use pin against the published `signing-key.pub`; fail closed with no state entry on any failure.
- **Compatibility** paragraph + **acceptance scenario 2** reworded for the sibling-file shape.
- **FR-003 unchanged** — already persists `public_key_hex` / `signature_hex`.

`Status` stays **Draft** — approval is the owner's call; this only makes the text approvable.

## Governing Spec

Spec `124-materialized-artifact-signatures` is `Draft` and not yet listed in `specs/governance/approved-specs.json`, so no approved spec governs `specs/124-materialized-artifact-signatures/spec.md`. This PR edits only that draft's own text; it changes no approved spec and no governed code.

## Project Item

`traverse#1203` — this PR removes the reason that issue's implementation is blocked (FR-001/FR-002 unsatisfiable by the registry's real output). Also refs `traverse-framework/registry#333` (Spec 007 v1.1.0), registry decision-log entries 75 / 77 / 78.

## Validation

- `bash scripts/ci/pr_body_check.sh` — required sections present.
- `bash scripts/ci/spec_alignment_check.sh` — the one changed file (`specs/124-…/spec.md`) is governed by no approved spec; `## Governing Spec` section present.
- Cross-checked against live registry output: `capabilities/validation/validation.validate-email/1.2.2/signature.json` carries `scheme` / `public_key_hex` / `signature_hex` inline; `https://registry.traverse-framework.com/signing-key.pub` → HTTP 200. No traverse code changed by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
