### PR TITLE
docs: draft Registry genericity policy

### DIFF
--- a/docs/adr/0059-registry-genericity-and-configuration-policy.md
+++ b/docs/adr/0059-registry-genericity-and-configuration-policy.md
@@ -1,0 +1,48 @@
+# ADR-0059: Registry Genericity and Configuration-Evolution Policy
+
+- Status: Proposed
+- Date: 2026-09-07
+- Governing spec: `1256-registry-genericity-policy` (Draft)
+- Related issue: #1256
+
+## Context
+
+Registry admission needs a discoverable policy that distinguishes portable
+business capabilities from application composition and host authority. Without
+one, a domain-shaped record can conceal a product workflow, vendor binding, or
+secret-bearing configuration behind an apparently reusable name.
+
+## Decision
+
+Public capabilities represent stable domain operations with typed contracts,
+portable configuration semantics, and deterministic or explicitly mediated
+behavior. Names describe the operation, not an app, UI, customer, vendor,
+model, database, microphone, target, or host binding. Connectors own
+unavoidable host authority; applications own composition and concrete binding.
+
+Publication requires two materially distinct portable fixture/configuration
+scenarios. A genuinely new primitive may instead present a documented,
+reviewed exception rationale. This is evidence of portability, not a demand
+for two shipping customers. Configuration is versioned and typed, records only
+redacted provenance/reference names, evolves additively when existing meaning
+is retained, and otherwise requires a major version plus migration guidance.
+
+Automation rejects only objectively detectable structural leakage. Human
+review remains responsible for semantic genericity and exception assessment.
+
+## Consequences
+
+The Registry gains a consistent admission checklist and redaction/compatibility
+policy without pretending that a static validator can understand arbitrary
+domain semantics. Publication work must supply portable fixture evidence and
+may need a schema migration for incompatible configuration changes. Existing
+records are audited only for confirmed violations.
+
+## Alternatives considered
+
+- Require two shipping customers: rejected because it blocks new primitives
+  despite credible portable evidence.
+- Permit one ordinary example: rejected because it does not demonstrate
+  portability across materially different contexts.
+- Infer genericity from source code: rejected because it is unreliable and
+  would create a false approval signal.

--- a/docs/capability-contract-authoring-guide.md
+++ b/docs/capability-contract-authoring-guide.md
@@ -20,6 +20,27 @@ A capability contract is a `contract.json` artifact placed under `contracts/`. T
 - `inputs` / `outputs` — JSON Schemas used for deterministic validation
 - `execution` — binary format, entrypoint, preferred targets, and constraints
 
+## Public Registry boundary (Draft)
+
+When authoring for public Registry publication, make the contract describe a
+stable domain operation. `audio-window-plan` and `inference-request-prepare`
+are domain-shaped examples; a microphone capture binding, a provider/model
+selection, or a review-screen workflow is not. The latter belongs respectively
+to a host connector, runtime/connector policy, or application composition.
+
+The proposed `1256-registry-genericity-policy` requires typed, versioned
+configuration with portable defaults separated from host-required references.
+Do not put credential values, endpoints, paths, device IDs, or vendor choices
+in a public capability contract or its evidence. Additive optional
+configuration fields may preserve compatibility; removing or reinterpreting a
+required field, enum member, range, or default requires a major schema version
+and migration/deprecation guidance.
+
+Supply two materially distinct portable fixture/configuration scenarios for
+publication, or a documented reviewed exception for a genuinely new primitive.
+Structural validation can reject unambiguous leakage, but human review decides
+whether the capability is semantically generic.
+
 ## Minimal Working Template
 
 This is a minimal contract you can copy, edit, and validate locally. It intentionally avoids events and dependencies so you can focus on structure first.

--- a/docs/capability-publish.md
+++ b/docs/capability-publish.md
@@ -40,3 +40,19 @@ persona before opening a registry PR.
 
 The resulting registry PR still requires registry CI and explicit human review
 before the record can become visible to consumers.
+
+## Registry admission policy (Draft)
+
+The proposed `1256-registry-genericity-policy` requires public capabilities to
+name a stable domain operation, not an application, workflow, UI, customer,
+vendor, model, host target, connector implementation, or secret-bearing
+binding. Publish portable fixture/configuration evidence for two materially
+distinct scenarios. A genuinely new primitive may provide a documented,
+reviewed exception rationale instead; two shipping customers are not required.
+
+Configuration must be typed and versioned. Registry evidence may record only
+schema versions, reference names, target limitations, and redacted provenance;
+it must never include values, credentials, endpoints, local paths, or device
+identities. The command's structural checks are not semantic approval: a
+registry reviewer still verifies genericity, ownership boundaries, fixture
+distinctness, and any exception.

