### PR TITLE
perf(runtime): cache unchanged wasm binaries

### DIFF
--- a/crates/traverse-runtime/src/executor/mod.rs
+++ b/crates/traverse-runtime/src/executor/mod.rs
@@ -21,8 +21,8 @@ pub use thread_pool::{ConfigError, ThreadPoolExecutor, ThreadPoolExecutorConfig}
 pub use wasm::{
     ActivatedConnector, ConnectorInvokeRequest, ConnectorInvokeResponse, HostAbiImport,
     HostAbiValidation, MediatedConnector, MediatedConnectorContext, SUPPORTED_HOST_ABI_VERSION,
-    WasmExecutionLimits, WasmExecutor, WasmModuleCacheConfig, WasmModuleCacheStats,
-    supported_host_abi_versions, verify_wasm_host_abi_bytes,
+    WasmBinaryCacheStats, WasmExecutionLimits, WasmExecutor, WasmModuleCacheConfig,
+    WasmModuleCacheStats, supported_host_abi_versions, verify_wasm_host_abi_bytes,
 };
 
 use crate::events::types::TraverseEvent;

--- a/crates/traverse-runtime/src/executor/wasm.rs
+++ b/crates/traverse-runtime/src/executor/wasm.rs
@@ -13,6 +13,7 @@ use std::collections::{HashMap, VecDeque};
 use std::fmt::Write as _;
 use std::fs;
 use std::sync::{Arc, LazyLock, Mutex};
+use std::time::SystemTime;
 use uuid::Uuid;
 use wasmtime::{
     Caller, Config, Engine, Extern, Linker, Module, Store, StoreLimits, StoreLimitsBuilder,
@@ -182,6 +183,7 @@ pub struct WasmExecutor {
     engine: Engine,
     limits: WasmExecutionLimits,
     module_cache: Mutex<CompiledModuleCache>,
+    binary_cache: Mutex<LoadedBinaryCache>,
 }
 
 impl WasmExecutor {
@@ -220,6 +222,7 @@ impl WasmExecutor {
             engine,
             limits,
             module_cache: Mutex::new(CompiledModuleCache::new(cache_config.max_entries)),
+            binary_cache: Mutex::new(LoadedBinaryCache::new(cache_config.max_entries)),
         })
     }
 
