### PR TITLE
fix(cli): adopt signed public bundle trust boundary

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2701,9 +2701,9 @@ dependencies = [
 
 [[package]]
 name = "traverse-registry"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79e23b8a73668c86d194bee6fceabf9ef822986d34f9234707305ae4b48ed29d"
+checksum = "fc6c6b7d3f23660a9a2f58f4eb5b038f954b80eae15c0e6082a4522615e6601f"
 dependencies = [
  "semver",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ version = "0.9.1"
 
 [workspace.dependencies]
 traverse-contracts = { path = "crates/traverse-contracts", version = "0.9.1" }
-traverse-registry = { version = "=0.16.0" }
+traverse-registry = { version = "=0.17.0" }
 traverse-runtime = { path = "crates/traverse-runtime", version = "0.9.1" }
 traverse-embedder = { path = "crates/traverse-embedder", version = "0.9.1" }
 traverse-mcp = { path = "crates/traverse-mcp", version = "0.9.1" }

--- a/crates/traverse-cli/src/main.rs
+++ b/crates/traverse-cli/src/main.rs
@@ -7846,7 +7846,8 @@ mod tests {
         format_capability_package_execution_summary, help_expedition_execute, help_serve,
         inspect_bundle, inspect_capability, inspect_capability_package, inspect_event,
         inspect_trace, latest_index_release_asset, load_artifact_state, load_capability_package,
-        load_registered_bundle, load_registered_bundle_with_public_records, load_runtime_request,
+        load_governed_public_bundle_with_artifacts, load_registered_bundle,
+        load_registered_bundle_with_public_records, load_runtime_request,
         materialize_ed25519_signature, materialize_registry_artifacts, parse_command,
         prepare_public_registry_bundle, publish_file_sha256_digest, register_bundle,
         register_generated_app_bundle, registry_record_order, registry_sync_at,
@@ -13106,7 +13107,7 @@ mod tests {
     }
 
     #[test]
-    fn materialize_writes_verified_state_and_serve_loader_uses_its_local_binary() {
+    fn materialize_writes_verified_public_state_and_serve_loader_uses_its_local_binary() {
         let dir = unique_temp_dir();
         fs::create_dir_all(&dir).expect("fixture directory");
         let wasm = dir.join("source.wasm");
@@ -13122,6 +13123,7 @@ mod tests {
         let mut contract: Value =
             serde_json::from_str(&fs::read_to_string(source).expect("source contract"))
                 .expect("contract json");
+        contract["emits"] = serde_json::json!([]);
         contract["artifact"] = serde_json::json!({
             "url": format!("file://{}", wasm.display()),
             "digest": digest,
@@ -13145,7 +13147,7 @@ mod tests {
         )
         .expect("signature sibling write");
         let bundle_path = dir.join("bundle.json");
-        fs::write(&bundle_path, serde_json::json!({"bundle_id":"fixture","version":"1.0.0","scope":"private","capabilities":[{"id":"expedition.planning.capture-expedition-objective","version":"1.0.0","path":"contract.json"}],"events":[],"workflows":[]}).to_string()).expect("bundle write");
+        fs::write(&bundle_path, serde_json::json!({"bundle_id":"fixture","version":"1.0.0","scope":"public","capabilities":[{"id":"expedition.planning.capture-expedition-objective","version":"1.0.0","path":"contract.json"}],"events":[],"workflows":[]}).to_string()).expect("bundle write");
         let out = dir.join("out");
         let state_path =
             PathBuf::from(materialize_registry_artifacts(&bundle_path, &out).expect("materialize"));
@@ -13160,6 +13162,9 @@ mod tests {
                 .map(|value| &value.scheme),
             Some(&"ed25519".to_string())
         );
+        let registered = load_governed_public_bundle_with_artifacts(&bundle_path, Some(&state))
+            .expect("serve loader accepts materialized signed public content");
+        assert_eq!(registered.capability_records.len(), 1);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- adopt `traverse-registry` 0.17.0, which delegates publish-time semver checks for signed public bundles
- exercise the materialize-to-governed-serve-loader handoff for signed public content

## Governing Spec

- 127-host-load-trust-boundary

## Project Item

- #1219

## Definition of Done

- [x] Signed public bundle registration uses the published scope/provenance gate.
- [x] Materialized signature evidence reaches the governed serve loader.

## Validation

- `cargo test -p traverse-cli-rs --locked tests::materialize_writes_verified_public_state_and_serve_loader_uses_its_local_binary -- --exact`
- `cargo fmt --check`
- `git diff --check`
