### PR TITLE
docs: approve browser-local workflow composition spec

### DIFF
--- a/docs/adr/0062-browser-local-workflow-composition.md
+++ b/docs/adr/0062-browser-local-workflow-composition.md
@@ -1,0 +1,44 @@
+# ADR-0062: Browser-Local Deterministic Workflow Composition
+
+- Status: Accepted
+- Date: 2026-09-08
+- Governing spec: `1277-browser-local-workflow-composition` (Approved)
+- Related issues: #1271, #1277, #1269, #1270
+
+## Context
+
+The backend-less `/discover` experience needs a real proposal-producing path.
+Accepted ADR-0043 requires deterministic, data-grounded planning with no
+automatic candidate choice; ADR-0050 makes every planner an untrusted
+proposer. The remaining question was whether the browser should plan locally
+from a verified snapshot or call a public governed endpoint.
+
+## Decision
+
+Planning runs fully in the browser over an already synced, verified,
+digest-pinned public registry snapshot. It produces only untrusted,
+versioned workflow proposals; the local governed runtime remains the sole
+validator, authorizer, and executor. Exact prepared `registry_ref`
+components follow the offline, fail-closed lifecycle of Spec 1258.
+
+Traverse will not add a public remote planning endpoint for this scope. The
+browser neither refreshes the registry nor falls back to a bundle during
+planning, validation, or execution.
+
+## Consequences
+
+`/discover` can remain backend-less and provider-neutral without hosted model
+credentials, CORS policy, anonymous abuse controls, or a service operator.
+The browser planner and local composed-execution adapter are explicit
+downstream work with bounded inputs and redacted evidence. A remote endpoint
+is a future architectural change requiring its own approved spec and ADR.
+
+## Alternatives considered
+
+- A public governed planning endpoint: rejected because it changes the
+  backend-less commitment and requires deployment, CORS/auth, abuse controls,
+  and an operational owner.
+- Browser name/namespace heuristics or automatic choice: rejected by
+  ADR-0043's deterministic structural-planning boundary.
+- A hosted model planner: rejected by ADR-0050's provider, credential,
+  privacy, and authority constraints.

