### PR TITLE
docs(spec): propose mixed registry activation policy

### DIFF
--- a/docs/adr/0059-mixed-registry-reference-activation.md
+++ b/docs/adr/0059-mixed-registry-reference-activation.md
@@ -1,0 +1,41 @@
+# ADR-0059: Mixed Local and Registry-Reference Activation
+
+- Status: Proposed
+- Proposed governing spec: `130-mixed-registry-reference-activation`
+- Related issue: #1258
+
+## Context
+
+Specs 106 and 107 separately govern local executable-artifact activation and
+cross-host verified `registry_ref` caches. Spec 107 explicitly excludes
+activation-time artifact selection. Consequently, a mixed application can
+prepare and validate registry dependencies but has no governed offline path to
+activate them alongside local components.
+
+## Proposed Decision
+
+Extend activation with a resolver that treats a prepared verified cache entry
+as the sole admissible candidate for a `registry_ref` component. The host
+continues to own storage, secrets, fetching, and preparation. Traverse records
+only immutable non-secret selected-component and validation evidence, and
+execution consumes that evidence without a network request or re-resolution.
+
+The resolver validates the component identity and range, digests, trust
+lifecycle, ABI, target, placement, and constraints. Any missing or altered
+evidence fails closed. Local-only activation remains unchanged.
+
+## Consequences
+
+This gives mixed applications an auditable offline lifecycle while preserving
+the cache and trust boundaries of Spec 107. It adds activation evidence and
+failure semantics that must be implemented consistently in Rust and Web and
+certified across the native host matrix.
+
+## Alternatives Considered
+
+- Re-resolve from the registry during activation or execution: rejected because
+  it weakens offline operation and permits unrecorded selection drift.
+- Materialize a local-path substitute from the cache: rejected because it
+  obscures provenance and permits an unproven equivalent candidate.
+- Rewrite the application manifest after preparation: rejected because it
+  changes portable application intent into host state.

--- a/specs/130-mixed-registry-reference-activation/spec.md
+++ b/specs/130-mixed-registry-reference-activation/spec.md
@@ -1,0 +1,90 @@
+# Feature Specification: Mixed Local and Registry-Reference Activation
+
+**Status**: Draft
+**Canonical governing ID**: `130-mixed-registry-reference-activation`
+**Version**: 1.0.0-draft
+**Extends**: `106-activation-artifact-resolution`,
+`107-cross-host-embedded-registry-cache`
+**Input**: #1258; ADR-0059.
+
+## Purpose
+
+Allow an application containing local components and `registry_ref` components
+to activate and execute offline, using only host-owned verified cache evidence
+prepared before activation. This successor closes the activation boundary
+explicitly excluded by Spec 107 without changing cache ownership or allowing
+runtime re-resolution.
+
+## Boundary and Ownership
+
+| Concern | Owner |
+| --- | --- |
+| Syncing indexes and fetching artifacts | Host or deployment tooling before preparation |
+| Selecting and verifying a `registry_ref` cache entry | Traverse resolver contract |
+| Cache storage, paths, credentials, encryption, retention | Host |
+| Combining local and verified registry candidates at activation | Traverse activation resolver |
+| Activation evidence and drift checks | Traverse runtime/host integration |
+
+## Requirements
+
+- **FR-001**: Activation MUST accept mixed local and `registry_ref` components
+  without rewriting the application manifest.
+- **FR-002**: A `registry_ref` component MUST resolve only from a previously
+  prepared verified cache entry. Activation, execution, and drift checking MUST
+  perform no network request or fallback resolution.
+- **FR-003**: Before activation succeeds, the resolver MUST verify namespace,
+  capability id, requested version range, selected version, contract digest,
+  artifact digest, signature/trust lifecycle, ABI, target, placement, and
+  declared execution constraints.
+- **FR-004**: Successful activation MUST persist deterministic immutable,
+  non-secret evidence for each selected local or registry component, including
+  identity, selected version, requested version range where applicable,
+  contract and artifact digests, trust lifecycle, ABI, target, placement,
+  resolver/cache evidence, connector evidence, and configuration-reference
+  names only.
+- **FR-005**: Evidence MUST NOT contain cache paths, configuration values,
+  credentials, endpoints, or artifact bytes.
+- **FR-006**: Missing, altered, inactive or yanked, trust-invalid,
+  contract-mismatched, ABI-incompatible, target-incompatible, placement- or
+  constraint-incompatible cache entries MUST fail closed with stable,
+  secret-free errors.
+- **FR-007**: Execution MUST consume activation evidence and MUST reject every
+  selected-component drift without re-resolution.
+- **FR-008**: Rust and Web implementations MUST expose equivalent observable
+  evidence and error semantics. Native host conformance follows the Spec 107
+  matrix.
+
+## Acceptance Scenarios
+
+1. A prepared signed registry component and a local component validate,
+   register, activate, and execute offline from their recorded evidence.
+2. A missing or modified cache entry fails closed and no alternate local or
+   registry candidate is selected.
+3. A yanked, inactive, trust-invalid, ABI-incompatible, wrong-target, or
+   contract-digest-mismatched entry fails with deterministic non-secret
+   evidence.
+4. Execution after a post-activation mutation fails with activation drift and
+   performs no network request.
+5. Equivalent Rust and Web fixtures emit the same normalized result projection
+   and omit all host-private values.
+
+## Compatibility
+
+This is additive. Existing local-only activation remains unchanged. Existing
+Spec 107 cache APIs and error codes remain supported; this spec may add stable
+activation-specific error codes but MUST NOT change their meanings. Any later
+incompatible evidence-schema change requires a new major version and a
+documented migration.
+
+## Quality Gates
+
+- Unit and integration tests cover every failure class and deterministic
+  evidence projection.
+- Offline fixtures prove no network request occurs after preparation.
+- Cross-host conformance covers Rust, Web, and the applicable native matrix.
+- Spec-alignment, contract validation, and targeted regression suites pass.
+
+## Out of Scope
+
+Runtime network fetching, manifest rewriting, a shared cache layout, cache
+storage/secrets ownership, and silent artifact re-resolution.


### PR DESCRIPTION
## Summary

Proposes the governing successor spec and ADR for offline activation of mixed local and verified `registry_ref` application components.

## Governing Spec

- `065-sigstore-bundle-verification`
- `070-runtime-event-sink-boundary`

Draft `130-mixed-registry-reference-activation` extends approved Specs 106 and 107. No approved-spec registry change is included.

## Project Item

Project 1 / issue #1258 — In Progress.

## Definition of Done

This proposal captures the required decision boundary. Implementation remains blocked pending human approval of the draft governing spec and ADR.

## Validation

`git diff --check` passed. `bash scripts/ci/spec_alignment_check.sh /private/tmp/traverse-1258-pr-body.md` passed.
