### PR TITLE
docs: rewrite README as product-first

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,35 +4,80 @@
 # Traverse
 
 [![CI](https://github.com/traverse-framework/traverse/actions/workflows/ci.yml/badge.svg)](https://github.com/traverse-framework/traverse/actions/workflows/ci.yml)
-[![Coverage](https://img.shields.io/badge/coverage-100%25-brightgreen)](https://github.com/traverse-framework/traverse/actions/workflows/ci.yml)
+[![Coverage](https://img.shields.io/badge/coverage-core%20100%25-brightgreen)](https://github.com/traverse-framework/traverse/actions/workflows/ci.yml)
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue)](LICENSE)
 [![Rust](https://img.shields.io/badge/rust-1.94%2B-orange)](https://www.rust-lang.org/)
 [![Version](https://img.shields.io/badge/version-v0.10.0-blue)](https://github.com/traverse-framework/traverse/releases)
-[![Registry](https://img.shields.io/badge/registry-live%20catalog-6f42c1)](https://registry.traverse-framework.com/)
+[![Registry](https://img.shields.io/badge/registry-46%20capabilities-6f42c1)](https://registry.traverse-framework.com/)
 
-Your business logic runs in the browser, on your server, and in a cloud function.
-They drift. You maintain three versions of the same behavior.
-Traverse keeps it in one contract and runs it anywhere — with a full execution trace every time.
+**Define once. Run anywhere.**
 
-Traverse is the working implementation of [Universal Microservices Architecture](https://www.universalmicroservices.com/).
+Traverse is a contract-driven WebAssembly runtime for portable business
+capabilities. You write a piece of business logic once — as a capability with a
+machine-readable contract — and the same signed WASM binary runs natively, in
+the browser, and inside an AI agent, producing a verifiable execution trace
+every time.
+
+No reimplementation per environment. No agent free-handing your pricing rules.
+One behavior, governed, everywhere it needs to run.
 
 ---
 
-## Current State & Roadmap
+## Why this matters
 
-Traverse is pre-1.0 (`v0.10.0`) and evolving under spec-driven governance — every capability below is real, running code, not a plan.
+Business logic no longer lives in one place. The same eligibility check,
+pricing rule, or approval policy now has to run in a web client, on a server,
+at the edge, and — increasingly — inside an AI agent that a user is talking to.
+Teams answer that by reimplementing the rule in each stack. The copies drift.
+The behavior stops being one thing.
 
-- **8 crates in this repo** plus the capability registry (now its own repo, see below) — 7 of these 9 are [published on crates.io](https://crates.io/search?q=traverse-): runtime, contracts, registry, CLI, MCP server, embedder SDK, and the expedition WASM example. `traverse-native-bridge` and `traverse-swift-host` are newer, not yet published.
-- **133 approved, immutable specs** govern the runtime, contracts, registry, MCP surface, WASM execution, native embedding, event delivery, and durable local storage. Full list: `jq -r '.specs[].id' specs/governance/approved-specs.json` (or see [Governance](#governance) below).
-- **100% coverage enforced on core logic**, spec-alignment and supply-chain gates on every PR, 5-platform CI matrix (Linux x86_64/aarch64, macOS x86_64/arm64, Windows x86_64).
-- **Capability registry** was extracted into its own repo, [`traverse-framework/registry`](https://github.com/traverse-framework/registry), so capabilities can be published, versioned, and consumed independently of the runtime. Browse what's actually published at the live catalog: **[registry.traverse-framework.com](https://registry.traverse-framework.com/)**.
-- **Reference apps** for multiple platforms (web, iOS, macOS, Android, Windows, Linux, CLI) live in [`traverse-framework/reference-apps`](https://github.com/traverse-framework/reference-apps).
+AI coding agents make this sharper, not softer. An agent asked to "add the
+discount logic" will re-derive that logic from scratch, in prose, every
+session — unversioned, unreviewed, and authoritative only because it ran last.
 
-### Where this is going: v1.0.0
+Traverse takes the other position: **the agent proposes, the runtime decides.**
+A capability is a contract (JSON Schema in, JSON Schema out), an immutable
+version, a signature, and a WASM artifact. The runtime validates every input
+against the contract, isolates execution in a WASM sandbox, enforces policy,
+and emits a trace you can audit. An agent's job is to *find and compose* the
+right capabilities — not to be the source of truth for what the business does.
 
-v1.0.0 is gated, not a date — governed by [`spec 049-v1-milestone-gate`](specs/049-v1-milestone-gate/spec.md) and checkable locally with `bash scripts/ci/v1_gate_check.sh`. It signals stable public API surfaces, every published crate live on crates.io, and the runtime stress-tested on every supported platform. Full gate conditions: [docs/v1-milestone.md](docs/v1-milestone.md).
+This is the working implementation of
+[Universal Microservices Architecture](https://www.universalmicroservices.com/):
+write once, run where it makes sense, keep the decisions queryable instead of
+buried in a framework.
 
-Explicitly **not** required for v1.0.0: a reference app in this repo (that's `reference-apps`), an HTTP admin API, a cloud deployment surface, or worker-isolation message passing (planned for v2).
+---
+
+## Reuse instead of regenerate
+
+The [public registry](https://registry.traverse-framework.com/) currently holds
+**46 capabilities across 24 domains** (117 published versions) — pricing,
+authorization, escalation, deadline pressure, completion-quality scoring,
+classification, summarization, and more. Every record is contract-defined,
+semver'd, signed, and CI-validated before it merges.
+
+Before an agent (or a developer) writes a rule, it can check whether that rule
+already exists:
+
+```bash
+traverse-cli registry sync   --workspace local-default --json   # pull the index locally
+traverse-cli registry search price --workspace local-default --json
+traverse-cli registry list   --workspace local-default --json
+```
+
+Find `core.calculate-price@1.1.0`, compose it into a workflow, done. What you
+*don't* spend tokens or review cycles on:
+
+- re-deriving the input/output contract
+- re-implementing and re-testing the logic
+- re-reviewing a fresh, unverified copy of a rule the org already agreed on
+
+The same discovery surface is exposed over MCP, so an AI client can list and
+call governed capabilities directly. The
+[claude-skills](https://github.com/traverse-framework/claude-skills) skill set
+makes "check the registry first" the default step, so agents stop duplicating
+what's already published.
 
 ---
 
@@ -57,83 +102,174 @@ events: 5
 workflows: 1
 ```
 
-You just inspected a live capability bundle — 6 capabilities, 5 events, 1 workflow, all defined in contracts that the runtime validates and executes.
+You just inspected a live capability bundle — 6 capabilities, 5 events, 1
+workflow, all defined in contracts the runtime validates and executes. From
+here:
 
-Ready to run the full browser demo? → [quickstart.md](quickstart.md)
-
----
-
-## What Can I Build?
-
-### A browser app with governed runtime behavior
-
-Build the UI. Traverse owns execution, workflow state, and trace output.
-The same capability contract runs locally in development and on the edge in production — no rewrite.
-
-→ [quickstart.md](quickstart.md) · [docs/app-consumable-entry-path.md](docs/app-consumable-entry-path.md)
-
-### A governed MCP server
-
-Expose capability discovery and execution over stdio. Downstream AI clients and tools
-discover and call governed capabilities without touching your internals.
-
-→ [docs/mcp-stdio-server.md](docs/mcp-stdio-server.md)
-
-### Portable WASM capabilities
-
-Package executable behavior as WASM. Traverse validates, places, and runs it —
-browser, edge, or cloud — under the same contract.
-
-→ [docs/wasm-agent-authoring-guide.md](docs/wasm-agent-authoring-guide.md)
-
-### An app with an AI coding agent
-
-Building with Claude or another coding agent? [traverse-framework/claude-skills](https://github.com/traverse-framework/claude-skills) hosts Claude Skills that walk through checking the registry, authoring and composing capabilities, and validating them against the real `traverse-cli` — including this platform's current honest limitations.
-
-### Workflow-backed business logic
-
-Model multi-step business behavior as a workflow. The runtime traverses it
-deterministically and produces a structured trace you can inspect and audit.
-
-→ [docs/workflow-composition-guide.md](docs/workflow-composition-guide.md) · [docs/getting-started.md](docs/getting-started.md)
-
-### Publish a reusable capability
-
-Author, validate, and publish an executable WASM capability through the governed registry flow. Publishing validates the contract, use-case coverage, artifact digest, and referenced personas before creating the reviewable registry change.
-
-→ [docs/capability-publish.md](docs/capability-publish.md) · [docs/capability-contract-authoring-guide.md](docs/capability-contract-authoring-guide.md)
-
-### Your own app bundle
-
-```bash
-cargo run -p traverse-cli-rs -- app new my-app
-```
-
-Scaffolds a governed app bundle. Add your capability contracts, workflows, and WASM components.
-
-→ [docs/expedition-example-authoring.md](docs/expedition-example-authoring.md)
+- Run it end to end and see the trace → [docs/getting-started.md](docs/getting-started.md)
+- Full browser + HTTP walkthrough → [quickstart.md](quickstart.md)
+- Author your own capability → [docs/capability-contract-authoring-guide.md](docs/capability-contract-authoring-guide.md)
 
 ---
 
-## Documentation
+## Where it runs
 
-### Onboarding and tutorial path
+The same capability contract and WASM artifact, four ways — none of them
+privileged over the others:
 
-| Goal | Start here | Continue with |
+| Target | How | Guide |
 |---|---|---|
-| First runnable flow | [quickstart.md](quickstart.md) | [docs/app-consumable-entry-path.md](docs/app-consumable-entry-path.md) |
-| Learn the core path | [docs/getting-started.md](docs/getting-started.md) | [docs/expedition-example-authoring.md](docs/expedition-example-authoring.md) |
-| Author a capability contract | [docs/capability-contract-authoring-guide.md](docs/capability-contract-authoring-guide.md) | [docs/getting-started.md](docs/getting-started.md) |
-| Author an event contract | [docs/event-contract-authoring-guide.md](docs/event-contract-authoring-guide.md) | [docs/event-publishing-tutorial.md](docs/event-publishing-tutorial.md) |
-| Build WASM capabilities | [docs/wasm-agent-authoring-guide.md](docs/wasm-agent-authoring-guide.md) | [docs/wasm-microservice-authoring-guide.md](docs/wasm-microservice-authoring-guide.md) |
-| Integrate a downstream app | [docs/app-consumable-consumer-bundle.md](docs/app-consumable-consumer-bundle.md) | [docs/youaskm3-integration-validation.md](docs/youaskm3-integration-validation.md) |
-| Troubleshoot a failure | [docs/troubleshooting.md](docs/troubleshooting.md) | [docs/quality-standards.md](docs/quality-standards.md) |
+| **Native / server** | Embed the Rust runtime (`traverse-embedder`, `embedder-api/1.0.0`) or invoke `traverse-cli` per request | [docs/wasm-microservice-authoring-guide.md](docs/wasm-microservice-authoring-guide.md) |
+| **AI agent** | `traverse-mcp` stdio server — agents discover and call governed capabilities over MCP | [docs/mcp-stdio-server.md](docs/mcp-stdio-server.md) · [docs/mcp-real-agent-exercise.md](docs/mcp-real-agent-exercise.md) |
+| **Browser** | The runtime compiles to WASM; the app owns the UI, Traverse owns execution, state, and trace | [quickstart.md](quickstart.md) |
+| **Your own app bundle** | `traverse-cli app new <id>` scaffolds a governed bundle of contracts, workflows, and components | [docs/expedition-example-authoring.md](docs/expedition-example-authoring.md) |
 
-### Consumer and release surfaces
+Edge and cloud placement targets are on the roadmap, not shipped.
+
+---
+
+## Project state
+
+Traverse is **pre-1.0 (`v0.10.0`)** and spec-driven — every capability below is
+real, running, tested code.
+
+| | |
+|---|---|
+| **Runtime crates** | 8 in this repo; 6 published to [crates.io](https://crates.io/search?q=traverse-) at `0.10.0` (`traverse-contracts`, `traverse-runtime`, `traverse-embedder`, `traverse-mcp`, `traverse-cli-rs`, `traverse-expedition-wasm`). `traverse-native-bridge` and `traverse-swift-host` are newer and not yet published. |
+| **Registry** | [`traverse-framework/registry`](https://github.com/traverse-framework/registry) — its own repo (spec 051). `traverse-registry` `0.18.0` on crates.io; **46 capabilities / 117 versions / 24 domains** in the live catalog, all signed and CI-validated. |
+| **Governance** | **133 approved, immutable specs** gate the runtime, contracts, registry, MCP surface, WASM execution, native embedding, event delivery, and durable local storage. `jq -r '.specs[].id' specs/governance/approved-specs.json` |
+| **Quality bar** | 100% line coverage enforced on the core crates (`traverse-contracts`, `traverse-runtime`, `traverse-embedder`); `traverse-cli-rs` 87%, `traverse-mcp` 98%. Spec-alignment and supply-chain gates on every PR. 5-target CI matrix: Linux x86_64/aarch64, macOS x86_64/arm64, Windows x86_64. |
+| **Reference apps** | Web, iOS, macOS, Android, Windows, Linux, and CLI clients live in [`traverse-framework/reference-apps`](https://github.com/traverse-framework/reference-apps). |
+| **Latency** | No container runtime; one binary per platform. Measured cold-start and steady-state methodology in [docs/benchmarks.md](docs/benchmarks.md). |
+
+### Toward v1.0.0
+
+v1.0.0 is **gated, not dated** — governed by
+[`spec 049-v1-milestone-gate`](specs/049-v1-milestone-gate/spec.md), checkable
+with `bash scripts/ci/v1_gate_check.sh`. It signals stable public API surfaces,
+every published crate live on crates.io, and the runtime stress-tested on every
+supported platform. Full conditions: [docs/v1-milestone.md](docs/v1-milestone.md).
+
+Explicitly **not** required for v1.0.0: a reference app in this repo (that's
+`reference-apps`), an HTTP admin API, a cloud deployment surface, or
+worker-isolation message passing (v2).
+
+---
+
+## How it works
+
+| Crate | Role |
+|---|---|
+| `traverse-runtime` | Core execution engine — validates, places, and executes capabilities |
+| `traverse-contracts` | Contract definitions, parsing, and validation |
+| `traverse-cli-rs` | Command-line interface (binary: `traverse-cli`) — register, list, validate, run |
+| `traverse-mcp` | Model Context Protocol stdio server and governed MCP-facing surface |
+| `traverse-embedder` | Public Rust embedder SDK (`embedder-api/1.0.0`) for Linux GTK and CLI clients |
+| `traverse-expedition-wasm` | Expedition example domain compiled to `wasm32-wasi` |
+| `traverse-native-bridge` | Deterministic builder for the governed native runtime WebAssembly bridge |
+| `traverse-swift-host` | Apple static-library feasibility host for the Traverse runtime bridge |
+
+`traverse-registry` (capability and event registries with deterministic
+traversal) lives in [`traverse-framework/registry`](https://github.com/traverse-framework/registry)
+so capabilities publish and version independently of the runtime. The runtime
+never talks to that repo live — `traverse-cli registry sync` pulls a signed
+index artifact into local workspace state, and execution reads local state
+only.
+
+Boundaries and portability rules: [docs/adapter-boundaries.md](docs/adapter-boundaries.md) ·
+[docs/compatibility-policy.md](docs/compatibility-policy.md) ·
+[docs/decision-log.md](docs/decision-log.md).
+
+---
+
+## For Agents
+
+This project supports AI-assisted development with Codex and Claude Code running
+in parallel.
+
+| Agent | File | Purpose |
+|---|---|---|
+| Claude Code | [`CLAUDE.md`](CLAUDE.md) | Project context, governance rules, speckit workflow |
+| Codex | [`AGENTS.md`](AGENTS.md) | Project context, coordination rules, speckit workflow |
+| All agents | [`.specify/memory/constitution.md`](.specify/memory/constitution.md) | Governing constitution — mirrors [`traverse-framework/.github`](https://github.com/traverse-framework/.github) at the version in [`.governance-version`](.governance-version) |
+
+Workflow: read your entry-point file → claim the ticket (check `agent:claude` /
+`agent:codex` labels and existing branches) → branch `NNN-feature-name` → write
+`specs/<branch>/spec.md` before code → implement the smallest change that
+satisfies the spec → open a PR with `## Governing Spec`, `## Project Item`, and
+`## Validation` sections. Full rules: [`docs/multi-thread-workflow.md`](docs/multi-thread-workflow.md).
+
+---
+
+## Governance
+
+Code must align with an approved, immutable spec or it does not merge.
+
+| Artifact | Location | Role |
+|---|---|---|
+| Specs | [`specs/`](specs/) | Versioned, immutable, merge-gating |
+| Contracts | [`contracts/`](contracts/) | Source of truth for runtime behavior |
+| Constitution | [`.specify/memory/constitution.md`](.specify/memory/constitution.md) | Overrides all convenience decisions |
+| CI gate | [`scripts/ci/spec_alignment_check.sh`](scripts/ci/spec_alignment_check.sh) | Deterministic, AI-agnostic |
+
+Start with [001-foundation-v0-1](specs/001-foundation-v0-1/spec.md) (core
+runtime, CLI, MCP surface), [004-spec-alignment-gate](specs/004-spec-alignment-gate/spec.md)
+(the CI gate), and [049-v1-milestone-gate](specs/049-v1-milestone-gate/spec.md)
+(what v1.0.0 requires).
+
+[GitHub Project 1](https://github.com/orgs/traverse-framework/projects/1/) is
+the canonical board — all active work has an issue, a project item, and a PR.
+
+---
+
+## Contributing
+
+Read [CONTRIBUTING.md](CONTRIBUTING.md), [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md),
+[SECURITY.md](SECURITY.md), and [docs/quality-standards.md](docs/quality-standards.md)
+before opening a PR. Every PR must be backed by an approved spec.
+
+Common starting points: [docs/getting-started.md](docs/getting-started.md) ·
+[docs/troubleshooting.md](docs/troubleshooting.md) ·
+[docs/what-can-i-build.md](docs/what-can-i-build.md).
+
+---
+
+## Built on UMA
+
+| | UMA | Traverse |
+|---|---|---|
+| What it is | Architecture model + book | Working runtime implementation |
+| Business capabilities | Defines the concept | Executes them with contracts and specs |
+| Portability | Describes the pattern | Enforces it through WASM and adapters |
+| Governance | Specifies the rules | Immutable specs and CI gates |
+| AI safety | Describes requirements | Explainable runtime traces |
+
+Read the [UMA book](https://www.universalmicroservices.com/) and the
+[UMA code examples](https://github.com/enricopiovesan/UMA-code-examples).
+
+---
+
+<details>
+<summary><strong>Full documentation index</strong></summary>
+
+### Authoring
+
+- [docs/capability-contract-authoring-guide.md](docs/capability-contract-authoring-guide.md) — capability contracts
+- [docs/event-contract-authoring-guide.md](docs/event-contract-authoring-guide.md) — event contracts
+- [docs/wasm-agent-authoring-guide.md](docs/wasm-agent-authoring-guide.md) — WASM capability authoring
+- [docs/wasm-microservice-authoring-guide.md](docs/wasm-microservice-authoring-guide.md) — WASM microservice authoring
+- [docs/workflow-composition-guide.md](docs/workflow-composition-guide.md) — composing workflows
+- [docs/capability-publish.md](docs/capability-publish.md) — publishing to the registry
+- [docs/expedition-example-authoring.md](docs/expedition-example-authoring.md) — worked example
+
+### Releases
 
 - [docs/releases/v0.10.0.md](docs/releases/v0.10.0.md) — current release notes
 - [docs/releases/v0.9.1.md](docs/releases/v0.9.1.md) — prior release notes
 - [docs/releases/v0.8.1.md](docs/releases/v0.8.1.md) — prior release notes
+
+### Consumer and packaging paths
+
 - [docs/app-consumable-consumer-bundle.md](docs/app-consumable-consumer-bundle.md) — versioned consumer bundle
 - [docs/app-consumable-package-release-pointer.md](docs/app-consumable-package-release-pointer.md) — package release pointer
 - [docs/packaged-traverse-runtime-artifact.md](docs/packaged-traverse-runtime-artifact.md) — packaged runtime artifact
@@ -159,117 +295,10 @@ Scaffolds a governed app bundle. Add your capability contracts, workflows, and W
 - [docs/compatibility-policy.md](docs/compatibility-policy.md) — versioning and compatibility
 - [docs/troubleshooting.md](docs/troubleshooting.md) — shortest path through common failures
 - [docs/what-can-i-build.md](docs/what-can-i-build.md) — concrete app and integration patterns
-- [docs/benchmarks.md](docs/benchmarks.md) — measured latency numbers
+- [docs/benchmarks.md](docs/benchmarks.md) — measured latency methodology
 - [docs/decision-log.md](docs/decision-log.md) — consolidated architecture decisions
 
----
-
-## Architecture
-
-### Crates
-
-In this repo:
-
-| Crate | Role |
-|---|---|
-| `traverse-runtime` | Core execution engine — validates, places, and executes capabilities |
-| `traverse-contracts` | Contract definitions, parsing, and validation |
-| `traverse-cli-rs` | Command-line interface (binary: `traverse-cli`) — register, list, validate, run |
-| `traverse-mcp` | Model Context Protocol stdio server and governed MCP-facing surface |
-| `traverse-embedder` | Public Rust embedder SDK (`embedder-api/1.0.0`) for Linux GTK and CLI clients |
-| `traverse-expedition-wasm` | Expedition example domain compiled to `wasm32-wasi` |
-| `traverse-native-bridge` | Deterministic builder for the governed native runtime WebAssembly bridge |
-| `traverse-swift-host` | Apple static-library feasibility host for the Traverse runtime bridge |
-
-In a separate repo:
-
-| Crate | Repo | Role |
-|---|---|---|
-| `traverse-registry` | [`traverse-framework/registry`](https://github.com/traverse-framework/registry) | Capability and event registries with deterministic traversal — extracted from this repo (spec 051) so capabilities can be published and versioned independently. Live catalog: [registry.traverse-framework.com](https://registry.traverse-framework.com/) |
-
----
-
-## Contributing
-
-Please read before opening a PR:
-
-- [CONTRIBUTING.md](CONTRIBUTING.md)
-- [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)
-- [SECURITY.md](SECURITY.md)
-- [docs/quality-standards.md](docs/quality-standards.md)
-
-All work follows the governance workflow below. Every PR must be backed by an approved spec.
-
-[GitHub Project 1](https://github.com/orgs/traverse-framework/projects/1/) is the canonical board. All active work has an issue, a project item, and a PR.
-
----
-
-## Built on UMA
-
-Traverse is the runtime that [Universal Microservices Architecture](https://www.universalmicroservices.com/) describes — the answer in working Rust code to the question: *how do you keep one business behavior portable and governed as execution moves across browser, edge, cloud, workflows, and AI?*
-
-| | UMA | Traverse |
-|---|---|---|
-| What it is | Architecture model + book | Working runtime implementation |
-| Business capabilities | Defines the concept | Executes them with contracts and specs |
-| Portability | Describes the pattern | Enforces it through WASM and adapters |
-| Governance | Specifies the rules | Implements them as immutable specs and CI gates |
-| AI safety | Describes requirements | Delivers through explainable runtime traces |
-
-**If you want to understand the ideas:** [read the UMA book](https://www.universalmicroservices.com/) and explore the [UMA code examples](https://github.com/enricopiovesan/UMA-code-examples).
-
----
-
-## Governance
-
-Traverse is spec-driven. Code must align with an approved, immutable spec or it does not merge.
-
-| Artifact | Location | Role |
-|---|---|---|
-| Specs | [`specs/`](specs/) | Versioned, immutable, merge-gating |
-| Contracts | [`contracts/`](contracts/) | Source of truth for runtime behavior |
-| Constitution | [`.specify/memory/constitution.md`](.specify/memory/constitution.md) | Overrides all convenience decisions |
-| CI gate | [`scripts/ci/spec_alignment_check.sh`](scripts/ci/spec_alignment_check.sh) | Deterministic, AI-agnostic |
-
-### Approved Specs
-
-133 approved specs currently govern this repo, spanning the runtime, contracts, registry integration, CLI, MCP surface, WASM execution, native embedding, event delivery, and durable local storage. The list changes as specs are approved — query it instead of reading a snapshot:
-
-```bash
-jq -r '.specs[].id' specs/governance/approved-specs.json
-```
-
-Foundational specs worth reading first: [001-foundation-v0-1](specs/001-foundation-v0-1/spec.md) (core runtime, CLI, MCP surface), [004-spec-alignment-gate](specs/004-spec-alignment-gate/spec.md) (this CI gate), [049-v1-milestone-gate](specs/049-v1-milestone-gate/spec.md) (what v1.0.0 requires).
-
----
-
-## For Agents
-
-This project supports AI-assisted development with Codex and Claude Code running in parallel.
-
-### Entry points
-
-| Agent | File | Purpose |
-|---|---|---|
-| Claude Code | [`CLAUDE.md`](CLAUDE.md) | Project context, governance rules, speckit workflow |
-| Codex | [`AGENTS.md`](AGENTS.md) | Project context, coordination rules, speckit workflow |
-| All agents | [`.specify/memory/constitution.md`](.specify/memory/constitution.md) | Governing constitution — mirrors [`traverse-framework/.github`](https://github.com/traverse-framework/.github) at the version in [`.governance-version`](.governance-version) |
-
-### Agent workflow
-
-1. **Read** your entry point file (`CLAUDE.md` or `AGENTS.md`)
-2. **Claim** the ticket — check for `agent:claude` / `agent:codex` labels and existing branches
-3. **Create** a feature branch: `NNN-feature-name`
-4. **Run** `.specify/scripts/bash/setup-plan.sh --json` to initialize the spec directory
-5. **Write** `specs/<branch>/spec.md` and `plan.md` before any code
-6. **Implement** the smallest change that satisfies the spec and contracts
-7. **Open** a PR with `## Governing Spec`, `## Project Item`, and `## Validation` sections
-
-### Agent coordination
-
-- `agent:claude` label = claimed by Claude Code — Codex must skip
-- `agent:codex` label = claimed by Codex — Claude Code must skip
-- Full coordination rules: [`docs/multi-thread-workflow.md`](docs/multi-thread-workflow.md)
+</details>
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@
 
 Traverse is a contract-driven WebAssembly runtime for portable business
 capabilities. You write a piece of business logic once — as a capability with a
-machine-readable contract — and the same signed WASM binary runs natively, in
-the browser, and inside an AI agent, producing a verifiable execution trace
-every time.
+machine-readable contract — and the same signed WASM binary runs on Linux,
+macOS, and Windows, on iOS and Android, in the browser, and inside an AI agent
+— producing a verifiable execution trace every time.
 
 No reimplementation per environment. No agent free-handing your pricing rules.
 One behavior, governed, everywhere it needs to run.
@@ -114,17 +114,34 @@ here:
 
 ## Where it runs
 
-The same capability contract and WASM artifact, four ways — none of them
-privileged over the others:
+One capability contract and one WASM artifact, executed the same way on every
+target through a platform embedder that speaks `embedder-api/1.0.0`. Each
+embedder digest-verifies the runtime, rejects ambient imports, and enforces the
+same Host ABI — the browser is one target among several, not the default.
 
-| Target | How | Guide |
-|---|---|---|
-| **Native / server** | Embed the Rust runtime (`traverse-embedder`, `embedder-api/1.0.0`) or invoke `traverse-cli` per request | [docs/wasm-microservice-authoring-guide.md](docs/wasm-microservice-authoring-guide.md) |
-| **AI agent** | `traverse-mcp` stdio server — agents discover and call governed capabilities over MCP | [docs/mcp-stdio-server.md](docs/mcp-stdio-server.md) · [docs/mcp-real-agent-exercise.md](docs/mcp-real-agent-exercise.md) |
-| **Browser** | The runtime compiles to WASM; the app owns the UI, Traverse owns execution, state, and trace | [quickstart.md](quickstart.md) |
-| **Your own app bundle** | `traverse-cli app new <id>` scaffolds a governed bundle of contracts, workflows, and components | [docs/expedition-example-authoring.md](docs/expedition-example-authoring.md) |
+| Platform | Embedder | WASM host | Status |
+|---|---|---|---|
+| **Linux / server / CLI** | `traverse-embedder` (Rust) · `traverse-cli` | Wasmtime | Published on crates.io |
+| **Browser** | `traverse-embedder-web` (TypeScript) | the browser's own `WebAssembly` | Published (npm) |
+| **iOS / macOS** | `packages/swift` — `TraverseEmbedder` Swift Package | WasmKit | In-repo package, CI-conformed; not yet on SwiftPM |
+| **Android** | `packages/kotlin` — `TraverseEmbedder` Android library | Chicory | In-repo package, CI-conformed; not yet on Maven |
+| **Windows / WinUI** | `packages/dotnet` — `TraverseEmbedder` .NET library | Wasmtime .NET | In-repo package, CI-conformed; not yet on NuGet |
+| **AI agent** | `traverse-mcp` stdio server | via the host embedder | Published on crates.io |
 
-Edge and cloud placement targets are on the roadmap, not shipped.
+All five embedders run against one CI-enforced conformance suite (spec
+`068-public-platform-embedder-packages`), so a capability that passes on one
+platform behaves the same on the rest. Desktop targets (Linux x86_64/aarch64,
+macOS x86_64/arm64, Windows x86_64) are covered by the CI matrix on every PR.
+
+**Cloud and edge** placement targets are specified and on the roadmap, not yet
+shipped.
+
+Scaffold your own governed bundle with `traverse-cli app new <id>` —
+[docs/expedition-example-authoring.md](docs/expedition-example-authoring.md).
+Guides: [docs/wasm-microservice-authoring-guide.md](docs/wasm-microservice-authoring-guide.md) ·
+[docs/mcp-stdio-server.md](docs/mcp-stdio-server.md) ·
+[docs/mcp-real-agent-exercise.md](docs/mcp-real-agent-exercise.md) ·
+[quickstart.md](quickstart.md).
 
 ---
 
@@ -136,6 +153,7 @@ real, running, tested code.
 | | |
 |---|---|
 | **Runtime crates** | 8 in this repo; 6 published to [crates.io](https://crates.io/search?q=traverse-) at `0.10.0` (`traverse-contracts`, `traverse-runtime`, `traverse-embedder`, `traverse-mcp`, `traverse-cli-rs`, `traverse-expedition-wasm`). `traverse-native-bridge` and `traverse-swift-host` are newer and not yet published. |
+| **Platform SDKs** | 5 embedders on one `embedder-api/1.0.0` contract and one CI conformance suite — Rust (crates.io) and Web/TypeScript (npm) published; Swift/iOS+macOS (WasmKit), Kotlin/Android (Chicory), and .NET/Windows (Wasmtime) in `packages/` with production runtime bridges, not yet on SwiftPM/Maven/NuGet. |
 | **Registry** | [`traverse-framework/registry`](https://github.com/traverse-framework/registry) — its own repo (spec 051). `traverse-registry` `0.18.0` on crates.io; **46 capabilities / 117 versions / 24 domains** in the live catalog, all signed and CI-validated. |
 | **Governance** | **133 approved, immutable specs** gate the runtime, contracts, registry, MCP surface, WASM execution, native embedding, event delivery, and durable local storage. `jq -r '.specs[].id' specs/governance/approved-specs.json` |
 | **Quality bar** | 100% line coverage enforced on the core crates (`traverse-contracts`, `traverse-runtime`, `traverse-embedder`); `traverse-cli-rs` 87%, `traverse-mcp` 98%. Spec-alignment and supply-chain gates on every PR. 5-target CI matrix: Linux x86_64/aarch64, macOS x86_64/arm64, Windows x86_64. |


### PR DESCRIPTION
## Summary

Rewrites the main README so it reads as a product, not an architecture doc.

## What changed

- **Leads with the value proposition** — "Define once. Run anywhere.", a
  contract-driven WASM runtime for portable business capabilities — aligned
  with traverse-framework.com.
- **New "Why this matters" section** — business logic is reimplemented per
  environment and drifts; AI agents re-derive it every session; Traverse's
  position is *agent proposes, runtime decides* (contract + sandbox + policy +
  trace).
- **New "Reuse instead of regenerate" section** — the registry holds 46
  capabilities / 117 versions / 24 domains; `traverse-cli registry
  sync|search|list` and the MCP discovery surface let an agent compose an
  existing signed capability instead of re-deriving the contract,
  re-implementing and re-testing the logic, and re-reviewing a fresh copy.
  Links the `claude-skills` "check the registry first" skill.
- **De-emphasizes the browser** — a "Where it runs" table presents native/
  server, AI agent, browser, and app-bundle targets as peers; edge/cloud
  called out as roadmap, not shipped.
- **Consolidated "Project state"** — one scannable table: v0.10.0, 8 crates (6
  published at 0.10.0), `traverse-registry` 0.18.0, 46/117/24 registry
  catalog, per-crate coverage (core crates 100%, CLI 87%, MCP 98%), 5-target
  CI matrix, reference apps, benchmark methodology link. No invented latency
  numbers.
- **Architecture detail moved below the product story** — crate table and the
  long consumer-path / v0.3.0 / youaskm3 doc lists are now in a collapsed
  "Full documentation index" so every `scripts/ci/repository_checks.sh` README
  assertion still resolves.
- **Preserved**: badge row (FR-001), human quick-start (FR-002), "For Agents"
  entry points — CLAUDE.md / AGENTS.md / constitution (FR-003), governance
  section, UMA framing.

## Why

The README is the top of the funnel for adopters, contributors, and AI agents
loading project context. It should communicate what Traverse is for and how
far along it is on the first screen. Every claim is grounded in the repo, the
registry catalog, or CI config.

## Governing Spec

- `190-readme-rewrite`
- `001-foundation-v0-1`

Documentation only; no runtime, contract, or CI gate changes.

## Project Item

Closes #1246.

## Depends on

none

## Blocked by

not blocked

## Definition of done

- README leads with product value and the future-of-dev thesis.
- Registry reuse / token-saving section present with real commands and numbers.
- FR-001/002/003 elements preserved.
- Every `scripts/ci/repository_checks.sh` README substring still present.
- `bash scripts/ci/repository_checks.sh` passes; spec-alignment passes.

## Validation

- `bash scripts/ci/repository_checks.sh` → passes
- `bash scripts/ci/spec_alignment_check.sh <pr-body>` → passes
- `bash scripts/ci/local_preflight.sh --pr <number>`
- `git diff --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