--- a/specs/1277-browser-local-workflow-composition/spec.md
+++ b/specs/1277-browser-local-workflow-composition/spec.md
@@ -1,0 +1,98 @@
+# Feature Specification: Browser-Local Deterministic Workflow Composition
+
+**Status**: Approved (2026-09-08)
+**Canonical governing ID**: `1277-browser-local-workflow-composition`
+**Version**: 0.1.0
+**Extends**: `108-governed-runtime-workflow-composition`,
+`109-runtime-workflow-proposals`, `113-declarative-workflow-planning`, and
+`1258-offline-cache-activation`.
+**Decision evidence**: Traverse #1271 decision record (2026-09-08).
+
+## Purpose and boundary
+
+Define the backend-less `/discover` path: a browser uses an already synced,
+digest-verified public registry snapshot to deterministically produce one or
+more untrusted workflow proposals, then hands a selected reviewed proposal to
+the local governed runtime for manifest-bounded execution. The browser is not
+a runtime authority and this path does not introduce a Traverse-operated
+planning service.
+
+## Requirements
+
+- **FR-001**: The browser planner MUST accept only the structured target and
+  starting facts defined by Spec 113. It MUST use a supplied snapshot identity
+  containing the registry snapshot digest, preparation/verification evidence,
+  and supported contract-schema version; it MUST reject missing, altered,
+  unverified, unsupported, or stale evidence with a stable secret-free error.
+- **FR-002**: Planning MUST be deterministic and read-only over that exact
+  snapshot. It MUST derive candidates only from the structural and declared
+  event relationships allowed by Spec 113, enumerate ambiguity rather than
+  choose it, retain Spec 113's five-plan/eight-node bounds, and expose stable
+  `plan_search_truncated` and no-candidate outcomes.
+- **FR-003**: The browser planner MUST NOT infer a plan from capability names,
+  namespaces, natural-language goals, prompt/model output, recency, or an
+  undisclosed scoring rule. It MUST NOT fetch, sync, refresh, mutate, or
+  persist registry, manifest, workflow-catalog, or proposal state.
+- **FR-004**: Each browser result MUST be a versioned,
+  canonicalizable `workflow_proposal` structurally compatible with Spec 109.
+  It MUST bind the source snapshot identity, exact capability identities and
+  versions, graph, and explicit field mappings; all inferred mappings remain
+  `mapping_unconfirmed` until a separate reviewer/caller action clears them.
+- **FR-005**: Browser planning is an untrusted proposer. Proposal validation,
+  authorization, data-flow/egress policy, connector and placement checks,
+  approval-token checks, canonicalization, execution scheduling, and trace
+  production MUST remain with the local governed runtime under Specs 108 and
+  109. A browser result MUST NOT enlarge manifest authority or bypass a
+  runtime denial.
+- **FR-006**: The local handoff MUST execute only exact, prepared
+  `registry_ref` components whose activation evidence satisfies Spec 1258. It
+  MUST fail closed when activation evidence, digests, versions, ABI, target,
+  placement, trust lifecycle, or policy inputs do not match; it MUST NOT
+  substitute a candidate, re-resolve a range, fetch, sync, refresh, or fall
+  back to an expedition bundle during validation or execution.
+- **FR-007**: The browser and local handoff MUST enforce bounded input,
+  proposal, graph, payload, validation-time, execution-time, and memory
+  limits. Failures and public evidence MUST be stable and redacted: they may
+  identify declared artifact identity, snapshot digest, and failure class, but
+  MUST NOT expose credentials, private configuration, host paths, raw request
+  values, or artifact bytes.
+- **FR-008**: This path MUST operate without a public remote planning endpoint.
+  It MUST NOT require CORS exceptions, anonymous service access, hosted model
+  credentials, or a Traverse-operated planning service. A future remote
+  endpoint requires a separately approved specification and ADR.
+
+## Acceptance scenarios
+
+1. A browser receives a verified pinned public snapshot and a structured
+   target; it deterministically returns all bounded candidate proposals with
+   mappings marked unconfirmed, without making a network request.
+2. Two candidate producers structurally satisfy a consumer; the browser
+   returns separate proposals and no automatic winner. A name-only apparent
+   match returns no candidate.
+3. A changed snapshot digest, absent verification evidence, or unsupported
+   schema version fails before planning with a stable redacted error.
+4. A reviewed proposal with exact prepared `registry_ref` components passes
+   through local Spec-109 validation and executes offline. A missing, drifted,
+   incompatible, or unprepared component fails closed without fallback.
+5. A proposal that asks for an undeclared capability, prohibited mapping,
+   connector, placement, or side effect is rejected by the local runtime even
+   though the browser produced it.
+6. Oversize inputs, candidate search beyond the fixed bound, or a resource
+   limit breach yields the specified stable bounded outcome and no raw private
+   data in evidence.
+
+## Compatibility and non-goals
+
+This is additive. Specs 108, 109, 113, and 1258 remain immutable and retain
+their authority. It does not implement the browser proposal UI (#1269), the
+runtime-composed execution adapter (#1270), a hosted endpoint, natural-
+language planning, automatic review/submission, registry mutation, dynamic
+manifest mutation, or network activity after preparation.
+
+## Validation
+
+Conformance fixtures must cover deterministic identical-snapshot output,
+ambiguity, no name/namespace inference, invalid snapshot evidence, offline
+handoff, prepared-component drift, authorization/policy denial, resource
+bounds, and evidence redaction. Run `bash scripts/ci/spec_alignment_check.sh`
+with the PR body and the repository documentation checks.

--- a/specs/governance/approved-specs.json
+++ b/specs/governance/approved-specs.json
@@ -1733,6 +1733,17 @@
         "specs/1258-offline-cache-activation/",
         "docs/adr/0061-offline-activation-from-verified-cache-evidence.md"
       ]
+    },
+    {
+      "id": "1277-browser-local-workflow-composition",
+      "version": "0.1.0",
+      "status": "approved",
+      "immutable": true,
+      "path": "specs/1277-browser-local-workflow-composition/spec.md",
+      "governs": [
+        "specs/1277-browser-local-workflow-composition/",
+        "docs/adr/0062-browser-local-workflow-composition.md"
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary

Approves the governing browser-local workflow composition contract and its ADR.

## Governing Spec

- `1277-browser-local-workflow-composition`
- `004-spec-alignment-gate`

## Project Item

- https://github.com/orgs/traverse-framework/projects/1/views/1
- https://github.com/traverse-framework/traverse/issues/1277

## What Changed

- Contracts changed: none; this is a governing specification package.
- Runtime behavior changed: none implemented; defines the downstream browser-local planning and local handoff boundary.
- Compatibility impact: additive; existing approved Specs 108, 109, 113, and 1258 remain immutable.
- ADR needed or linked: ADR-0062.

## Validation

- [x] `BASE_SHA=origin/main bash scripts/ci/local_preflight.sh --pr-body /private/tmp/traverse-pr-1277.md`
- [x] `BASE_SHA=origin/main bash scripts/ci/spec_alignment_check.sh /private/tmp/traverse-pr-1277.md`

## Notes

One cohesive governing-spec PR intentionally unblocks #1269 and #1270; implementation remains in those downstream tickets.

Closes #1277
