### PR TITLE
governance: approve Spec 125 (synced public registry bundle preparation)

### DIFF
--- a/specs/125-synced-public-registry-preparation/spec.md
+++ b/specs/125-synced-public-registry-preparation/spec.md
@@ -2,7 +2,7 @@
 
 **Feature Branch**: `codex/issue-1211-synced-registry-bridge`
 **Created**: 2026-08-29
-**Status**: Draft — successor specification requiring maintainer approval before implementation.
+**Status**: Approved
 **Input**: Traverse #1211; Specs 055, 118, 120, and 124.
 
 ## Purpose
@@ -102,5 +102,7 @@ is the only registry-side location rule in this slice.
 
 ## Approval Note
 
-This draft MUST not be registered in `approved-specs.json` or used for a
-merged implementation without explicit maintainer approval.
+Approved by the maintainer on 2026-08-29 (standalone instruction, re: Traverse
+#1211), reviewed against `traverse-framework/registry`'s live synced-index and
+published `signature.json` shape. Registered in `approved-specs.json` at
+`version 0.1.0`, governing `crates/traverse-cli/` and this spec directory.

--- a/specs/governance/approved-specs.json
+++ b/specs/governance/approved-specs.json
@@ -1651,6 +1651,17 @@
         "specs/124-materialized-artifact-signatures/",
         "docs/adr/0055-materialized-artifact-signatures.md"
       ]
+    },
+    {
+      "id": "125-synced-public-registry-preparation",
+      "version": "0.1.0",
+      "status": "approved",
+      "immutable": true,
+      "path": "specs/125-synced-public-registry-preparation/spec.md",
+      "governs": [
+        "crates/traverse-cli/",
+        "specs/125-synced-public-registry-preparation/"
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary

Records the maintainer's approval of **Spec 125 — Synced Public Registry Bundle Preparation** (drafted by codex via #1212 for `#1211`).

Reviewed against `traverse-framework/registry`'s live behaviour before approval:
- `traverse-cli registry sync`'s `index.json` records carry `contract_url` + `contract_digest` (FR-002 is satisfiable).
- Registry publishes the additive `signature.json` sibling with Spec-124 `ed25519` / `public_key_hex` / `signature_hex` at `<contract-dir>/signature.json` (FR-003 is satisfiable).
- The spec derives the sibling URL from `contract_url` and **defers** any registry-index signature field — so **no registry-side change is required** for this slice.

Changes: `Status` Draft -> Approved; new `approved-specs.json` record (`version 0.1.0`, `governs` `crates/traverse-cli/` + the spec dir); Approval Note updated.

## Governing Spec

- `004-spec-alignment-gate`
- `125-synced-public-registry-preparation`

## Project Item

`#1211` — approval + registration is its stated blocker. Refs `#1212`, `#1210`, Spec `124`, Spec `118`.

## Validation

- `bash scripts/ci/pr_body_check.sh` — required sections present.
- `bash scripts/ci/spec_alignment_check.sh` — `approved-specs.json` covered by `004-spec-alignment-gate`; `specs/125-.../spec.md` covered by the now-approved `125-synced-public-registry-preparation`.
- Entry shape matches sibling records (`id` / `version` / `status` / `immutable` / `path` / `governs`).

Generated with Claude Code
