### PR TITLE
ci: paginate Project state audit queries

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,7 +31,9 @@ If a `claude/issue-<NUMBER>-*` branch exists → **STOP**. Report:
 gh issue edit <NUMBER> --repo traverse-framework/traverse --add-label "agent:codex"
 
 # Get project item ID with bounded output
-gh project item-list 1 --owner traverse-framework --format json --limit 300 \
+# Keep Project reads in bounded pages: large `project item-list` GraphQL
+# requests can exceed GitHub's per-query cost limit even with account quota.
+gh project item-list 1 --owner traverse-framework --format json --limit 100 \
   --jq '.items[] | select(.content.number == <NUMBER>) | .id'
 
 # Set Status → In Progress

--- a/scripts/ci/project_state_audit.sh
+++ b/scripts/ci/project_state_audit.sh
@@ -4,7 +4,63 @@ set -euo pipefail
 
 repo="traverse-framework/traverse"
 
-project_items_json=$(gh project item-list 1 --owner traverse-framework --format json --limit 500)
+project_items_query='query {
+  organization(login: "traverse-framework") {
+    projectV2(number: 1) {
+      items(first: 100) {
+        nodes {
+          content { ... on Issue { number repository { nameWithOwner } } }
+          status: fieldValueByName(name: "Status") { ... on ProjectV2ItemFieldSingleSelectValue { name } }
+          note: fieldValueByName(name: "Note") { ... on ProjectV2ItemFieldTextValue { text } }
+        }
+        pageInfo { endCursor hasNextPage }
+      }
+    }
+  }
+}'
+
+project_items_after_query='query($after: String!) {
+  organization(login: "traverse-framework") {
+    projectV2(number: 1) {
+      items(first: 100, after: $after) {
+        nodes {
+          content { ... on Issue { number repository { nameWithOwner } } }
+          status: fieldValueByName(name: "Status") { ... on ProjectV2ItemFieldSingleSelectValue { name } }
+          note: fieldValueByName(name: "Note") { ... on ProjectV2ItemFieldTextValue { text } }
+        }
+        pageInfo { endCursor hasNextPage }
+      }
+    }
+  }
+}'
+
+project_items_json='{"items":[]}'
+after=''
+has_next_page=true
+while [[ "$has_next_page" == "true" ]]; do
+  if [[ -z "$after" ]]; then
+    page_json=$(gh api graphql -f query="$project_items_query")
+  else
+    page_json=$(gh api graphql -f query="$project_items_after_query" -f after="$after")
+  fi
+
+  page_items=$(jq '[
+    .data.organization.projectV2.items.nodes[]
+    | select(.content.number != null)
+    | {
+        content: {
+          type: "Issue",
+          repository: .content.repository.nameWithOwner,
+          number: .content.number
+        },
+        status: (.status.name // ""),
+        note: (.note.text // "")
+      }
+  ]' <<<"$page_json")
+  project_items_json=$(jq --argjson page_items "$page_items" '.items += $page_items' <<<"$project_items_json")
+  after=$(jq -r '.data.organization.projectV2.items.pageInfo.endCursor // empty' <<<"$page_json")
+  has_next_page=$(jq -r '.data.organization.projectV2.items.pageInfo.hasNextPage' <<<"$page_json")
+done
 
 failures=0
 
@@ -40,8 +96,7 @@ for issue_number in $blocked_without_note_issue_numbers; do
 done
 
 open_pr_bodies=$(
-  gh pr list --repo "$repo" --state open --json body \
-    | jq -r '.[] | .body'
+  gh api "repos/$repo/pulls?state=open&per_page=100" --jq '.[].body'
 )
 
 while IFS= read -r pr_body; do


### PR DESCRIPTION
## Summary

Paginate Project 1 audit reads in 100-item cursor pages and use REST for open PR bodies, avoiding GitHub GraphQL query-cost failures.

## Governing Spec

No product-spec change. This is a CI audit reliability repair.

## Project Item

#1250

## Definition of Done

- [x] Project item reads are bounded and paginated.
- [x] Existing audit checks are preserved.
- [x] The live board validates through the paginated read path.
- [x] Agent guidance avoids the large request pattern.

## Validation

- `bash -n scripts/ci/project_state_audit.sh`
- `bash scripts/ci/project_state_audit.sh` (pagination completed; correctly reported existing #1168 blocked-without-note violation)
- `git diff --check`
