### PR TITLE
ci: bump_version.sh keeps Cargo.lock in step; --locked guard in CI (#1236)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,28 @@ jobs:
 
           echo "Cargo.toml workspace version ${workspace_version} matches ${tag_name}."
 
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: 1.94.0
+
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@v2
+
+      - name: Verify Cargo.lock is in sync with Cargo.toml
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          # `scripts/ci/bump_version.sh` rewrites the workspace path-crate
+          # versions in both Cargo.toml and Cargo.lock. A desynced lockfile
+          # (e.g. a hand bump that misses Cargo.lock) still passes branch/PR
+          # CI today because nothing runs with --locked. Fail it here — on
+          # every push, PR, and release tag — so it can never reach the
+          # tag-only publish job's `cargo publish`.
+          cargo metadata --locked --format-version 1 > /dev/null
+          echo "Cargo.lock resolves cleanly under --locked; lockfile is in sync."
+
   repository-checks:
     needs: classify-changes
     if: needs.classify-changes.outputs.full_ci == 'true'

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -15,13 +15,24 @@ Use the release helper from a clean `main` checkout after CI is green:
 
 The version argument is `MAJOR.MINOR.PATCH` without a leading `v`. The helper
 refuses invalid versions, dirty working trees, and pre-existing local release
-tags. It updates only `[workspace.package] version` in `Cargo.toml`, creates the
-commit `chore: bump version to v<version>`, and creates the local tag
-`v<version>`. It does not push commits or tags.
+tags. It rewrites the version in two files and no others: `[workspace.package]
+version` (plus the matching `[workspace.dependencies]` path-crate `version =`
+pins) in `Cargo.toml`, and the `version = "…"` line of every workspace path
+crate in `Cargo.lock` (`[[package]]` entries named `traverse-*` with no
+`source` line; registry dependencies such as `traverse-registry` are left
+untouched). Both files land in one `chore: bump version to v<version>` commit,
+and the local tag `v<version>` is created. It does not push commits or tags.
+
+Keeping `Cargo.lock` in step matters: a lockfile left at the old version breaks
+every `--locked` build and blocks `cargo publish`. After running the helper,
+`cargo metadata --locked` must succeed with no lockfile change.
 
 On a tag push, the `version-guard` CI job compares the tag without the leading
 `v` to the workspace version in `Cargo.toml`. Branch and pull-request runs pass
 without a release tag, while mismatched release tags fail before publishing.
+The same job also runs `cargo metadata --locked` on every push, pull request,
+and tag, so a `Cargo.toml`/`Cargo.lock` version drift fails CI before it can
+reach the tag-only `publish` job.
 
 The tag-only `publish` CI job runs after `version-guard`, repository checks, and
 coverage pass. It runs `bash scripts/ci/publish_crates.sh` with

--- a/scripts/ci/bump_version.sh
+++ b/scripts/ci/bump_version.sh
@@ -87,14 +87,89 @@ if git diff --quiet -- Cargo.toml; then
   exit 1
 fi
 
+# Keep Cargo.lock in step with Cargo.toml. The lockfile records a
+# `version = "…"` line for every workspace path crate (the members under
+# `crates/`), and a stale value breaks `--locked` builds and `cargo metadata
+# --locked` on the release tag. Rewrite only those entries: a `[[package]]`
+# block whose `name` starts with `traverse-` and which has no `source` line is
+# a local path crate. Registry dependencies (e.g. `traverse-registry`) carry a
+# `source` line and are left untouched.
+lock_tmp_file="$(mktemp)"
+trap 'rm -f "${tmp_file}" "${lock_tmp_file}"' EXIT
+
+awk -v new_version="${new_version}" '
+  function flush_block(   i) {
+    if (is_path_crate) {
+      for (i = 0; i < n; i++) {
+        if (buf[i] ~ /^version = "[0-9]+\.[0-9]+\.[0-9]+"$/) {
+          buf[i] = "version = \"" new_version "\""
+          lock_replacements += 1
+        }
+      }
+    }
+    for (i = 0; i < n; i++) {
+      print buf[i]
+    }
+    n = 0
+    is_path_crate = 0
+    has_source = 0
+  }
+  BEGIN {
+    in_block = 0
+    n = 0
+    is_path_crate = 0
+    has_source = 0
+    lock_replacements = 0
+  }
+  /^\[\[package\]\]$/ {
+    if (in_block) {
+      flush_block()
+    }
+    in_block = 1
+    buf[n++] = $0
+    next
+  }
+  in_block && /^$/ {
+    flush_block()
+    in_block = 0
+    print
+    next
+  }
+  in_block {
+    if ($1 == "name" && $2 == "=" && $3 ~ /^"traverse-/ && !has_source) {
+      is_path_crate = 1
+    }
+    if ($1 == "source" && $2 == "=") {
+      has_source = 1
+      is_path_crate = 0
+    }
+    buf[n++] = $0
+    next
+  }
+  {
+    print
+  }
+  END {
+    if (in_block) {
+      flush_block()
+    }
+    if (lock_replacements < 1) {
+      exit 1
+    }
+  }
+' Cargo.lock > "${lock_tmp_file}"
+
+mv "${lock_tmp_file}" Cargo.lock
+
 changed_files="$(git diff --name-only)"
-if [[ "${changed_files}" != "Cargo.toml" ]]; then
+unexpected_files="$(printf '%s\n' "${changed_files}" | grep -vxE 'Cargo\.toml|Cargo\.lock' || true)"
+if [[ -n "${unexpected_files}" ]]; then
   echo "Version bump changed unexpected files:" >&2
-  echo "${changed_files}" >&2
+  echo "${unexpected_files}" >&2
   exit 1
 fi
 
-git add Cargo.toml
+git add Cargo.toml Cargo.lock
 git commit -m "chore: bump version to ${tag_name}"
 git tag "${tag_name}"
 

--- a/specs/048-semver-publishing-pipeline/spec.md
+++ b/specs/048-semver-publishing-pipeline/spec.md
@@ -2,7 +2,9 @@
 
 **Feature Branch**: `048-semver-publishing-pipeline`
 **Created**: 2026-07-03
+**Amended**: 2026-09-05
 **Status**: Approved
+**Version**: 1.1.0
 **Input**: Cargo.toml workspace version has drifted from the git tag (0.5.0 in Cargo.toml, v0.7.0 tagged). No crates.io publishing is configured. No automated version bump exists. `repository` field still points to old org URL. This spec closes all three gaps.
 
 ## Purpose
@@ -64,8 +66,10 @@ As a crates.io consumer, I want the `repository` and `homepage` fields in publis
 - **FR-004**: CI MUST include a `publish` job triggered only on `push` of a `v*` tag, publishing crates in dependency order.
 - **FR-005**: `scripts/ci/bump_version.sh <semver>` MUST validate input is a valid semver string before making any changes.
 - **FR-006**: `bump_version.sh` MUST refuse to run on a dirty working tree.
-- **FR-007**: `bump_version.sh` MUST update only `[workspace.package] version` in `Cargo.toml` — no other files.
-- **FR-008**: After `bump_version.sh`, running `cargo build` MUST succeed without manual intervention.
+- **FR-007**: `bump_version.sh` MUST restrict its edits to `Cargo.toml` and `Cargo.lock` — no other files. In `Cargo.toml` it updates `[workspace.package] version` and the matching `[workspace.dependencies]` path-crate `version =` pins; in `Cargo.lock` it updates the `version = "…"` line of each workspace path crate only (`[[package]]` entries named `traverse-*` that carry no `source` line). If any other file shows as changed, the script MUST abort without committing.
+- **FR-008**: After `bump_version.sh`, running `cargo build` MUST succeed without manual intervention, and `cargo metadata --locked` (equivalently `cargo build --locked`) MUST succeed with no further change to `Cargo.lock`.
+- **FR-009**: `bump_version.sh` MUST stage `Cargo.toml` and `Cargo.lock` together in the single `chore: bump version to v<version>` commit, so the tree is tag-ready in one step with no follow-up lockfile-sync commit.
+- **FR-010**: CI MUST fail a `Cargo.toml`/`Cargo.lock` version drift before the `publish` job runs. The `version-guard` job MUST run `cargo metadata --locked` on every `push`, `pull_request`, and `v*` tag, and `publish` MUST depend on `version-guard`.
 
 ## Non-Functional Requirements
 
@@ -76,6 +80,29 @@ As a crates.io consumer, I want the `repository` and `homepage` fields in publis
 ## Files Governed
 
 - `Cargo.toml` (repository URL, version)
+- `Cargo.lock` (workspace path-crate `version` entries only, kept in step with
+  `Cargo.toml` by `bump_version.sh`; not registered as a spec-alignment
+  `governs` prefix, since routine dependency updates touch this file
+  independently of the release pipeline)
 - `scripts/ci/bump_version.sh` (new)
 - `.github/workflows/ci.yml` (version-guard job, publish job)
 - `docs/release-process.md` (new — documents the full release sequence)
+
+## Amendment History
+
+### 1.1.0 — 2026-09-05
+
+**Owner**: Traverse maintainers (issue #1236). **Rationale**: the v0.10.0 release
+shipped `Cargo.toml` at `0.10.0` while `Cargo.lock` still pinned the workspace
+crates at `0.9.1`, breaking every `--locked` build on `main` and forcing a
+follow-up sync PR (#1233). Branch/PR CI never ran `--locked`, so the drift was
+invisible until tag time.
+
+**Changes**: FR-007 widened from "only `Cargo.toml`" to "`Cargo.toml` and
+`Cargo.lock` only", with `Cargo.lock` edits scoped to workspace path-crate
+version lines. FR-008 now also requires `cargo metadata --locked` to succeed
+with no lockfile change. New FR-009 (single tag-ready commit contains both
+files) and FR-010 (`version-guard` runs `cargo metadata --locked` on every
+push, PR, and tag; `publish` depends on it). `Cargo.lock` documented under
+Files Governed but deliberately left out of the `governs` prefix list. No
+change to the publish flow, crate list, or version-bump interface.

--- a/specs/governance/approved-specs.json
+++ b/specs/governance/approved-specs.json
@@ -525,7 +525,7 @@
     },
     {
       "id": "048-semver-publishing-pipeline",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "status": "approved",
       "immutable": true,
       "path": "specs/048-semver-publishing-pipeline/spec.md",


### PR DESCRIPTION
## Governing Spec

- `048-semver-publishing-pipeline`
- `004-spec-alignment-gate`

## Project Item

- Closes traverse-framework/traverse#1236
- Tracked on org Project 1

## Summary

`scripts/ci/bump_version.sh` rewrote only `Cargo.toml` and aborted if any other
file changed. The v0.10.0 release (traverse-framework/traverse#1232) therefore
merged with `Cargo.lock` still pinning the 8 workspace crates at `0.9.1`,
breaking every `--locked` build on `main` and needing a follow-up sync PR
(traverse-framework/traverse#1233).

Changes:

- `bump_version.sh` now also rewrites the `version = "…"` line of every
  workspace path crate in `Cargo.lock` (`[[package]]` entries named `traverse-*`
  with no `source` line — registry deps like `traverse-registry` are untouched),
  and stages `Cargo.toml` + `Cargo.lock` together in the single
  `chore: bump version to v<version>` commit. The "unexpected files changed"
  guard now allows exactly those two files.
- `version-guard` CI job runs `cargo metadata --locked` on every push, PR, and
  tag, so a `Cargo.toml`/`Cargo.lock` drift fails before the tag-only `publish`
  job.
- `docs/release-process.md` updated.
- Spec `048` amended to v1.1.0: FR-007 widened to `Cargo.toml` + `Cargo.lock`,
  FR-008 now requires `cargo metadata --locked` to pass with no lockfile change,
  new FR-009 (single tag-ready commit) and FR-010 (CI `--locked` guard).
  `Cargo.lock` is intentionally not added as a `governs` prefix so routine
  dependency PRs don't have to cite this spec.

A targeted rewrite is used rather than `cargo update --workspace`: once the
workspace version moves past the `traverse-registry` `traverse-contracts`
ceiling (`<0.11.0` today), a full re-resolve pulls a second `traverse-contracts`
copy and breaks the build. Bumping only the path-crate version lines mirrors the
manual fix in traverse-framework/traverse#1233 and keeps `--locked` clean within
the compatible range. Cross-repo release ordering past that ceiling is a
separate concern (needs a `traverse-registry` release) and is out of scope here;
the new CI `--locked` guard is what surfaces it before publish.

## Validation

- `bash scripts/ci/bump_version.sh 0.10.1` on a clean tree → one commit
  containing only `Cargo.toml` + `Cargo.lock`; `cargo metadata --locked` and
  `cargo build --locked` pass immediately after with no further lockfile change.
- Desynced lockfile (bump `Cargo.toml` only) → `cargo metadata --locked` exits
  non-zero, matching the new CI step.
- `bash -n scripts/ci/bump_version.sh`, `ci.yml` YAML parse, `approved-specs.json`
  `jq` parse — all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