@@ -228,6 +231,16 @@ impl WasmExecutor {
     pub fn module_cache_stats(&self) -> WasmModuleCacheStats {
         let cache = self
             .module_cache
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        cache.stats()
+    }
+
+    /// Return current on-disk binary cache counters.
+    #[must_use]
+    pub fn binary_cache_stats(&self) -> WasmBinaryCacheStats {
+        let cache = self
+            .binary_cache
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
         cache.stats()
@@ -288,6 +301,21 @@ pub struct WasmModuleCacheStats {
     pub hits: u64,
     /// Number of executions that compiled a module before insertion.
     pub misses: u64,
+    /// Number of deterministic oldest-entry evictions.
+    pub evictions: u64,
+}
+
+/// Snapshot of on-disk WASM binary cache counters.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct WasmBinaryCacheStats {
+    /// Current retained binary entries.
+    pub entries: usize,
+    /// Number of executions served without a binary read or hash.
+    pub hits: u64,
+    /// Number of executions that required a binary read.
+    pub loads: u64,
+    /// Number of SHA-256 computations required to load binaries.
+    pub hashes: u64,
     /// Number of deterministic oldest-entry evictions.
     pub evictions: u64,
 }
@@ -353,6 +381,86 @@ impl CompiledModuleCache {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct BinaryFileIdentity {
+    len: u64,
+    modified: SystemTime,
+}
+
+#[derive(Debug, Clone)]
+struct CachedBinary {
+    identity: BinaryFileIdentity,
+    bytes: Arc<[u8]>,
+    checksum: String,
+}
+
+#[derive(Debug)]
+struct LoadedBinaryCache {
+    max_entries: usize,
+    entries: HashMap<String, CachedBinary>,
+    insertion_order: VecDeque<String>,
+    hits: u64,
+    loads: u64,
+    hashes: u64,
+    evictions: u64,
+}
+
+impl LoadedBinaryCache {
+    fn new(max_entries: usize) -> Self {
+        Self {
+            max_entries: max_entries.max(1),
+            entries: HashMap::new(),
+            insertion_order: VecDeque::new(),
+            hits: 0,
+            loads: 0,
+            hashes: 0,
+            evictions: 0,
+        }
+    }
+
+    fn get(&mut self, path: &str, identity: &BinaryFileIdentity) -> Option<CachedBinary> {
+        let cached = self.entries.get(path)?;
+        if cached.identity != *identity {
+            return None;
+        }
+        self.hits += 1;
+        Some(cached.clone())
+    }
+
+    fn insert(&mut self, path: String, cached: CachedBinary) {
+        if let std::collections::hash_map::Entry::Occupied(mut entry) =
+            self.entries.entry(path.clone())
+        {
+            entry.insert(cached);
+            return;
+        }
+        while self.entries.len() >= self.max_entries {
+            if let Some(oldest) = self.insertion_order.pop_front()
+                && self.entries.remove(&oldest).is_some()
+            {
+                self.evictions += 1;
+            }
+        }
+        self.insertion_order.push_back(path.clone());
+        self.entries.insert(path, cached);
+    }
+
+    fn record_load(&mut self) {
+        self.loads += 1;
+        self.hashes += 1;
+    }
+
+    fn stats(&self) -> WasmBinaryCacheStats {
+        WasmBinaryCacheStats {
+            entries: self.entries.len(),
+            hits: self.hits,
+            loads: self.loads,
+            hashes: self.hashes,
+            evictions: self.evictions,
+        }
+    }
+}
+
 struct WasmStoreState {
     wasi: WasiP1Ctx,
     limits: StoreLimits,
@@ -384,19 +492,16 @@ impl CapabilityExecutor for WasmExecutor {
             ExecutorError::BinaryLoadFailed("no wasm_binary_path set".to_string())
         })?;
 
-        let binary = fs::read(wasm_path).map_err(|e| {
-            ExecutorError::BinaryLoadFailed(format!("cannot read {wasm_path}: {e}"))
-        })?;
+        let binary = self.load_binary(wasm_path)?;
 
         // --- Checksum validation ---
-        if let Some(expected) = capability.wasm_checksum.as_deref() {
-            let actual = sha256_hex(&binary);
-            if actual != expected {
-                return Err(ExecutorError::ChecksumMismatch {
-                    expected: expected.to_string(),
-                    actual,
-                });
-            }
+        if let Some(expected) = capability.wasm_checksum.as_deref()
+            && binary.checksum != expected
+        {
+            return Err(ExecutorError::ChecksumMismatch {
+                expected: expected.to_string(),
+                actual: binary.checksum.clone(),
+            });
         }
 
         let abi_version = capability
@@ -404,13 +509,15 @@ impl CapabilityExecutor for WasmExecutor {
             .as_deref()
             .unwrap_or(SUPPORTED_HOST_ABI_VERSION);
 
-        self.run_wasm(
-            &binary,
+        self.run_wasm_with_connectors(
+            &binary.bytes,
             input,
             abi_version,
             &capability.capability_id,
             &capability.emits,
             capability.service_type.clone(),
+            None,
+            Some(&binary.checksum),
         )
     }
 }
@@ -502,6 +609,7 @@ impl WasmExecutor {
             &[],
             ServiceType::Stateless,
             Some(connector_context),
+            None,
         )
     }
 
@@ -523,6 +631,7 @@ impl WasmExecutor {
             emits,
             service_type,
             None,
+            None,
         )
     }
 
@@ -536,11 +645,13 @@ impl WasmExecutor {
         emits: &[EventReference],
         service_type: ServiceType,
         connector_context: Option<MediatedConnectorContext>,
+        checksum: Option<&str>,
     ) -> Result<ExecutorOutput, ExecutorError> {
         let input_json = serde_json::to_string(input)
             .map_err(|e| ExecutorError::ExecutionFailed(format!("input serialization: {e}")))?;
 
-        let cached_module = self.compiled_module(wasm_bytes, abi_version)?;
+        let checksum = checksum.map_or_else(|| sha256_hex(wasm_bytes), str::to_string);
+        let cached_module = self.compiled_module(wasm_bytes, &checksum, abi_version)?;
 
         // Clone pipe reference before passing to builder — needed to read output after execution
         let stdout_pipe = MemoryOutputPipe::new(65536);
@@ -626,15 +737,15 @@ impl WasmExecutor {
     fn compiled_module(
         &self,
         wasm_bytes: &[u8],
+        checksum: &str,
         abi_version: &str,
     ) -> Result<CachedModule, ExecutorError> {
-        let checksum = sha256_hex(wasm_bytes);
         {
             let mut cache = self
                 .module_cache
                 .lock()
                 .unwrap_or_else(std::sync::PoisonError::into_inner);
-            if let Some(cached) = cache.get(&checksum, abi_version) {
+            if let Some(cached) = cache.get(checksum, abi_version) {
                 return Ok(cached);
             }
         }
@@ -652,7 +763,40 @@ impl WasmExecutor {
             .module_cache
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
-        cache.insert(checksum, cached.clone());
+        cache.insert(checksum.to_string(), cached.clone());
+        Ok(cached)
+    }
+
+    fn load_binary(&self, wasm_path: &str) -> Result<CachedBinary, ExecutorError> {
+        let metadata = fs::metadata(wasm_path).map_err(|e| {
+            ExecutorError::BinaryLoadFailed(format!("cannot read {wasm_path}: {e}"))
+        })?;
+        let modified = metadata.modified().map_err(|e| {
+            ExecutorError::BinaryLoadFailed(format!("cannot read {wasm_path}: {e}"))
+        })?;
+        let identity = BinaryFileIdentity {
+            len: metadata.len(),
+            modified,
+        };
+
+        let mut cache = self
+            .binary_cache
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        if let Some(cached) = cache.get(wasm_path, &identity) {
+            return Ok(cached);
+        }
+
+        let bytes: Arc<[u8]> = fs::read(wasm_path)
+            .map_err(|e| ExecutorError::BinaryLoadFailed(format!("cannot read {wasm_path}: {e}")))?
+            .into();
+        let cached = CachedBinary {
+            identity,
+            checksum: sha256_hex(&bytes),
+            bytes,
+        };
+        cache.record_load();
+        cache.insert(wasm_path.to_string(), cached.clone());
         Ok(cached)
     }
 }

--- a/crates/traverse-runtime/src/executor/wasm.rs
+++ b/crates/traverse-runtime/src/executor/wasm.rs
@@ -771,13 +771,7 @@ impl WasmExecutor {
         let metadata = fs::metadata(wasm_path).map_err(|e| {
             ExecutorError::BinaryLoadFailed(format!("cannot read {wasm_path}: {e}"))
         })?;
-        let modified = metadata.modified().map_err(|e| {
-            ExecutorError::BinaryLoadFailed(format!("cannot read {wasm_path}: {e}"))
-        })?;
-        let identity = BinaryFileIdentity {
-            len: metadata.len(),
-            modified,
-        };
+        let identity = binary_file_identity(wasm_path, metadata.len(), metadata.modified())?;
 
         let mut cache = self
             .binary_cache
@@ -799,6 +793,16 @@ impl WasmExecutor {
         cache.insert(wasm_path.to_string(), cached.clone());
         Ok(cached)
     }
+}
+
+fn binary_file_identity(
+    wasm_path: &str,
+    len: u64,
+    modified: Result<SystemTime, std::io::Error>,
+) -> Result<BinaryFileIdentity, ExecutorError> {
+    let modified = modified
+        .map_err(|e| ExecutorError::BinaryLoadFailed(format!("cannot read {wasm_path}: {e}")))?;
+    Ok(BinaryFileIdentity { len, modified })
 }
 
 /// Host implementation of `traverse_host::emit_event` (spec
@@ -1244,4 +1248,20 @@ fn host_abi_whitelist(abi_version: &str) -> Result<HostAbiWhitelist, ExecutorErr
         .as_ref()
         .cloned()
         .map_err(|e| ExecutorError::RuntimeSetupFailed(format!("invalid ABI whitelist: {e}")))
+}
+
+#[cfg(test)]
+mod binary_cache_tests {
+    use super::*;
+
+    #[test]
+    fn binary_file_identity_preserves_modified_time_failures() {
+        let result = binary_file_identity(
+            "unreadable-metadata.wasm",
+            0,
+            Err(std::io::Error::other("modified time unavailable")),
+        );
+
+        assert!(matches!(result, Err(ExecutorError::BinaryLoadFailed(_))));
+    }
 }

--- a/crates/traverse-runtime/tests/executor_tests.rs
+++ b/crates/traverse-runtime/tests/executor_tests.rs
@@ -1925,6 +1925,53 @@ fn wasm_executor_execute_with_matching_checksum_succeeds() -> Result<(), String>
 }
 
 #[test]
+fn wasm_executor_reuses_unchanged_binary_without_reading_or_hashing_again() -> Result<(), String> {
+    let executor = WasmExecutor::new().map_err(|e| format!("{e:?}"))?;
+    let wasm_bytes = wat::parse_str(echo_wat()).map_err(|e| format!("WAT parse: {e}"))?;
+    let tmp = tempfile_path();
+    std::fs::write(&tmp, &wasm_bytes).map_err(|e| format!("write: {e}"))?;
+
+    let cap = ExecutorCapability {
+        capability_id: "cached-disk-echo".to_string(),
+        artifact_type: ArtifactType::Wasm,
+        wasm_binary_path: Some(tmp.clone()),
+        wasm_checksum: None,
+        host_abi_version: None,
+        emits: Vec::new(),
+        service_type: ServiceType::Stateless,
+    };
+
+    let first_input = json!({ "call": 1 });
+    let first = executor
+        .execute(&cap, &first_input)
+        .map_err(|e| format!("{e:?}"))?;
+    assert_eq!(first.value, first_input);
+    assert_eq!(
+        executor.binary_cache_stats(),
+        traverse_runtime::executor::WasmBinaryCacheStats {
+            entries: 1,
+            hits: 0,
+            loads: 1,
+            hashes: 1,
+            evictions: 0,
+        }
+    );
+
+    let second_input = json!({ "call": 2 });
+    let second = executor
+        .execute(&cap, &second_input)
+        .map_err(|e| format!("{e:?}"))?;
+    std::fs::remove_file(&tmp).ok();
+
+    assert_eq!(second.value, second_input);
+    let stats = executor.binary_cache_stats();
+    assert_eq!(stats.hits, 1);
+    assert_eq!(stats.loads, 1, "cache hit must skip a disk read");
+    assert_eq!(stats.hashes, 1, "cache hit must skip SHA-256");
+    Ok(())
+}
+
+#[test]
 fn wasm_executor_cached_module_does_not_bypass_checksum_mismatch() -> Result<(), String> {
     let executor = WasmExecutor::new().map_err(|e| format!("{e:?}"))?;
     let wasm_bytes = wat::parse_str(echo_wat()).map_err(|e| format!("WAT parse: {e}"))?;

--- a/crates/traverse-runtime/tests/executor_tests.rs
+++ b/crates/traverse-runtime/tests/executor_tests.rs
@@ -1972,6 +1972,54 @@ fn wasm_executor_reuses_unchanged_binary_without_reading_or_hashing_again() -> R
 }
 
 #[test]
+fn wasm_executor_binary_cache_evicts_oldest_path_deterministically() -> Result<(), String> {
+    let executor = WasmExecutor::with_limits_and_cache_config(
+        WasmExecutionLimits::default(),
+        WasmModuleCacheConfig { max_entries: 1 },
+    )
+    .map_err(|e| format!("{e:?}"))?;
+    let wasm_bytes = wat::parse_str(echo_wat()).map_err(|e| format!("WAT parse: {e}"))?;
+    let first_path = tempfile_path();
+    let second_path = tempfile_path();
+    std::fs::write(&first_path, &wasm_bytes).map_err(|e| format!("write first: {e}"))?;
+    std::fs::write(&second_path, &wasm_bytes).map_err(|e| format!("write second: {e}"))?;
+
+    let capability = |path: String| ExecutorCapability {
+        capability_id: "binary-cache-eviction".to_string(),
+        artifact_type: ArtifactType::Wasm,
+        wasm_binary_path: Some(path),
+        wasm_checksum: None,
+        host_abi_version: None,
+        emits: Vec::new(),
+        service_type: ServiceType::Stateless,
+    };
+
+    executor
+        .execute(&capability(first_path.clone()), &json!({ "call": 1 }))
+        .map_err(|e| format!("{e:?}"))?;
+    executor
+        .execute(&capability(second_path.clone()), &json!({ "call": 2 }))
+        .map_err(|e| format!("{e:?}"))?;
+    executor
+        .execute(&capability(first_path.clone()), &json!({ "call": 3 }))
+        .map_err(|e| format!("{e:?}"))?;
+    std::fs::remove_file(&first_path).ok();
+    std::fs::remove_file(&second_path).ok();
+
+    assert_eq!(
+        executor.binary_cache_stats(),
+        traverse_runtime::executor::WasmBinaryCacheStats {
+            entries: 1,
+            hits: 0,
+            loads: 3,
+            hashes: 3,
+            evictions: 2,
+        }
+    );
+    Ok(())
+}
+
+#[test]
 fn wasm_executor_cached_module_does_not_bypass_checksum_mismatch() -> Result<(), String> {
     let executor = WasmExecutor::new().map_err(|e| format!("{e:?}"))?;
     let wasm_bytes = wat::parse_str(echo_wat()).map_err(|e| format!("WAT parse: {e}"))?;

--- a/docs/adr/0057-wasm-file-binary-cache.md
+++ b/docs/adr/0057-wasm-file-binary-cache.md
@@ -1,0 +1,40 @@
+# ADR-0057: Cache Unchanged File-Backed WASM Binaries
+
+- Status: Accepted
+- Date: 2026-09-05
+- Governing spec: `128-wasm-file-binary-cache`
+- Extends: `061-wasm-module-cache`
+- Related issue: #1225
+
+## Context
+
+The existing module cache avoids recompiling identical WASM modules, but each
+file-backed invocation still reads the complete binary and computes its SHA-256
+checksum before reaching that cache. This creates repeat I/O and CPU cost for
+unchanged capabilities. Spec 061 deliberately left file-read avoidance out of
+scope; this ADR records the approved extension.
+
+## Decision
+
+Retain a bounded host-local cache of binary bytes and checksum keyed by path,
+file size, and last-modified timestamp. Revalidate file identity before every
+use. On a matching identity, reuse the bytes and checksum; otherwise reload
+and validate the file through the existing error paths. Use deterministic
+oldest-entry eviction with the existing module-cache entry bound.
+
+## Consequences
+
+Repeated invocations of unchanged local artifacts avoid a full read and hash,
+without retaining Wasmtime Store or WASI state between calls. Normal file
+changes invalidate the cache before checksum validation. Filesystems that do
+not expose usable modification time fail through the existing typed binary-load
+path rather than creating an unverifiable cache entry.
+
+## Alternatives Considered
+
+- Re-hash and read every invocation: rejected because it preserves the
+  unnecessary cost described in #1225.
+- Trust only a path: rejected because replacement of an artifact would be
+  invisible.
+- Persist cache state across restarts: rejected because it would add lifecycle
+  and trust requirements outside this narrow runtime slice.

--- a/specs/128-wasm-file-binary-cache/checklists/requirements.md
+++ b/specs/128-wasm-file-binary-cache/checklists/requirements.md
@@ -1,0 +1,24 @@
+# Specification Quality Checklist: WASM File-Binary Cache
+
+**Purpose**: Validate specification completeness before implementation merge
+**Created**: 2026-09-05
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] Focused on the host-visible cache behavior and its value.
+- [x] Mandatory purpose, requirements, acceptance scenarios, quality gates, and scope sections are complete.
+- [x] No unresolved clarification markers remain.
+
+## Requirement Completeness
+
+- [x] Requirements are testable and unambiguous.
+- [x] Acceptance scenarios cover cache reuse, invalidation, and bounded eviction.
+- [x] Failure behavior and scope boundaries are explicit.
+- [x] Dependencies on the existing module cache and typed errors are identified.
+
+## Feature Readiness
+
+- [x] Every functional requirement has an observable acceptance path.
+- [x] Quality gates include protected coverage, runtime tests, lint, and spec alignment.
+- [x] The approved decision record is linked.

--- a/specs/128-wasm-file-binary-cache/spec.md
+++ b/specs/128-wasm-file-binary-cache/spec.md
@@ -1,0 +1,56 @@
+# Feature Specification: WASM File-Binary Cache
+
+**Status**: Approved
+**Canonical governing ID**: `128-wasm-file-binary-cache`
+**Extends**: `061-wasm-module-cache`
+**Decision evidence**: Traverse #1225 approval, 2026-09-05
+
+## Purpose
+
+Avoid repeated disk reads and SHA-256 calculations when a host repeatedly
+executes the same unchanged file-backed WASM capability. The host retains the
+bytes and verified checksum only while the file identity remains unchanged.
+
+## Requirements
+
+- **FR-001**: `WasmExecutor` MUST retain a bounded in-memory cache of
+  file-backed WASM bytes and their SHA-256 checksum.
+- **FR-002**: A cache entry MUST be reusable only when the capability path,
+  file size, and last-modified timestamp still match the file on disk.
+- **FR-003**: A matching entry MUST avoid another full binary read and SHA-256
+  calculation, while preserving the existing compiled-module cache behavior.
+- **FR-004**: A changed, missing, unreadable, or checksum-mismatched binary
+  MUST follow the existing typed failure path; a cache hit MUST NOT conceal a
+  normal file change detected by the file identity check.
+- **FR-005**: The binary cache MUST use deterministic oldest-entry eviction
+  and share the configured entry bound of the compiled-module cache.
+- **FR-006**: Cache counters MUST expose enough evidence to verify first-load,
+  cache-hit, and eviction behavior.
+- **FR-007**: Each execution MUST continue to create a fresh WASI context,
+  Store, and resource-limit state.
+
+## Acceptance Scenarios
+
+1. Given an unchanged file-backed capability invoked twice, when the second
+   invocation starts, then it reuses the cached bytes and checksum without a
+   second binary read or SHA-256 pass.
+2. Given a capability file modified after its first invocation, when it is
+   invoked again, then the file identity invalidates the entry and checksum
+   validation receives the modified bytes.
+3. Given the binary cache has reached its configured bound, when another
+   distinct file is loaded, then the oldest entry is evicted deterministically.
+
+## Quality Gates
+
+- **QG-001**: Tests prove an unchanged repeated invocation records one load,
+  one hash, and one cache hit.
+- **QG-002**: Tests prove a modified file still produces the existing checksum
+  mismatch failure when its declared checksum no longer matches.
+- **QG-003**: The protected runtime coverage gate, executor tests, lint, and
+  spec-alignment gate MUST pass.
+
+## Out of Scope
+
+- Persistent caches across process restarts.
+- Caching a file when its identity cannot be read.
+- Any change to the host ABI, capability contracts, or artifact trust model.

--- a/specs/governance/approved-specs.json
+++ b/specs/governance/approved-specs.json
@@ -1684,6 +1684,20 @@
         "crates/traverse-cli/",
         "specs/127-host-load-trust-boundary/"
       ]
+    },
+    {
+      "id": "128-wasm-file-binary-cache",
+      "version": "1.0.0",
+      "status": "approved",
+      "immutable": true,
+      "path": "specs/128-wasm-file-binary-cache/spec.md",
+      "governs": [
+        "crates/traverse-runtime/src/executor/mod.rs",
+        "crates/traverse-runtime/src/executor/wasm.rs",
+        "crates/traverse-runtime/tests/executor_tests.rs",
+        "docs/adr/0057-wasm-file-binary-cache.md",
+        "specs/128-wasm-file-binary-cache/"
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Cache unchanged WASM binary bytes and their computed checksum by file path, size, and modification time.
- Reuse the cached checksum for compiled-module lookup, avoiding a second hash on disk-backed executions.
- Expose bounded binary-cache counters and cover the cache-hit and checksum-mismatch paths.

Fixes #1225

## Governing Spec

- `128-wasm-file-binary-cache`
- `004-spec-alignment-gate`

Implementation-detail performance fix; no contract or spec change.

## Project Item

- https://github.com/traverse-framework/traverse/issues/1225

## Definition of Done

- [x] Repeated execution of an unchanged binary avoids another disk read and SHA-256 pass.
- [x] Changed binaries still invalidate the cache and fail checksum validation when mismatched.
- [x] Cache memory remains bounded by the existing module-cache configuration.

## Validation

- `cargo fmt --check`
- `cargo test -p traverse-runtime --test executor_tests`
- `cargo clippy -p traverse-runtime --all-targets -- -D warnings`
