### PR TITLE
fix(runtime): accept successful WASI proc_exit

### DIFF
--- a/crates/traverse-runtime/src/executor/wasm.rs
+++ b/crates/traverse-runtime/src/executor/wasm.rs
@@ -697,13 +697,22 @@ impl WasmExecutor {
             .module(&mut store, "", &cached_module.module)
             .map_err(|e| ExecutorError::RuntimeSetupFailed(format!("module link: {e}")))?;
 
-        linker
+        let invocation = linker
             .get_default(&mut store, "")
             .map_err(|e| ExecutorError::RuntimeSetupFailed(format!("get_default: {e}")))?
             .typed::<(), ()>(&store)
             .map_err(|e| ExecutorError::RuntimeSetupFailed(format!("typed: {e}")))?
-            .call(&mut store, ())
-            .map_err(|error| classify_wasm_execution_error(&error))?;
+            .call(&mut store, ());
+
+        if let Err(error) = invocation {
+            // WASI preview1 implements `proc_exit` by returning `I32Exit` from
+            // the guest invocation. A zero status is the command's successful
+            // completion signal, so stdout remains the capability result.
+            if !matches!(error.downcast_ref::<wasmtime_wasi::I32Exit>(), Some(exit) if exit.0 == 0)
+            {
+                return Err(classify_wasm_execution_error(&error));
+            }
+        }
 
         // Extract captured stdout — contents() reads the buffer without consuming it
         let raw_output = stdout_ref.contents();

--- a/crates/traverse-runtime/tests/executor_tests.rs
+++ b/crates/traverse-runtime/tests/executor_tests.rs
@@ -231,6 +231,58 @@ fn wasm_executor_runs_echo_module() -> Result<(), String> {
 }
 
 #[test]
+fn wasm_executor_accepts_proc_exit_zero_after_json_stdout() -> Result<(), String> {
+    let executor = WasmExecutor::new().map_err(|e| format!("{e:?}"))?;
+    let wat_src = r#"
+        (module
+            (import "wasi_snapshot_preview1" "fd_write"
+                (func $fd_write (param i32 i32 i32 i32) (result i32)))
+            (import "wasi_snapshot_preview1" "proc_exit"
+                (func $proc_exit (param i32)))
+            (memory (export "memory") 1)
+            (data (i32.const 8) "{\"status\":\"ok\"}")
+            (func $_start (export "_start")
+                (i32.store (i32.const 0) (i32.const 8))
+                (i32.store (i32.const 4) (i32.const 15))
+                (drop (call $fd_write (i32.const 1) (i32.const 0) (i32.const 1) (i32.const 32)))
+                (call $proc_exit (i32.const 0))
+            )
+        )
+    "#;
+    let wasm_bytes = wat::parse_str(wat_src).map_err(|e| format!("WAT parse: {e}"))?;
+
+    let result = executor
+        .run_bytes(&wasm_bytes, &json!({}))
+        .map_err(|e| format!("{e:?}"))?;
+
+    assert_eq!(result, json!({ "status": "ok" }));
+    Ok(())
+}
+
+#[test]
+fn wasm_executor_rejects_nonzero_proc_exit() -> Result<(), String> {
+    let executor = WasmExecutor::new().map_err(|e| format!("{e:?}"))?;
+    let wat_src = r#"
+        (module
+            (import "wasi_snapshot_preview1" "proc_exit"
+                (func $proc_exit (param i32)))
+            (func $_start (export "_start")
+                (call $proc_exit (i32.const 1))
+            )
+        )
+    "#;
+    let wasm_bytes = wat::parse_str(wat_src).map_err(|e| format!("WAT parse: {e}"))?;
+
+    let error = expect_err(
+        executor.run_bytes(&wasm_bytes, &json!({})),
+        "nonzero proc_exit must fail closed",
+    )?;
+
+    assert!(matches!(error, ExecutorError::ExecutionFailed(_)));
+    Ok(())
+}
+
+#[test]
 fn wasm_executor_rejects_invalid_json_output() -> Result<(), String> {
     let executor = WasmExecutor::new().map_err(|e| format!("{e:?}"))?;
 


### PR DESCRIPTION
## Summary

Treat a WASI preview1 `proc_exit(0)` after JSON stdout as successful command completion in the shared Wasmtime executor.

## Governing Spec

- `025-wasm-executor-adapter`
- `038-wasi-host-insulation`

Existing ADR 0031 / ADR 0032 govern the WASI stdio and no-std guest profile. Issue #1240 is labeled `no-spec-needed`; no contract or artifact version changes.

## Project Item

Closes #1240. Project 1 item is In Progress.

## Definition of Done

- [x] Clean exit-0 stdout JSON is returned as a successful artifact result.
- [x] Nonzero exits remain closed failures.
- [x] Regression coverage exercises both paths through `WasmExecutor` / `ArtifactRouter`'s shared executor.

## Validation

- `cargo fmt --check`
- `cargo test -p traverse-runtime`
- `bash scripts/ci/spec_alignment_check.sh`
