### PR TITLE
chore: sync Cargo.lock to v0.10.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2619,7 +2619,7 @@ dependencies = [
 
 [[package]]
 name = "traverse-cli-rs"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "chrono",
  "ed25519-dalek",
@@ -2647,7 +2647,7 @@ dependencies = [
 
 [[package]]
 name = "traverse-contracts"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "semver",
  "serde",
@@ -2657,7 +2657,7 @@ dependencies = [
 
 [[package]]
 name = "traverse-embedder"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "semver",
  "serde",
@@ -2671,7 +2671,7 @@ dependencies = [
 
 [[package]]
 name = "traverse-expedition-wasm"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -2679,7 +2679,7 @@ dependencies = [
 
 [[package]]
 name = "traverse-mcp"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "ed25519-dalek",
  "semver",
@@ -2693,7 +2693,7 @@ dependencies = [
 
 [[package]]
 name = "traverse-native-bridge"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "sha2 0.11.0",
  "wat",
@@ -2714,7 +2714,7 @@ dependencies = [
 
 [[package]]
 name = "traverse-runtime"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "aes-gcm",
  "chrono",
@@ -2736,7 +2736,7 @@ dependencies = [
 
 [[package]]
 name = "traverse-swift-host"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "serde_json",
  "sha2 0.11.0",


### PR DESCRIPTION
## Summary

Syncs `Cargo.lock` to the v0.10.0 workspace version. Follow-up to #1232.

## What changed

- `Cargo.lock`: the 8 workspace path crates (`traverse-cli-rs`,
  `traverse-contracts`, `traverse-embedder`, `traverse-expedition-wasm`,
  `traverse-mcp`, `traverse-native-bridge`, `traverse-runtime`,
  `traverse-swift-host`) `0.9.1` → `0.10.0`. Version lines only — no
  dependency graph or resolution changes.

## Why

`scripts/ci/bump_version.sh` only rewrites `Cargo.toml` (it aborts if the
bump touches any other file). #1232 therefore merged with `Cargo.toml` at
`0.10.0` but `Cargo.lock` still pinning the workspace crates at `0.9.1`. Any
`--locked` build or `cargo metadata --locked` on `main` now fails, and the
`v0.10.0` tag / crates.io publish must go out against a consistent lockfile.

## Governing Spec

- `048-semver-publishing-pipeline`
- `045-governed-model-dependency-resolution`

Mechanical lockfile sync under the publishing pipeline; no behavior change.

## Project Item

Part of #1231.

## Depends on

- #1232 (merged) — the `Cargo.toml` v0.10.0 bump.

## Blocked by

not blocked

## Definition of done

- `Cargo.lock` workspace crate versions read `0.10.0`.
- `cargo build --workspace --locked` succeeds.
- `cargo metadata --locked` succeeds.
- CI green.

## Validation

- `cargo build --workspace --locked`
- `cargo metadata --locked`
- `bash scripts/ci/local_preflight.sh --pr <number>`
- `git diff --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
