### PR TITLE
docs: draft portable authority contracts

### DIFF
--- a/docs/adr/0060-portable-audio-and-model-runtime-authority.md
+++ b/docs/adr/0060-portable-audio-and-model-runtime-authority.md
@@ -1,0 +1,39 @@
+# ADR-0060: Portable Audio and Model-Runtime Authority Boundaries
+
+- Status: Proposed
+- Date: 2026-09-07
+- Governing spec: `1259-portable-authority-contracts` (Draft)
+- Related issue: #1259
+
+## Context
+
+Applications need reusable boundaries for physical audio capture and model
+activation without turning microphone, provider, or product workflow choices
+into public portable contracts. The existing connector architecture already
+separates abstract requirements, application bindings, and host-owned private
+configuration.
+
+## Decision
+
+Add native-only `traverse.audio-input` and vendor-neutral
+`traverse.model-runtime` connector contracts under that architecture. Keep
+portable audio/DSP algorithms and request/policy preparation in WASM
+capabilities. Defer an advisory-review connector; compose through
+`traverse.http` until a reusable authority is evidenced. Permit a future
+media-generic acceleration connector only for unavoidable host/hardware work.
+
+## Consequences
+
+Contracts gain typed, bounded authority envelopes and target-aware redacted
+evidence without vendor, device, endpoint, credential, or UI leakage. Native
+authorities fail before invocation on browsers. Future connector proposals
+need conformance fixtures and a separately justified host boundary.
+
+## Alternatives considered
+
+- Put capture/model activation inside WASM capabilities: rejected because it
+  hides host authority and breaks portability.
+- Standardize a review connector now: rejected because it would likely encode
+  application workflow rather than a stable authority.
+- Make codec/DSP connector-first: rejected because portable algorithms should
+  remain portable capabilities.

--- a/specs/1259-portable-authority-contracts/spec.md
+++ b/specs/1259-portable-authority-contracts/spec.md
@@ -1,0 +1,88 @@
+# Feature Specification: Portable Authority Contracts for Audio and Model Runtime
+
+**Status**: Draft
+**Canonical governing ID**: `1259-portable-authority-contracts`
+**Version**: 0.1.0
+**Extends**: `039-connector-plugin-architecture`, `103-application-connector-binding`, and `104-mediated-connector-invocation`.
+**Decision evidence**: Traverse #1259 decision records (2026-09-07).
+
+## Purpose and boundary
+
+Define portable connector contracts for unavoidable physical audio input and
+model-runtime authority. The contracts name generic operations, not vendors,
+models, devices, codecs, applications, or user interfaces. Applications own
+workflow and binding selection; hosts own implementations, credentials,
+endpoints, permissions, discovery, device selection, and raw bytes.
+
+Portable audio/DSP algorithms and model request/policy preparation remain WASM
+capabilities. Advisory/review exchange composes through `traverse.http` until
+cross-application evidence justifies a distinct typed authority.
+
+## Requirements
+
+- **FR-001**: `traverse.audio-input` MUST be a native-only connector with
+  bounded generic capture requests. Its request/response envelope MUST declare
+  duration/size limits, correlation, cancellation, and a content reference or
+  host-mediated result; it MUST NOT contain device IDs, microphone names,
+  codec vendors, paths, credentials, or application workflow fields.
+- **FR-002**: Audio-input discovery, permission prompts, device selection, and
+  byte capture MUST remain host-owned. Browser activation of a native-only
+  binding MUST reject deterministically before invocation with a stable,
+  secret-free target-incompatible error.
+- **FR-003**: `traverse.model-runtime` MUST be a vendor-neutral connector for
+  activating and executing a declared model artifact. Its typed envelope MUST
+  cover artifact identity, licence/policy reference, resource limits, label
+  schema, target, correlation, cancellation, quotas, and trace constraints.
+  It MUST NOT contain provider choice, model ID, endpoint, credential, or
+  application-specific taxonomy.
+- **FR-004**: A portable capability MAY prepare model requests or evaluate
+  model policy, but it MUST invoke an activated model-runtime binding for
+  provider/runtime authority. Connector activation MUST verify compatible
+  contract version, configured host implementation, policy/permission, and
+  target before execution.
+- **FR-005**: Portable codec/DSP algorithms MUST publish as WASM capabilities.
+  A media-generic acceleration connector MAY be proposed only for an
+  unavoidable host/hardware operation and must expose bounded abstract media
+  operations, targets, limits, cancellation, and redacted evidence.
+- **FR-006**: Connector operations MUST define stable secret-free failure
+  classes for unbound, incompatible, unconfigured, policy-denied,
+  target-incompatible, quota-limited, cancelled, and replay/idempotency cases
+  that apply to the operation.
+- **FR-007**: Activation and invocation evidence MUST record connector ID and
+  version, abstract operation, target, binding/configuration reference name,
+  decision outcome, and correlation identifier. It MUST NOT record values,
+  credentials, endpoints, paths, device identities, raw audio, or provider
+  identifiers.
+- **FR-008**: Each approved connector contract MUST include
+  implementation-independent fixtures for success, missing/incompatible or
+  unconfigured binding, policy denial, limits, cancellation, replay or
+  idempotency where relevant, redaction, and browser/native behavior.
+
+## Acceptance scenarios
+
+1. A native host activates `traverse.audio-input` with a compatible private
+   binding and processes a bounded capture request; a browser rejects that
+   binding before invocation without exposing host details.
+2. A declared model artifact runs through a compatible `traverse.model-runtime`
+   binding under policy and resource limits; an untrusted or incompatible
+   binding fails closed with a stable redacted error.
+3. A WASM capability prepares an inference request and invokes the activated
+   model-runtime connector without embedding provider or credential data.
+4. A portable DSP algorithm runs as WASM; a proposed hardware acceleration
+   binding supplies only media-generic operation evidence.
+5. An advisory workflow uses `traverse.http`; no review UI, taxonomy, or
+   provider-specific advisory connector becomes a public contract.
+
+## Compatibility and non-goals
+
+This is additive to the existing connector architecture. It does not design
+production drivers, choose codecs/models/vendors/databases/microphones/clouds,
+add browser emulation of native authority, standardize advisory/review UI or
+workflow, or publish a media acceleration connector without a separately
+approved unavoidable-host proposal.
+
+## Validation
+
+Parser and activation validation must reject invalid envelopes and incompatible
+bindings deterministically. Contract, activation, and fixture tests must cover
+every requirement and prove that trace/evidence output is redacted.


### PR DESCRIPTION
## Summary

Drafts the approved portable authority decisions for audio input, model runtime, advisory review, and codec/DSP boundaries. It adds a Proposed ADR and Draft governing spec only; implementation waits for formal approval.

## Governing Spec

- `039-connector-plugin-architecture`
- `103-application-connector-binding`
- `104-mediated-connector-invocation`
- `065-sigstore-bundle-verification`
- `070-runtime-event-sink-boundary`

`1259-portable-authority-contracts` is Draft and ADR-0060 is Proposed; neither is added to `approved-specs.json`.

## Project Item

Traverse #1259 — In Progress. All four owner decisions are recorded on the issue.

## Definition of Done

- [x] Authority-boundary decisions are recorded.
- [x] Draft ADR/spec define contract, target, evidence, and fixture requirements.
- [ ] Formal approval, schemas, parser/activation implementation, and conformance fixtures remain governed follow-up work.

## Validation

- `git diff --check`
- `bash scripts/ci/spec_alignment_check.sh <PR body>` with the merge-base SHA
