### PR TITLE
fix(web): align Host ABI connector imports

### DIFF
--- a/packages/web/TraverseEmbedder/src/bundleEmbedder.ts
+++ b/packages/web/TraverseEmbedder/src/bundleEmbedder.ts
@@ -644,6 +644,14 @@ function executeWasmModule(target: WasmTarget, input: JsonValue): WasmExecutionR
   const memoryRef: WasiMemoryRef = { memory: null };
   const importObject: WebAssembly.Imports = {
     wasi_snapshot_preview1: createWasiPreview1Imports(pipes, memoryRef),
+    // The browser does not receive ambient connector authority.  Supplying
+    // this explicit host namespace keeps ABI-valid modules loadable while
+    // returning a deterministic denial until an activated binding adapter is
+    // provided by a later host integration.
+    traverse_host: {
+      emit_event: (_ptr: number, _len: number): number => -1,
+      connector_invoke: (_requestPtr: number, _requestLen: number, _responsePtr: number, _responseLen: number): number => -1,
+    },
   };
 
   let instance: WebAssembly.Instance;

--- a/packages/web/TraverseEmbedder/src/hostAbi.ts
+++ b/packages/web/TraverseEmbedder/src/hostAbi.ts
@@ -25,6 +25,8 @@ export const HOST_ABI_V1_WHITELIST: readonly HostAbiImport[] = [
   { module: "traverse_host", name: "runtime_config" },
   { module: "traverse_host", name: "trace_context" },
   { module: "traverse_host", name: "execution_id" },
+  { module: "traverse_host", name: "emit_event" },
+  { module: "traverse_host", name: "connector_invoke" },
 ];
 
 /**


### PR DESCRIPTION
## Summary

Align the Web embedder Host ABI whitelist with the canonical ABI v1 connector imports and provide deterministic deny-by-default browser stubs.

## Governing Spec

Specs 038 and 104; ADR-0039.

## Project Item

Closes #1257.

## Definition of Done

- [x] Browser accepts sanctioned connector ABI imports without ambient authority.
- [x] Unbound browser connector calls return deterministic non-secret denial.

## Validation

- `npm test` (50 passing tests)
