### PR TITLE
docs: approve portable authority contracts

### DIFF
--- a/docs/adr/0060-portable-audio-and-model-runtime-authority.md
+++ b/docs/adr/0060-portable-audio-and-model-runtime-authority.md
@@ -1,8 +1,8 @@
 # ADR-0060: Portable Audio and Model-Runtime Authority Boundaries
 
-- Status: Proposed
+- Status: Accepted
 - Date: 2026-09-07
-- Governing spec: `1259-portable-authority-contracts` (Draft)
+- Governing spec: `1259-portable-authority-contracts` (Approved)
 - Related issue: #1259
 
 ## Context

--- a/specs/1259-portable-authority-contracts/spec.md
+++ b/specs/1259-portable-authority-contracts/spec.md
@@ -1,6 +1,6 @@
 # Feature Specification: Portable Authority Contracts for Audio and Model Runtime
 
-**Status**: Draft
+**Status**: Approved (2026-09-07)
 **Canonical governing ID**: `1259-portable-authority-contracts`
 **Version**: 0.1.0
 **Extends**: `039-connector-plugin-architecture`, `103-application-connector-binding`, and `104-mediated-connector-invocation`.

--- a/specs/governance/approved-specs.json
+++ b/specs/governance/approved-specs.json
@@ -1711,6 +1711,17 @@
         "docs/adr/0058-governed-workflow-reliability.md",
         "specs/129-governed-workflow-reliability/"
       ]
+    },
+    {
+      "id": "1259-portable-authority-contracts",
+      "version": "0.1.0",
+      "status": "approved",
+      "immutable": true,
+      "path": "specs/1259-portable-authority-contracts/spec.md",
+      "governs": [
+        "specs/1259-portable-authority-contracts/",
+        "docs/adr/0060-portable-audio-and-model-runtime-authority.md"
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary

Drafts the approved portable authority decisions for audio input, model runtime, advisory review, and codec/DSP boundaries. It adds a Proposed ADR and Draft governing spec only; implementation waits for formal approval.

## Governing Spec

- `039-connector-plugin-architecture`
- `103-application-connector-binding`
- `104-mediated-connector-invocation`
- `065-sigstore-bundle-verification`
- `070-runtime-event-sink-boundary`
- `1259-portable-authority-contracts`

ADR-0060 is accepted and the approved immutable spec is registered in `approved-specs.json`.

## Project Item

Traverse #1259 — In Progress. All four owner decisions are recorded on the issue.

## Definition of Done

- [x] Authority-boundary decisions are recorded.
- [x] Accepted ADR/spec define contract, target, evidence, and fixture requirements.
- [ ] Schemas, parser/activation implementation, and conformance fixtures remain governed follow-up work.

## Validation

- `git diff --check`
- `bash scripts/ci/spec_alignment_check.sh <PR body>` with the merge-base SHA
