### PR TITLE
chore: bump version to v0.10.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2701,9 +2701,9 @@ dependencies = [
 
 [[package]]
 name = "traverse-registry"
-version = "0.17.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc6c6b7d3f23660a9a2f58f4eb5b038f954b80eae15c0e6082a4522615e6601f"
+checksum = "a37f764c419f487496576cf8d013f09acd8449254ca72e81e13faf66b4be6686"
 dependencies = [
  "semver",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,14 +16,14 @@ edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/traverse-framework/traverse"
 rust-version = "1.94"
-version = "0.9.1"
+version = "0.10.0"
 
 [workspace.dependencies]
-traverse-contracts = { path = "crates/traverse-contracts", version = "0.9.1" }
+traverse-contracts = { path = "crates/traverse-contracts", version = "0.10.0" }
 traverse-registry = { version = "=0.18.0" }
-traverse-runtime = { path = "crates/traverse-runtime", version = "0.9.1" }
-traverse-embedder = { path = "crates/traverse-embedder", version = "0.9.1" }
-traverse-mcp = { path = "crates/traverse-mcp", version = "0.9.1" }
+traverse-runtime = { path = "crates/traverse-runtime", version = "0.10.0" }
+traverse-embedder = { path = "crates/traverse-embedder", version = "0.10.0" }
+traverse-mcp = { path = "crates/traverse-mcp", version = "0.10.0" }
 
 # The published registry crate pins the current contracts release.  During
 # Traverse development, resolve that transitive dependency to this workspace's

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ version = "0.9.1"
 
 [workspace.dependencies]
 traverse-contracts = { path = "crates/traverse-contracts", version = "0.9.1" }
-traverse-registry = { version = "=0.17.0" }
+traverse-registry = { version = "=0.18.0" }
 traverse-runtime = { path = "crates/traverse-runtime", version = "0.9.1" }
 traverse-embedder = { path = "crates/traverse-embedder", version = "0.9.1" }
 traverse-mcp = { path = "crates/traverse-mcp", version = "0.9.1" }


### PR DESCRIPTION
## Summary

Pins `traverse-registry` to `0.18.0` and bumps the workspace version to
`0.10.0` via `scripts/ci/bump_version.sh`. This is the mechanical release
commit for v0.10.0; the release notes, changelog, and README already landed
in #1230.

## What changed

- `Cargo.toml` / `Cargo.lock`: `traverse-registry` `=0.17.0` → `=0.18.0`.
  `0.18.0` widens its `traverse-contracts` requirement to
  `">=0.8.1, <0.11.0"` (traverse-framework/registry#352), without which the
  `[patch.crates-io]` redirect of `traverse-contracts` to the local `0.10.0`
  path crate is rejected and the workspace fails to compile.
- `Cargo.toml`: `[workspace.package] version` and the `traverse-*`
  `[workspace.dependencies]` path-crate versions `0.9.1` → `0.10.0`
  (produced by `scripts/ci/bump_version.sh 0.10.0`).

## Why

`main` carries 80+ commits since `v0.9.1` (governed runtime workflow
composition, durable trace journal, browser-hosted verified execution,
host-owned verified registry metadata, authoring telemetry, bounded native
WASI profile, mediated connectors, stricter publish gates). They are
unreleased and not on crates.io. The version bump was previously blocked by
the published `traverse-registry` `traverse-contracts` upper bound; that is
resolved with `0.18.0`.

## Governing Spec

- `048-semver-publishing-pipeline`
- `045-governed-model-dependency-resolution`

Mechanical version bump under the established publishing pipeline; no runtime,
contract, or API behavior changes.

## Project Item

Closes #1231.

## Depends on

- traverse-framework/registry#352 — `traverse-registry 0.18.0`, published to
  crates.io.

## Blocked by

not blocked

## Definition of done

- `traverse-registry` pinned at `=0.18.0`; `cargo build --workspace` green
  with the workspace at `0.10.0`.
- `[workspace.package] version = "0.10.0"`.
- CI green on this PR (`version-guard` passes without a release tag on PR
  runs).
- After merge: `v0.10.0` tag created on the merged `main` commit and pushed,
  triggering `version-guard` then `publish`.

## Validation

- `cargo build --workspace`
- `bash scripts/ci/repository_checks.sh`
- `bash scripts/ci/local_preflight.sh --pr <number>`
- `bash scripts/ci/spec_alignment_check.sh <pr-body>`
- `git diff --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
