### PR TITLE
governance: approve Spec 124 (materialized artifact signatures)

### DIFF
--- a/specs/124-materialized-artifact-signatures/spec.md
+++ b/specs/124-materialized-artifact-signatures/spec.md
@@ -1,6 +1,6 @@
 # Feature Specification: Materialized Artifact Signatures
 
-**Status**: Draft
+**Status**: Approved
 **Canonical governing ID**: `124-materialized-artifact-signatures`
 **Extends**: `030-security-identity-model`, `120-host-owned-artifact-preparation`, and ADR-0051
 **Tracks**: #1203; depends on `traverse-framework/registry` #333, #334, and #335.

--- a/specs/governance/approved-specs.json
+++ b/specs/governance/approved-specs.json
@@ -1638,6 +1638,19 @@
         "specs/123-host-owned-authoring-telemetry-aggregation/",
         "docs/adr/0054-host-owned-authoring-telemetry-aggregation.md"
       ]
+    },
+    {
+      "id": "124-materialized-artifact-signatures",
+      "version": "0.1.0",
+      "status": "approved",
+      "immutable": true,
+      "path": "specs/124-materialized-artifact-signatures/spec.md",
+      "governs": [
+        "crates/traverse-cli/",
+        "crates/traverse-runtime/",
+        "specs/124-materialized-artifact-signatures/",
+        "docs/adr/0055-materialized-artifact-signatures.md"
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary

Records the owner's approval of **Spec 124 — Materialized Artifact Signatures**, given on 2026-08-29 as a standalone instruction in the `#1203` discussion after [#1207](https://github.com/traverse-framework/traverse/pull/1207) reconciled FR-001/FR-002 with what `traverse-framework/registry` actually publishes (sibling `signature.json`, inline hex).

- `specs/124-materialized-artifact-signatures/spec.md`: `Status` Draft → Approved.
- `specs/governance/approved-specs.json`: new record, `version 0.1.0`, `immutable: true`, modelled on the parent Spec 120's entry.
  - `governs`: `crates/traverse-cli/` (`registry materialize` + `serve`), `crates/traverse-runtime/` (FR-005 resolved-binary construction and the `#1203` signature-loader wiring), `specs/124-materialized-artifact-signatures/`, `docs/adr/0055-materialized-artifact-signatures.md`.

No code changes. Unblocks `#1203`.

## Governing Spec

- `004-spec-alignment-gate`
- `124-materialized-artifact-signatures`

## Project Item

`#1203` — approval was its stated blocker. Also refs `#1207`, `traverse-framework/registry#333`.

## Validation

- `bash scripts/ci/pr_body_check.sh` — required sections present.
- `bash scripts/ci/spec_alignment_check.sh` — `specs/governance/approved-specs.json` covered by `004-spec-alignment-gate`; `specs/124-…/spec.md` covered by the now-approved `124-materialized-artifact-signatures`.
- `approved-specs.json` entry carries `id` / `version` / `status: approved` / `immutable: true` / `path` / `governs`, matching sibling entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
