### PR TITLE
docs: prepare v0.10.0 release notes and changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,112 @@
 
 ## Unreleased
 
+## v0.10.0 — 2026-09-05
+
+### Governed runtime workflow composition
+
+- Declarative workflow planner (spec 113, P0): the MCP surface can plan a
+  multi-capability workflow from a goal, chaining steps on schema-shape
+  compatibility rather than declared `consumes`/`emits` (Decision 62).
+- Runtime workflow proposal lifecycle over MCP (P1), bounded deterministic
+  parallel proposal scheduling (P2), and governed export and promotion of
+  runtime-generated proposals back into authored workflows (P4).
+- Durable orchestration controls with checkpoint/recovery guards, and proven
+  recovery of an explicitly abandoned workflow proposal.
+
+### Durable trace journal
+
+- `DurableTraceJournal` persists execution traces through the existing
+  append-only, fsync-committed event journal (spec 079, ADR-0045). Traces are
+  canonical JSON Lines carrying only non-sensitive metadata and hashes, per
+  workspace, with the journal's existing crash-recovery and whole-segment
+  retention semantics. Opt-in via `PlacementRouter::with_durable_trace`;
+  existing call sites are unaffected. Callers choose fail-open or fail-closed
+  on durable-write failure (ADR-0017).
+
+### Browser-hosted execution
+
+- Governed browser proposal host and end-to-end proposal journey.
+- Browser execution of a verified single capability that returns an execution
+  receipt, along the validated `execute_entrypoint` path (spec 023).
+
+### Verified registry metadata and host-owned artifacts
+
+- `serve` requires host-supplied registry state and exposes a verified
+  entrypoint endpoint.
+- MCP verified capability search over host-owned, verified public metadata.
+- Embedder caches verified public contract metadata.
+- CLI materializes verified registry artifacts locally (spec 120, ADR-0051).
+
+### Authoring telemetry
+
+- Privacy-preserving, manifest-governed authoring telemetry: manifest policy
+  validation, host-owned aggregation, and host config that is **off by
+  default** (specs 184–197).
+
+### Cross-host and native execution
+
+- Bounded native WASI profile (spec 181) with native cross-host fixture
+  evidence, a cross-host CLI fixture runner in CI, and a cross-host
+  hello-world fixture corpus governed by a fixture comparison contract.
+
+### Connectors
+
+- Universal local connector contracts, runtime mediation of connector invoke
+  requests, activation of application connector bindings, and native registry
+  cache adapters for the embedder (specs 1054, 1074, 1083).
+
+### Capabilities and authoring
+
+- Immutable capability risk metadata on `CapabilityContract` — effect class,
+  determinism class, field-level data-flow/egress policy, reliability
+  semantics — with an `is_automatic_eligible()` gate, manifest-side egress
+  narrowing validated at app register/validate time, and redacted exposure
+  through MCP discovery (spec 109 FR-005/FR-006).
+- Publish now fails closed on incomplete `use_case` surface coverage: declared
+  schema surface must be covered by use cases, each with `ucNN` smoke fixtures
+  (Spec 102 v1.1.0, Decision 58).
+- Standalone capability packages are allowed, with a standalone package
+  discovery posture exposed over MCP.
+- `traverse-embedder-web` prepared for publish (packaging only).
+- Loop package: added remaining capabilities and the
+  `core.validate-action-item` example for registry publish;
+  `core.transition-action-status` honesty-bumped to 1.2.0 and now really
+  emits `status-transitioned`.
+
+### CLI and runtime
+
+- CLI resolves executable artifacts at activation time.
+- Pinned `traverse-registry` advanced (now `=0.17.0`); the 0.15.0 bump
+  published the resolve hook, and the runtime now threads an opt-in
+  `UsageTelemetrySink` (`Runtime::with_usage_telemetry_sink`, NoOp by
+  default) into semver-range resolution, wired at both production
+  Runtime-construction points in the CLI (#930).
+
+### Fixes
+
+- CLI: pinned down and regression-tested the artifact-metadata trust boundary.
+- CLI: bound gRPC event streams; use `Duration::from_mins` for
+  `MAX_STREAM_DURATION`.
+- Runtime: gate native inference on wasm.
+- CI: clear stale coverage artifacts before measuring; scope heavy PR checks
+  to code changes.
+
+### Upgrade notes
+
+- The binary remains `traverse-cli`.
+- **Publishing is stricter.** Packages that publish cleanly on v0.9.1 may now
+  be rejected: `use_case` surface coverage is fail-closed (schema ⊆
+  use_cases ⊆ smoke), and manifest egress that is broader than the
+  capability's declared data-flow/egress policy fails at register/validate
+  time. Pre-existing contracts without risk metadata take a conservative
+  migration default.
+- `traverse-registry` is pinned at `=0.17.0`. Usage/resolve telemetry is
+  opt-in and defaults to a no-op sink; no action needed unless you want to
+  collect it.
+- Durable trace and durable orchestration are opt-in builders; existing
+  `PlacementRouter` and `Runtime` construction paths are unchanged.
+
 ## v0.9.1 — 2026-08-09
 
 - Capability packages can be scaffolded, inspected, validated, and published through

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Coverage](https://img.shields.io/badge/coverage-100%25-brightgreen)](https://github.com/traverse-framework/traverse/actions/workflows/ci.yml)
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue)](LICENSE)
 [![Rust](https://img.shields.io/badge/rust-1.94%2B-orange)](https://www.rust-lang.org/)
-[![Version](https://img.shields.io/badge/version-v0.9.1-blue)](https://github.com/traverse-framework/traverse/releases)
+[![Version](https://img.shields.io/badge/version-v0.10.0-blue)](https://github.com/traverse-framework/traverse/releases)
 [![Registry](https://img.shields.io/badge/registry-live%20catalog-6f42c1)](https://registry.traverse-framework.com/)
 
 Your business logic runs in the browser, on your server, and in a cloud function.
@@ -20,10 +20,10 @@ Traverse is the working implementation of [Universal Microservices Architecture]
 
 ## Current State & Roadmap
 
-Traverse is pre-1.0 (`v0.9.1`) and evolving under spec-driven governance — every capability below is real, running code, not a plan.
+Traverse is pre-1.0 (`v0.10.0`) and evolving under spec-driven governance — every capability below is real, running code, not a plan.
 
 - **8 crates in this repo** plus the capability registry (now its own repo, see below) — 7 of these 9 are [published on crates.io](https://crates.io/search?q=traverse-): runtime, contracts, registry, CLI, MCP server, embedder SDK, and the expedition WASM example. `traverse-native-bridge` and `traverse-swift-host` are newer, not yet published.
-- **105 approved, immutable specs** govern the runtime, contracts, registry, MCP surface, WASM execution, native embedding, event delivery, and durable local storage. Full list: `jq -r '.specs[].id' specs/governance/approved-specs.json` (or see [Governance](#governance) below).
+- **133 approved, immutable specs** govern the runtime, contracts, registry, MCP surface, WASM execution, native embedding, event delivery, and durable local storage. Full list: `jq -r '.specs[].id' specs/governance/approved-specs.json` (or see [Governance](#governance) below).
 - **100% coverage enforced on core logic**, spec-alignment and supply-chain gates on every PR, 5-platform CI matrix (Linux x86_64/aarch64, macOS x86_64/arm64, Windows x86_64).
 - **Capability registry** was extracted into its own repo, [`traverse-framework/registry`](https://github.com/traverse-framework/registry), so capabilities can be published, versioned, and consumed independently of the runtime. Browse what's actually published at the live catalog: **[registry.traverse-framework.com](https://registry.traverse-framework.com/)**.
 - **Reference apps** for multiple platforms (web, iOS, macOS, Android, Windows, Linux, CLI) live in [`traverse-framework/reference-apps`](https://github.com/traverse-framework/reference-apps).
@@ -131,7 +131,8 @@ Scaffolds a governed app bundle. Add your capability contracts, workflows, and W
 
 ### Consumer and release surfaces
 
-- [docs/releases/v0.9.1.md](docs/releases/v0.9.1.md) — current release notes
+- [docs/releases/v0.10.0.md](docs/releases/v0.10.0.md) — current release notes
+- [docs/releases/v0.9.1.md](docs/releases/v0.9.1.md) — prior release notes
 - [docs/releases/v0.8.1.md](docs/releases/v0.8.1.md) — prior release notes
 - [docs/app-consumable-consumer-bundle.md](docs/app-consumable-consumer-bundle.md) — versioned consumer bundle
 - [docs/app-consumable-package-release-pointer.md](docs/app-consumable-package-release-pointer.md) — package release pointer
@@ -232,7 +233,7 @@ Traverse is spec-driven. Code must align with an approved, immutable spec or it 
 
 ### Approved Specs
 
-105 approved specs currently govern this repo, spanning the runtime, contracts, registry integration, CLI, MCP surface, WASM execution, native embedding, event delivery, and durable local storage. The list changes as specs are approved — query it instead of reading a snapshot:
+133 approved specs currently govern this repo, spanning the runtime, contracts, registry integration, CLI, MCP surface, WASM execution, native embedding, event delivery, and durable local storage. The list changes as specs are approved — query it instead of reading a snapshot:
 
 ```bash
 jq -r '.specs[].id' specs/governance/approved-specs.json

--- a/docs/releases/v0.10.0.md
+++ b/docs/releases/v0.10.0.md
@@ -1,0 +1,175 @@
+# Traverse v0.10.0
+
+Released 2026-09-05.
+
+Traverse v0.10.0 is a minor release covering 82 commits since `v0.9.1`. Its
+throughline is *governed composition*: the runtime can now plan, schedule,
+run, and promote multi-capability workflows through MCP, and it can persist
+what it did as a durable, tamper-evident trace. Alongside that, this release
+adds browser-hosted verified execution, host-owned verified registry
+metadata, privacy-preserving authoring telemetry (off by default), a bounded
+native WASI profile, and mediated local connectors.
+
+## Highlights
+
+### Governed runtime workflow composition
+
+- **Declarative workflow planner** (spec 113): plan a multi-capability
+  workflow from a stated goal. Steps chain on schema-shape compatibility
+  rather than declared `consumes`/`emits` (Decision 62).
+- **Runtime workflow proposal lifecycle** over MCP: propose (P1), schedule
+  with bounded deterministic parallelism (P2), and export/promote a
+  runtime-generated proposal back into an authored workflow under governance
+  (P4).
+- **Durable orchestration controls** with checkpoint and recovery guards, and
+  proven recovery of an explicitly abandoned proposal.
+
+### Durable trace journal
+
+- `DurableTraceJournal` persists execution traces through the existing
+  append-only, fsync-committed event journal (spec 079, ADR-0045). Traces are
+  canonical JSON Lines holding only non-sensitive metadata and hashes — never
+  raw payloads — scoped per workspace, and inherit the journal's crash
+  recovery and whole-segment retention.
+- Opt-in via `PlacementRouter::with_durable_trace(...)`. Existing call sites
+  are unaffected. The caller decides fail-open vs. fail-closed on a
+  durable-write failure (ADR-0017).
+
+### Browser-hosted execution
+
+- Governed browser proposal host and an end-to-end browser proposal journey.
+- Browser execution of a single verified capability that returns an execution
+  receipt, along the validated `execute_entrypoint` path (spec 023).
+
+### Verified registry metadata and host-owned artifacts
+
+- `serve` now requires host-supplied registry state and exposes a verified
+  entrypoint endpoint.
+- MCP verified capability search over host-owned verified public metadata.
+- The embedder caches verified public contract metadata.
+- The CLI materializes verified registry artifacts locally (spec 120,
+  ADR-0051).
+
+### Authoring telemetry
+
+- Privacy-preserving, manifest-governed authoring telemetry: manifest policy
+  validation, host-owned aggregation, and host configuration that is **off by
+  default**.
+
+### Cross-host and native execution
+
+- Bounded native WASI profile (spec 181) with native cross-host fixture
+  evidence, a cross-host CLI fixture runner in CI, and a governed cross-host
+  hello-world fixture corpus with a fixture comparison contract.
+
+### Connectors
+
+- Universal local connector contracts, runtime mediation of connector invoke
+  requests, activation of application connector bindings, and native registry
+  cache adapters for the embedder.
+
+### Capabilities and authoring
+
+- **Immutable capability risk metadata** on `CapabilityContract`: effect
+  class, determinism class, field-level data-flow/egress policy, and
+  reliability semantics, with an `is_automatic_eligible()` gate and redacted
+  exposure through MCP discovery (spec 109 FR-005/FR-006). Manifest egress is
+  narrowed and validated at app register/validate time. Pre-existing
+  contracts take a conservative migration default.
+- **Fail-closed `use_case` surface coverage** on publish: the declared schema
+  surface must be covered by use cases, each backed by `ucNN` smoke fixtures
+  (Spec 102 v1.1.0, Decision 58). Rule: schema ⊆ use_cases ⊆ smoke.
+- Standalone capability packages are allowed, with a standalone package
+  discovery posture exposed over MCP.
+- `traverse-embedder-web` prepared for publish (packaging only).
+- Loop package: remaining capabilities and the `core.validate-action-item`
+  example added for registry publish; `core.transition-action-status`
+  honesty-bumped to 1.2.0 and now really emits `status-transitioned`.
+
+### CLI and runtime
+
+- The CLI resolves executable artifacts at activation time.
+- Pinned `traverse-registry` advanced (now `=0.17.0`). The 0.15.0 bump
+  published the resolve hook; the runtime threads an opt-in
+  `UsageTelemetrySink` (`Runtime::with_usage_telemetry_sink`, NoOp by
+  default) into semver-range resolution, wired at both production
+  Runtime-construction points in the CLI (#930).
+
+### Fixes
+
+- CLI: pinned down and regression-tested the artifact-metadata trust
+  boundary; bound gRPC event streams; `Duration::from_mins` for
+  `MAX_STREAM_DURATION`.
+- Runtime: gate native inference on wasm.
+- CI: clear stale coverage artifacts before measuring; scope heavy PR checks
+  to code changes.
+
+## Upgrade notes
+
+- The binary remains `traverse-cli`.
+- **Publishing is stricter than v0.9.1.** A package that published cleanly
+  before may now be rejected:
+  - `use_case` surface coverage is fail-closed — every part of the declared
+    schema surface must be covered by a use case with `ucNN` smoke fixtures.
+  - Manifest egress broader than the capability's declared data-flow/egress
+    policy fails at register/validate time.
+  - Contracts without risk metadata are migrated with a conservative default;
+    review the assigned effect/determinism classes before relying on
+    automatic eligibility.
+- `traverse-registry` is pinned at `=0.17.0`. Usage/resolve telemetry is
+  opt-in and defaults to a no-op sink — no action needed unless you want to
+  collect it.
+- Durable trace and durable orchestration are opt-in builders; existing
+  `PlacementRouter` and `Runtime` construction paths are unchanged.
+- `serve` now requires host-supplied registry state. A host that previously
+  started `serve` without providing registry state must now supply it.
+
+## Validation
+
+Release preparation must pass these local gates before tagging:
+
+```bash
+cargo build --workspace
+bash scripts/ci/repository_checks.sh
+bash scripts/ci/spec_alignment_check.sh
+```
+
+The GitHub PR checks must also pass: `repository-checks`, `coverage-gate`,
+`pr-hygiene`, `spec-alignment`.
+
+## Release steps
+
+Per [docs/release-process.md](../release-process.md), from a clean `main`
+checkout with CI green:
+
+```bash
+bash scripts/ci/bump_version.sh 0.10.0
+git push origin main
+git push origin v0.10.0
+```
+
+The `v0.10.0` tag push triggers `version-guard` then the `publish` job, which
+publishes `traverse-contracts`, `traverse-runtime`, `traverse-mcp`,
+`traverse-cli-rs`, and `traverse-expedition-wasm` to crates.io in dependency
+order. `traverse-registry` is released separately from
+`traverse-framework/registry`.
+
+## Further reading
+
+- [Changelog](../../CHANGELOG.md)
+- [Release process](../release-process.md)
+- [Capability publishing](../capability-publish.md)
+- [Capability contract authoring](../capability-contract-authoring-guide.md)
+- [WASM agent authoring](../wasm-agent-authoring-guide.md)
+- [CLI reference](../cli-reference.md)
+
+## Traceability
+
+- Governing spec: `048-semver-publishing-pipeline`
+- Themes: `108`–`113` (governed runtime workflow composition), `079` /
+  `527-durable-trace-productization` (durable trace), `023` (browser-hosted
+  consumer model), `102` (contract surface coverage), `109` (capability risk
+  metadata), `120` (host-owned artifact preparation), `181` (bounded native
+  WASI profile), `103`–`107` (connectors and embedded registry cache),
+  `536-runtime-usage-telemetry`
+- Range: `v0.9.1..v0.10.0`


### PR DESCRIPTION
## Summary

Prepares the release-facing documentation for **v0.10.0**: the `CHANGELOG.md`
section, `docs/releases/v0.10.0.md`, and the README version/spec-count
references. Documentation only — no runtime, contract, API, or `Cargo.toml`
version change in this PR.

## What changed

- `CHANGELOG.md`: adds the `v0.10.0` section covering the 82 commits since
  `v0.9.1`, grouped by theme, with an upgrade-notes block.
- `docs/releases/v0.10.0.md`: full release notes in the established format
  (Highlights / Upgrade notes / Validation / Release steps / Further reading
  / Traceability).
- `README.md`: version badge and current-state line `v0.9.1` → `v0.10.0`;
  adds the `docs/releases/v0.10.0.md` link and retains the `v0.9.1` and
  `v0.8.1` links; corrects the approved-spec count `105` → `133` to match
  `specs/governance/approved-specs.json`.

## Why

`main` carries 82 commits since `v0.9.1` (28 `feat`, 5 `fix`), including
governed runtime workflow composition (specs 108–113), the durable trace
journal (spec 079 / ADR-0045), browser-hosted verified execution (spec 023),
host-owned verified registry metadata (spec 120 / ADR-0051), privacy-preserving
authoring telemetry, the bounded native WASI profile (spec 181), mediated
local connectors, and stricter publish gates (contract surface coverage,
capability risk metadata). None of it is discoverable from the release-facing
docs, and the README still advertises `v0.9.1` with a stale spec count.

## Governing Spec

- `060-wasm-resource-limits`
- `190-readme-rewrite`
- `065-sigstore-bundle-verification`

Release-facing documentation alignment for existing, already-governed
behavior; the release itself is governed by `048-semver-publishing-pipeline`.
No runtime or contract behavior changes.

## Project Item

Closes #1229.

## Depends on

none

## Blocked by

The **version bump itself is blocked** and is intentionally not in this PR.
`traverse-registry 0.17.0` (pinned `=0.17.0` in `Cargo.toml`) requires
`traverse-contracts = ">=0.8.1, <0.10.0"`. Bumping the workspace
`traverse-contracts` to `0.10.0` pulls the published `0.9.1` alongside the
local `0.10.0` and the workspace no longer compiles. Cutting `v0.10.0`
requires a `traverse-registry` release from `traverse-framework/registry`
whose `traverse-contracts` requirement admits `0.10.0`, then pinning that
version here, then running `bash scripts/ci/bump_version.sh 0.10.0`.

## Definition of done

- `CHANGELOG.md` has a `v0.10.0` section.
- `docs/releases/v0.10.0.md` exists and follows the release-notes format.
- README version references point at `v0.10.0`; `repository_checks`
  release-notes references still pass.
- No `Cargo.toml` version change in this PR.

## Validation

- `bash scripts/ci/repository_checks.sh`
- `bash scripts/ci/spec_alignment_check.sh <pr-body>`
- `cargo build --workspace`
- `git diff --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
