### PR TITLE
docs: fix stale version references after v0.10.0

### DIFF
--- a/docs/compatibility-policy.md
+++ b/docs/compatibility-policy.md
@@ -23,7 +23,7 @@ At `v1.0.0`, Traverse makes the following stability commitments:
 **Public API (stable — semver guarantees apply):**
 - `traverse-runtime`: `CapabilityExecutor`, `ExecutorCapability`, `ExecutorError`, `ArtifactType`, `PlacementRouter`, `RouterRequest`, `RouterResponse`, `TraceStore`, `TraceOutcome`
 - `traverse-contracts`: all public contract types (`CapabilityContract`, `EventContract`, etc.)
-- `traverse-registry` v0.9.0 is consumed as a separately published registry crate; its public API compatibility is governed in `traverse-framework/registry`.
+- `traverse-registry` (currently v0.18.0) is consumed as a separately published registry crate; its public API compatibility is governed in `traverse-framework/registry`.
 - `traverse-cli`: all documented CLI subcommands and their `--json` output shapes
 - `traverse-mcp`: `discover_capabilities()`, `execute_capability()` library surface
 

--- a/docs/native-runtime-artifact-registry.md
+++ b/docs/native-runtime-artifact-registry.md
@@ -28,7 +28,7 @@ use traverse_registry::{
 };
 
 let record = NativeRuntimeArtifactRecord {
-    runtime_version: "0.9.0".to_string(),
+    runtime_version: "0.10.0".to_string(),
     bridge_version: "1.1.0".to_string(),
     supported_bridge_range: ">=1.1.0,<2.0.0".to_string(),
     sha256: "<runtime.wasm digest>".to_string(),


### PR DESCRIPTION
## Summary

Fixes two stale hardcoded version references missed by the v0.10.0 release
docs pass (#1230).

## What changed

- `docs/compatibility-policy.md`: `traverse-registry` `v0.9.0` → `v0.18.0`.
  It is published from `traverse-framework/registry` and is long past 0.9.0
  (0.18.0 shipped alongside this release).
- `docs/native-runtime-artifact-registry.md`: the
  `NativeRuntimeArtifactRecord` example's `runtime_version` `"0.9.0"` →
  `"0.10.0"` so it tracks the current runtime release.

## Why

The README, CHANGELOG, and `docs/releases/v0.10.0.md` were updated for
v0.10.0, but these two references were not. `rg -n '0\.9\.[0-9]' README.md
docs --glob '!docs/releases/**'` now only matches the intentional
"prior release notes" link to `docs/releases/v0.9.1.md`.

## Governing Spec

- `049-v1-milestone-gate`
- `075-native-runtime-distribution-contract`
- `065-sigstore-bundle-verification`

`compatibility-policy.md` is covered by `049`; `native-runtime-artifact-registry.md`
by `075`; `065` covers both. Documentation accuracy only; no code or behavior
change.

## Project Item

Closes #1237.

## Depends on

none

## Blocked by

not blocked

## Definition of done

- No stale `traverse-registry` / runtime version literals in `README.md` or
  `docs/` outside `docs/releases/`.
- `bash scripts/ci/repository_checks.sh` passes.

## Validation

- `rg -n '0\.9\.[0-9]' README.md docs --glob '!docs/releases/**'` → only the
  `docs/releases/v0.9.1.md` prior-notes link
- `bash scripts/ci/repository_checks.sh` → passes
- `git diff --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