--- a/specs/1256-registry-genericity-policy/spec.md
+++ b/specs/1256-registry-genericity-policy/spec.md
@@ -1,0 +1,98 @@
+# Feature Specification: Registry Genericity, Naming, and Configuration Policy
+
+**Status**: Draft
+**Canonical governing ID**: `1256-registry-genericity-policy`
+**Version**: 0.1.0
+**Decision evidence**: Traverse #1256 decision record (2026-09-07).
+
+## Purpose
+
+Define the admission policy for public Registry capabilities. The policy keeps
+portable business authority publishable while preventing public records from
+embedding application workflows, user interfaces, vendors, hosts, secrets, or
+environment-specific bindings.
+
+## Boundary and ownership
+
+A Registry capability owns one stable domain operation, its typed input/output
+contract, and portable configuration semantics. A runtime primitive or
+connector contract owns an unavoidable host authority and its request/response
+envelope. An application owns workflow composition, product policy, UI, and
+the selection of a concrete connector. A host connector implementation owns
+credentials, endpoints, device IDs, filesystem paths, and provider-specific
+bindings. A public capability MUST NOT move host or application ownership into
+its name, configuration, contract, or evidence.
+
+Audio-window planning and inference-request preparation are portable
+capabilities when their schemas express only domain inputs and outputs.
+Model-policy values are portable configuration when they are typed and do not
+select a provider or secret. Microphone capture and a provider binding are
+host connector concerns; a review screen and a customer workflow are
+application concerns.
+
+## Requirements
+
+- **FR-001**: A public Registry capability MUST describe a stable domain
+  operation with typed inputs, outputs, side effects, dependencies, and
+  execution constraints. Its behavior MUST be deterministic or explicitly
+  mediated through a declared connector/runtime authority.
+- **FR-002**: A public capability `id`, namespace, and name MUST describe the
+  domain operation. They MUST NOT encode an application, workflow, UI,
+  customer, location, vendor, model identifier, database, microphone, host
+  target, credential, endpoint, filesystem path, or device identity.
+- **FR-003**: Persisted configuration MUST have a versioned typed schema. The
+  schema MUST distinguish portable defaults from host-required references;
+  records MAY retain only reference names and redacted provenance, never
+  configuration values, credentials, endpoints, paths, or device IDs.
+- **FR-004**: Configuration-schema evolution MAY add optional fields, enum
+  members, or ranges only when existing configurations retain their meaning.
+  Removing or reinterpreting a required field, enum member, range, or default
+  requires a major schema version and explicit migration/deprecation guidance.
+  Published identity/version pairs remain immutable.
+- **FR-005**: Publication MUST include at least two materially distinct,
+  portable fixture/configuration scenarios. A genuinely new primitive MAY use
+  one scenario only with a documented publication-review exception explaining
+  why a second scenario is not yet meaningful.
+- **FR-006**: Fixture evidence MUST identify the contract/configuration schema
+  version, target or target limitation, expected outcome, and redacted
+  provenance. It MUST contain no private value, credential, endpoint, local
+  path, device identity, or customer-specific data.
+- **FR-007**: Publication validation MUST reject objectively detectable
+  leakage in governed identity fields and evidence fields, including malformed
+  secret-like values and explicitly disallowed host/application identifiers.
+  It MUST emit stable, secret-free failures. It MUST NOT attempt to infer
+  genericity from arbitrary source code or prose.
+- **FR-008**: Human publication review MUST assess semantic genericity,
+  ownership boundary, fixture distinctness, and any exception rationale. A
+  successful structural validator MUST NOT by itself approve publication.
+
+## Acceptance scenarios
+
+1. Audio-window planning publishes with typed window parameters and portable
+   browser/native fixtures; it does not name a microphone or application.
+2. Inference-request preparation publishes with typed request and model-policy
+   configuration while a model-runtime connector owns provider activation.
+3. A contract whose identity contains a vendor, UI screen, host target, or
+   secret-like evidence value fails structural publication validation with a
+   stable, redacted error.
+4. A configuration schema adds an optional policy field without changing an
+   existing meaning; the publication is compatible. Reinterpreting a required
+   field requires a new major schema version and migration guidance.
+5. A new primitive with one fixture is rejected unless its reviewed exception
+   rationale is recorded; a normal capability with two distinct fixtures is
+   reviewable without evidence from two shipping customers.
+
+## Compatibility and non-goals
+
+This specification is additive. It does not rename existing public records
+solely for mentioning a legitimate domain, design concrete connector contracts
+or a runtime ABI, introduce a semantic-code classifier, or expose host-owned
+configuration values in Registry evidence. Existing records are audited and
+migration issues are created only for confirmed violations.
+
+## Validation
+
+Implement deterministic schema/structure tests for the rejectable fields,
+fixture evidence redaction, and compatible versus breaking configuration
+evolution. Keep semantic admission decisions and exceptions in the human
+publication checklist with inspectable decision evidence.


### PR DESCRIPTION
## Summary

Drafts the Registry genericity, naming, configuration-evolution, and portability-evidence policy approved in the #1256 decision record. The change adds a proposed ADR, a Draft governing spec, and focused capability authoring/publishing guidance. It intentionally adds no runtime or schema implementation before the governing spec receives formal approval.

## Governing Spec

- `065-sigstore-bundle-verification`
- `070-runtime-event-sink-boundary`
- `102-contract-surface-coverage`

`1256-registry-genericity-policy` is Draft and ADR-0059 is Proposed; neither
is declared as an approved governing spec or added to `approved-specs.json`.

## Project Item

Traverse #1256 — In Progress. The approved policy decision is recorded on the issue; formal spec/ADR approval remains required before implementation.

## Definition of Done

- [x] Product/governance decision recorded.
- [x] Draft ADR and governing spec capture admission, configuration, compatibility, redaction, and evidence rules.
- [x] Authoring and publication guidance include boundary examples and review posture.
- [ ] Approval evidence, mechanical validation, fixture coverage, and existing-record audit remain follow-up work governed by the approved spec.

## Validation

- `git diff --check`
- `bash scripts/ci/spec_alignment_check.sh <PR body>` with the merge-base SHA
