### PR TITLE
test(cli): diagnose exact-version registry_ref resolution collapse (#1273)

### DIFF
--- a/crates/traverse-cli/src/main.rs
+++ b/crates/traverse-cli/src/main.rs
@@ -7,6 +7,8 @@ mod capability_packages;
 mod federation_operator;
 mod grpc_event_transport;
 mod http_api;
+#[cfg(test)]
+mod registry_resolution_diagnostics;
 mod supply_chain;
 mod telemetry;
 
@@ -9971,6 +9973,420 @@ mod tests {
             "only deprecated public registry versions for fixture:expedition.planning.validate-team-readiness satisfy >=1.0.0, <1.1.0"
         );
         assert!(!state_root.join(".traverse/workspaces/local/apps").exists());
+    }
+
+    // ---------------------------------------------------------------------
+    // Issue #1273 -- diagnosis of exact-version `registry_ref` resolution
+    // failure (governing spec `1258-offline-cache-activation`).
+    //
+    // These are characterization tests: they pin the *current* behavior of
+    // `SyncedRegistryComponentResolver` so the successor implementation slice
+    // (#1272) can see exactly which boundaries collapse onto one opaque code
+    // and where the message leaks a local path. See
+    // `docs/registry-resolution-diagnosis.md` and
+    // `src/registry_resolution_diagnostics.rs`.
+    // ---------------------------------------------------------------------
+
+    struct ExactVersionRegistrySources {
+        contract_url: String,
+        contract_digest: String,
+        artifact_url: String,
+        artifact_digest: String,
+    }
+
+    /// Reads the checked-in expedition contract/artifact fixtures and returns
+    /// `file://` URLs plus their real digests. No network, fully deterministic.
+    fn exact_version_registry_sources() -> ExactVersionRegistrySources {
+        let repo = repo_root();
+        let contract_src = repo.join(
+            "contracts/examples/expedition/capabilities/validate-team-readiness/contract.json",
+        );
+        let artifact_src = repo.join(
+            "examples/capabilities/team-readiness-agent/artifacts/validate-team-readiness-agent.wasm",
+        );
+        let contract_digest = format!(
+            "sha256:{}",
+            sha256_hex(&fs::read(&contract_src).expect("contract fixture should read"))
+        );
+        let artifact_digest = format!(
+            "sha256:{}",
+            sha256_hex(&fs::read(&artifact_src).expect("artifact fixture should read"))
+        );
+        ExactVersionRegistrySources {
+            contract_url: format!("file://{}", contract_src.display()),
+            contract_digest,
+            artifact_url: format!("file://{}", artifact_src.display()),
+            artifact_digest,
+        }
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn write_exact_version_registry_state(
+        state_root: &Path,
+        version: &str,
+        contract_url: &str,
+        contract_digest: &str,
+        artifact_url: &str,
+        artifact_digest: &str,
+        deprecated: bool,
+    ) {
+        write_synced_public_registry_state(
+            state_root,
+            "local",
+            "fixture-registry",
+            "fixture-v1",
+            "2026-07-22T00:00:00Z",
+            PublicRegistryIndex {
+                index_version: 1,
+                generated_at: "2026-07-22T00:00:00Z".to_string(),
+                source_commit: None,
+                capabilities: vec![PublicRegistryCapabilityRecord {
+                    namespace: "fixture".to_string(),
+                    id: "expedition.planning.validate-team-readiness".to_string(),
+                    version: version.to_string(),
+                    digest: artifact_digest.to_string(),
+                    artifact_url: artifact_url.to_string(),
+                    contract_digest: contract_digest.to_string(),
+                    contract_url: contract_url.to_string(),
+                    deprecated,
+                    summary: String::new(),
+                    description: String::new(),
+                    use_cases: Vec::new(),
+                    service_type: "stateless".to_string(),
+                    permitted_targets: Vec::new(),
+                    lifecycle: "active".to_string(),
+                    provenance: None,
+                }],
+                events: Vec::new(),
+            },
+        )
+        .expect("synced fixture state should persist");
+    }
+
+    fn first_error_code(output: &str) -> String {
+        let json: Value = serde_json::from_str(output).expect("cli output must be JSON");
+        assert_eq!(json["status"], "failed", "expected a failed resolution");
+        json["errors"][0]["code"]
+            .as_str()
+            .expect("error code must be a string")
+            .to_string()
+    }
+
+    fn first_error_message(output: &str) -> String {
+        let json: Value = serde_json::from_str(output).expect("cli output must be JSON");
+        json["errors"][0]["message"]
+            .as_str()
+            .expect("error message must be a string")
+            .to_string()
+    }
+
+    #[test]
+    fn exact_version_registry_ref_resolves_when_every_boundary_passes() {
+        // Anchors the fixture: with every boundary satisfied the exact `=1.0.1`
+        // reference validates, so the negative cases below fail only for their
+        // injected reason.
+        let state_root = unique_temp_dir();
+        let fixture_root = unique_temp_dir();
+        let sources = exact_version_registry_sources();
+        let manifest_path =
+            write_registry_ref_app_fixture(&fixture_root, &sources.artifact_digest, "=1.0.1");
+        write_exact_version_registry_state(
+            &state_root,
+            "1.0.1",
+            &sources.contract_url,
+            &sources.contract_digest,
+            &sources.artifact_url,
+            &sources.artifact_digest,
+            false,
+        );
+
+        let output = app_validate_at(&state_root, &manifest_path, Some("local"), true)
+            .expect("exact-version reference should validate");
+        let json: Value = serde_json::from_str(&output).expect("validation output must be JSON");
+        assert_eq!(json["status"], "validated");
+    }
+
+    #[test]
+    fn exact_version_registry_ref_never_falls_back_to_another_version() {
+        // Spec 1258 FR-002 / #1272 AC5: an exact `=1.0.1` request must not
+        // resolve `1.0.0`.
+        let state_root = unique_temp_dir();
+        let fixture_root = unique_temp_dir();
+        let sources = exact_version_registry_sources();
+        let manifest_path =
+            write_registry_ref_app_fixture(&fixture_root, &sources.artifact_digest, "=1.0.1");
+        write_exact_version_registry_state(
+            &state_root,
+            "1.0.0",
+            &sources.contract_url,
+            &sources.contract_digest,
+            &sources.artifact_url,
+            &sources.artifact_digest,
+            false,
+        );
+
+        let output = app_register_at(&state_root, &manifest_path, "local", true)
+            .expect("version miss should render stable JSON evidence");
+        assert_eq!(
+            first_error_code(&output),
+            "registry_reference_requires_resolution"
+        );
+        assert!(
+            first_error_message(&output).contains("=1.0.1"),
+            "message should name the requested exact range"
+        );
+        assert!(
+            !state_root.join(".traverse/workspaces/local/apps").exists(),
+            "no registration state may be written when the exact version is absent"
+        );
+    }
+
+    #[test]
+    fn registry_ref_contract_and_artifact_fetch_failures_are_indistinguishable() {
+        // Both a contract-URL failure and an artifact-URL failure surface the
+        // identical code AND the identical literal message, with no HTTP status
+        // and no indication of which asset failed.
+        let sources = exact_version_registry_sources();
+
+        let contract_state_root = unique_temp_dir();
+        let contract_fixture_root = unique_temp_dir();
+        let contract_manifest = write_registry_ref_app_fixture(
+            &contract_fixture_root,
+            &sources.artifact_digest,
+            "=1.0.1",
+        );
+        write_exact_version_registry_state(
+            &contract_state_root,
+            "1.0.1",
+            &format!(
+                "file://{}",
+                contract_fixture_root.join("absent-contract.json").display()
+            ),
+            &sources.contract_digest,
+            &sources.artifact_url,
+            &sources.artifact_digest,
+            false,
+        );
+        let contract_output = app_validate_at(
+            &contract_state_root,
+            &contract_manifest,
+            Some("local"),
+            true,
+        )
+        .expect("contract fetch failure should render JSON evidence");
+
+        let artifact_state_root = unique_temp_dir();
+        let artifact_fixture_root = unique_temp_dir();
+        let artifact_manifest = write_registry_ref_app_fixture(
+            &artifact_fixture_root,
+            &sources.artifact_digest,
+            "=1.0.1",
+        );
+        write_exact_version_registry_state(
+            &artifact_state_root,
+            "1.0.1",
+            &sources.contract_url,
+            &sources.contract_digest,
+            &format!(
+                "file://{}",
+                artifact_fixture_root.join("absent-artifact.wasm").display()
+            ),
+            &sources.artifact_digest,
+            false,
+        );
+        let artifact_output = app_validate_at(
+            &artifact_state_root,
+            &artifact_manifest,
+            Some("local"),
+            true,
+        )
+        .expect("artifact fetch failure should render JSON evidence");
+
+        assert_eq!(
+            first_error_code(&contract_output),
+            "registry_reference_requires_resolution"
+        );
+        assert_eq!(
+            first_error_code(&artifact_output),
+            "registry_reference_requires_resolution"
+        );
+        assert_eq!(
+            first_error_message(&contract_output),
+            "registry asset download failed"
+        );
+        assert_eq!(
+            first_error_message(&contract_output),
+            first_error_message(&artifact_output),
+            "contract-URL and artifact-URL failures must be told apart by the next slice"
+        );
+    }
+
+    #[test]
+    fn registry_ref_digest_mismatch_collapses_and_leaks_cache_path() {
+        // CHARACTERIZATION: a contract digest mismatch collapses onto the same
+        // code as every other boundary, and the message embeds the local
+        // content-addressed cache path -- a redaction defect the successor
+        // slice must close (spec 1258 FR-003).
+        let state_root = unique_temp_dir();
+        let fixture_root = unique_temp_dir();
+        let sources = exact_version_registry_sources();
+        let manifest_path =
+            write_registry_ref_app_fixture(&fixture_root, &sources.artifact_digest, "=1.0.1");
+        let wrong_contract_digest = format!("sha256:{}", "0".repeat(64));
+        write_exact_version_registry_state(
+            &state_root,
+            "1.0.1",
+            &sources.contract_url,
+            &wrong_contract_digest,
+            &sources.artifact_url,
+            &sources.artifact_digest,
+            false,
+        );
+
+        let output = app_validate_at(&state_root, &manifest_path, Some("local"), true)
+            .expect("digest mismatch should render JSON evidence");
+        assert_eq!(
+            first_error_code(&output),
+            "registry_reference_requires_resolution"
+        );
+        let message = first_error_message(&output);
+        assert!(
+            message.contains("digest mismatch"),
+            "message should mention the digest mismatch: {message}"
+        );
+        assert!(
+            message.contains(".traverse/cache/sha256"),
+            "characterizes the current cache-path leak; the successor slice must redact this: {message}"
+        );
+    }
+
+    #[test]
+    #[allow(clippy::too_many_lines)] // Exercises five distinct resolution boundaries in one place.
+    fn every_registry_resolution_boundary_collapses_to_one_code() {
+        // Five semantically distinct boundaries -> one error code today.
+        let sources = exact_version_registry_sources();
+        let mut codes = std::collections::BTreeSet::new();
+
+        // 1. Index selection: synced state present but no record for the id.
+        {
+            let state_root = unique_temp_dir();
+            let fixture_root = unique_temp_dir();
+            let manifest_path =
+                write_registry_ref_app_fixture(&fixture_root, &sources.artifact_digest, "=1.0.1");
+            write_synced_public_registry_state(
+                &state_root,
+                "local",
+                "fixture-registry",
+                "fixture-v1",
+                "2026-07-22T00:00:00Z",
+                PublicRegistryIndex {
+                    index_version: 1,
+                    generated_at: "2026-07-22T00:00:00Z".to_string(),
+                    source_commit: None,
+                    capabilities: vec![registry_record_fixture(
+                        "fixture",
+                        "expedition.planning.some-other-capability",
+                        "1.0.1",
+                    )],
+                    events: Vec::new(),
+                },
+            )
+            .expect("synced fixture state should persist");
+            let output = app_validate_at(&state_root, &manifest_path, Some("local"), true)
+                .expect("index miss should render JSON evidence");
+            codes.insert(first_error_code(&output));
+        }
+
+        // 2. Version range: only 1.0.0 present, 1.0.1 requested.
+        {
+            let state_root = unique_temp_dir();
+            let fixture_root = unique_temp_dir();
+            let manifest_path =
+                write_registry_ref_app_fixture(&fixture_root, &sources.artifact_digest, "=1.0.1");
+            write_exact_version_registry_state(
+                &state_root,
+                "1.0.0",
+                &sources.contract_url,
+                &sources.contract_digest,
+                &sources.artifact_url,
+                &sources.artifact_digest,
+                false,
+            );
+            let output = app_validate_at(&state_root, &manifest_path, Some("local"), true)
+                .expect("version miss should render JSON evidence");
+            codes.insert(first_error_code(&output));
+        }
+
+        // 3. Lifecycle: the only matching version is deprecated.
+        {
+            let state_root = unique_temp_dir();
+            let fixture_root = unique_temp_dir();
+            let manifest_path =
+                write_registry_ref_app_fixture(&fixture_root, &sources.artifact_digest, "=1.0.1");
+            write_exact_version_registry_state(
+                &state_root,
+                "1.0.1",
+                &sources.contract_url,
+                &sources.contract_digest,
+                &sources.artifact_url,
+                &sources.artifact_digest,
+                true,
+            );
+            let output = app_validate_at(&state_root, &manifest_path, Some("local"), true)
+                .expect("deprecated-only should render JSON evidence");
+            codes.insert(first_error_code(&output));
+        }
+
+        // 4. Contract retrieval: contract URL unreachable.
+        {
+            let state_root = unique_temp_dir();
+            let fixture_root = unique_temp_dir();
+            let manifest_path =
+                write_registry_ref_app_fixture(&fixture_root, &sources.artifact_digest, "=1.0.1");
+            write_exact_version_registry_state(
+                &state_root,
+                "1.0.1",
+                &format!(
+                    "file://{}",
+                    fixture_root.join("absent-contract.json").display()
+                ),
+                &sources.contract_digest,
+                &sources.artifact_url,
+                &sources.artifact_digest,
+                false,
+            );
+            let output = app_validate_at(&state_root, &manifest_path, Some("local"), true)
+                .expect("contract fetch failure should render JSON evidence");
+            codes.insert(first_error_code(&output));
+        }
+
+        // 5. Contract digest: fetched bytes do not match the declared digest.
+        {
+            let state_root = unique_temp_dir();
+            let fixture_root = unique_temp_dir();
+            let manifest_path =
+                write_registry_ref_app_fixture(&fixture_root, &sources.artifact_digest, "=1.0.1");
+            write_exact_version_registry_state(
+                &state_root,
+                "1.0.1",
+                &sources.contract_url,
+                &format!("sha256:{}", "0".repeat(64)),
+                &sources.artifact_url,
+                &sources.artifact_digest,
+                false,
+            );
+            let output = app_validate_at(&state_root, &manifest_path, Some("local"), true)
+                .expect("digest mismatch should render JSON evidence");
+            codes.insert(first_error_code(&output));
+        }
+
+        assert_eq!(
+            codes,
+            std::collections::BTreeSet::from(
+                ["registry_reference_requires_resolution".to_string()]
+            ),
+            "all five boundaries collapse onto one code today: {codes:?}"
+        );
     }
 
     #[test]

--- a/crates/traverse-cli/src/registry_resolution_diagnostics.rs
+++ b/crates/traverse-cli/src/registry_resolution_diagnostics.rs
@@ -1,0 +1,476 @@
+//! Diagnosis harness for exact-version `registry_ref` resolution failures
+//! (issue #1273, governing spec `1258-offline-cache-activation`).
+//!
+//! This module is **diagnosis only** and is compiled under `#[cfg(test)]`. It
+//! does not change resolution or activation semantics. It captures, as an
+//! executable specification, the stable per-boundary error taxonomy that the
+//! successor implementation slice (#1272) must surface from
+//! [`crate::SyncedRegistryComponentResolver`].
+//!
+//! Today every boundary below collapses onto the single
+//! `ApplicationManifestErrorCode::RegistryReferenceRequiresResolution` code, and
+//! [`RegistryResolutionStage::Signature`], [`RegistryResolutionStage::Abi`], and
+//! [`RegistryResolutionStage::Target`] are not evaluated at all. See
+//! `docs/registry-resolution-diagnosis.md` and
+//! `tests/fixtures/registry-resolution/boundary-error-map.json`.
+
+/// One boundary in exact-version `registry_ref` resolution, in evaluation
+/// order. [`classify`] reports the first boundary that fails, so the ordering is
+/// part of the contract: an earlier failure hides later ones.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum RegistryResolutionStage {
+    /// Synced state presence/readability and a record for the namespace/id.
+    IndexSelection,
+    /// The exact `==x.y.z` range selects a synced version (never a fallback).
+    VersionRange,
+    /// The selected version is activatable (not deprecated/yanked/draft).
+    Lifecycle,
+    /// Contract bytes are retrievable.
+    ContractRetrieval,
+    /// Contract bytes match `contract_digest`.
+    ContractDigest,
+    /// Artifact bytes are retrievable.
+    ArtifactRetrieval,
+    /// Artifact bytes match `digest`.
+    ArtifactDigest,
+    /// The signed trust bundle verifies.
+    Signature,
+    /// The artifact Host ABI major is supported by this build.
+    Abi,
+    /// The selected version permits the requested placement target.
+    Target,
+    /// Verified bytes commit to the immutable digest-keyed cache.
+    CachePersistence,
+}
+
+impl RegistryResolutionStage {
+    /// Every boundary, in evaluation order.
+    pub const ALL: [RegistryResolutionStage; 11] = [
+        RegistryResolutionStage::IndexSelection,
+        RegistryResolutionStage::VersionRange,
+        RegistryResolutionStage::Lifecycle,
+        RegistryResolutionStage::ContractRetrieval,
+        RegistryResolutionStage::ContractDigest,
+        RegistryResolutionStage::ArtifactRetrieval,
+        RegistryResolutionStage::ArtifactDigest,
+        RegistryResolutionStage::Signature,
+        RegistryResolutionStage::Abi,
+        RegistryResolutionStage::Target,
+        RegistryResolutionStage::CachePersistence,
+    ];
+
+    /// Stable snake_case identifier used in the fixture map and (by the
+    /// successor slice) in emitted evidence.
+    pub fn slug(self) -> &'static str {
+        match self {
+            RegistryResolutionStage::IndexSelection => "index_selection",
+            RegistryResolutionStage::VersionRange => "version_range",
+            RegistryResolutionStage::Lifecycle => "lifecycle",
+            RegistryResolutionStage::ContractRetrieval => "contract_retrieval",
+            RegistryResolutionStage::ContractDigest => "contract_digest",
+            RegistryResolutionStage::ArtifactRetrieval => "artifact_retrieval",
+            RegistryResolutionStage::ArtifactDigest => "artifact_digest",
+            RegistryResolutionStage::Signature => "signature",
+            RegistryResolutionStage::Abi => "abi",
+            RegistryResolutionStage::Target => "target",
+            RegistryResolutionStage::CachePersistence => "cache_persistence",
+        }
+    }
+
+    /// Proposed stable error code for this boundary (issue #1273 deliverable).
+    pub fn proposed_code(self) -> &'static str {
+        match self {
+            RegistryResolutionStage::IndexSelection => "registry_index_selection_failed",
+            RegistryResolutionStage::VersionRange => "registry_version_range_unsatisfied",
+            RegistryResolutionStage::Lifecycle => "registry_lifecycle_rejected",
+            RegistryResolutionStage::ContractRetrieval => "registry_contract_unreachable",
+            RegistryResolutionStage::ContractDigest => "registry_contract_digest_mismatch",
+            RegistryResolutionStage::ArtifactRetrieval => "registry_artifact_unreachable",
+            RegistryResolutionStage::ArtifactDigest => "registry_artifact_digest_mismatch",
+            RegistryResolutionStage::Signature => "registry_signature_unverified",
+            RegistryResolutionStage::Abi => "registry_abi_incompatible",
+            RegistryResolutionStage::Target => "registry_target_incompatible",
+            RegistryResolutionStage::CachePersistence => "registry_cache_commit_failed",
+        }
+    }
+
+    /// Fixed, path/URL/credential-free one-line summary for this boundary.
+    pub fn summary(self) -> &'static str {
+        match self {
+            RegistryResolutionStage::IndexSelection => {
+                "synced registry state is missing, unreadable, or has no record for this capability"
+            }
+            RegistryResolutionStage::VersionRange => {
+                "no synced version satisfies the requested exact range; resolver does not fall back"
+            }
+            RegistryResolutionStage::Lifecycle => {
+                "the selected version is not in an activatable lifecycle state"
+            }
+            RegistryResolutionStage::ContractRetrieval => {
+                "the capability contract could not be retrieved"
+            }
+            RegistryResolutionStage::ContractDigest => {
+                "retrieved contract bytes do not match the expected contract digest"
+            }
+            RegistryResolutionStage::ArtifactRetrieval => {
+                "the capability artifact could not be retrieved"
+            }
+            RegistryResolutionStage::ArtifactDigest => {
+                "retrieved artifact bytes do not match the expected artifact digest"
+            }
+            RegistryResolutionStage::Signature => {
+                "the signed trust bundle for the artifact did not verify"
+            }
+            RegistryResolutionStage::Abi => {
+                "the artifact Host ABI major version is not supported by this build"
+            }
+            RegistryResolutionStage::Target => {
+                "the selected version does not permit the requested placement target"
+            }
+            RegistryResolutionStage::CachePersistence => {
+                "verified bytes could not be committed to the immutable digest-keyed cache"
+            }
+        }
+    }
+}
+
+/// Non-secret identity facts about the `registry_ref` under diagnosis. Only
+/// these fields (plus the stage slug/code/summary) are permitted in redacted
+/// evidence per spec `1258-offline-cache-activation` FR-003.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RegistryReferenceFacts {
+    pub namespace: String,
+    pub id: String,
+    pub requested_range: String,
+    pub selected_version: Option<String>,
+    pub contract_digest: Option<String>,
+    pub artifact_digest: Option<String>,
+    pub target: Option<String>,
+}
+
+impl RegistryReferenceFacts {
+    /// Returns `Err` with the offending field name if any fact carries a
+    /// filesystem path, URL, endpoint, or credential-shaped token.
+    pub fn assert_redacted(&self) -> Result<(), String> {
+        let fields = [
+            ("namespace", Some(self.namespace.as_str())),
+            ("id", Some(self.id.as_str())),
+            ("requested_range", Some(self.requested_range.as_str())),
+            ("selected_version", self.selected_version.as_deref()),
+            ("contract_digest", self.contract_digest.as_deref()),
+            ("artifact_digest", self.artifact_digest.as_deref()),
+            ("target", self.target.as_deref()),
+        ];
+        for (name, value) in fields {
+            let Some(value) = value else { continue };
+            let lower = value.to_ascii_lowercase();
+            let leaks = value.contains('/')
+                || value.contains('\\')
+                || lower.contains("://")
+                || lower.contains("authorization")
+                || lower.contains("bearer ")
+                || lower.contains("secret")
+                || lower.contains("password")
+                || lower.contains("token=");
+            if leaks {
+                return Err(name.to_string());
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Outcome observed at one boundary during a resolution attempt.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BoundaryOutcome {
+    /// The boundary was evaluated and passed.
+    Passed,
+    /// The boundary was not reached (an earlier boundary stopped resolution) or
+    /// is not evaluated by the current resolver.
+    NotEvaluated,
+    /// The boundary was evaluated and failed.
+    Failed,
+}
+
+/// Per-boundary outcomes for one resolution attempt, plus the reference facts.
+#[derive(Debug, Clone)]
+pub struct RegistryResolutionObservation {
+    pub reference: RegistryReferenceFacts,
+    outcomes: [(RegistryResolutionStage, BoundaryOutcome); 11],
+}
+
+impl RegistryResolutionObservation {
+    /// A fully-passing observation for `reference`; mutate individual boundaries
+    /// with [`Self::with`].
+    pub fn all_passed(reference: RegistryReferenceFacts) -> Self {
+        Self {
+            reference,
+            outcomes: RegistryResolutionStage::ALL.map(|stage| (stage, BoundaryOutcome::Passed)),
+        }
+    }
+
+    /// Sets one boundary's outcome.
+    #[must_use]
+    pub fn with(mut self, stage: RegistryResolutionStage, outcome: BoundaryOutcome) -> Self {
+        for entry in &mut self.outcomes {
+            if entry.0 == stage {
+                entry.1 = outcome;
+            }
+        }
+        self
+    }
+}
+
+/// A stable, redacted diagnostic for the first failing boundary.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RegistryResolutionDiagnostic {
+    pub stage: RegistryResolutionStage,
+    pub code: &'static str,
+    pub summary: &'static str,
+    pub reference: RegistryReferenceFacts,
+}
+
+impl RegistryResolutionDiagnostic {
+    /// Redacted evidence object: only the fields permitted by spec
+    /// `1258-offline-cache-activation` FR-003.
+    pub fn redacted_evidence(&self) -> serde_json::Value {
+        let mut object = serde_json::Map::new();
+        object.insert("stage".to_string(), self.stage.slug().into());
+        object.insert("code".to_string(), self.code.into());
+        object.insert("summary".to_string(), self.summary.into());
+        object.insert(
+            "namespace".to_string(),
+            self.reference.namespace.clone().into(),
+        );
+        object.insert("id".to_string(), self.reference.id.clone().into());
+        object.insert(
+            "requested_range".to_string(),
+            self.reference.requested_range.clone().into(),
+        );
+        if let Some(version) = &self.reference.selected_version {
+            object.insert("selected_version".to_string(), version.clone().into());
+        }
+        if let Some(digest) = &self.reference.contract_digest {
+            object.insert("contract_digest".to_string(), digest.clone().into());
+        }
+        if let Some(digest) = &self.reference.artifact_digest {
+            object.insert("artifact_digest".to_string(), digest.clone().into());
+        }
+        if let Some(target) = &self.reference.target {
+            object.insert("target".to_string(), target.clone().into());
+        }
+        serde_json::Value::Object(object)
+    }
+}
+
+/// Returns a diagnostic for the first failing boundary in evaluation order, or
+/// `None` when every boundary passed. Deterministic: the boundary ordering is
+/// fixed, so the same observation always yields the same diagnostic (no silent
+/// ambiguity, per the constitution's resolution-behavior rule).
+pub fn classify(
+    observation: &RegistryResolutionObservation,
+) -> Option<RegistryResolutionDiagnostic> {
+    observation
+        .outcomes
+        .iter()
+        .find(|(_, outcome)| *outcome == BoundaryOutcome::Failed)
+        .map(|(stage, _)| RegistryResolutionDiagnostic {
+            stage: *stage,
+            code: stage.proposed_code(),
+            summary: stage.summary(),
+            reference: observation.reference.clone(),
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::expect_used)]
+
+    use super::{
+        BoundaryOutcome, RegistryReferenceFacts, RegistryResolutionObservation,
+        RegistryResolutionStage, classify,
+    };
+    use std::collections::BTreeSet;
+
+    fn facts() -> RegistryReferenceFacts {
+        RegistryReferenceFacts {
+            namespace: "diagnostic".to_string(),
+            id: "diagnostic.evidence-normalize".to_string(),
+            requested_range: "==1.0.1".to_string(),
+            selected_version: Some("1.0.1".to_string()),
+            contract_digest: Some("sha256:".to_string() + &"a".repeat(64)),
+            artifact_digest: Some("sha256:".to_string() + &"b".repeat(64)),
+            target: Some("local".to_string()),
+        }
+    }
+
+    #[test]
+    fn every_boundary_has_a_distinct_stable_code() {
+        let mut codes = BTreeSet::new();
+        let mut slugs = BTreeSet::new();
+        for stage in RegistryResolutionStage::ALL {
+            assert!(
+                codes.insert(stage.proposed_code()),
+                "duplicate proposed_code for {stage:?}"
+            );
+            assert!(slugs.insert(stage.slug()), "duplicate slug for {stage:?}");
+            assert!(
+                stage.proposed_code().starts_with("registry_"),
+                "{stage:?} code is not registry_-prefixed"
+            );
+            assert!(
+                stage
+                    .proposed_code()
+                    .bytes()
+                    .all(|b| b.is_ascii_lowercase() || b == b'_'),
+                "{stage:?} code is not snake_case"
+            );
+        }
+        assert_eq!(codes.len(), RegistryResolutionStage::ALL.len());
+    }
+
+    #[test]
+    fn classify_reports_first_failing_boundary_in_evaluation_order() {
+        // Lifecycle (order 3) and Target (order 10) both fail; the earlier one wins.
+        let observation = RegistryResolutionObservation::all_passed(facts())
+            .with(RegistryResolutionStage::Lifecycle, BoundaryOutcome::Failed)
+            .with(RegistryResolutionStage::Target, BoundaryOutcome::Failed);
+        let diagnostic = classify(&observation).expect("a failing boundary yields a diagnostic");
+        assert_eq!(diagnostic.stage, RegistryResolutionStage::Lifecycle);
+        assert_eq!(diagnostic.code, "registry_lifecycle_rejected");
+    }
+
+    #[test]
+    fn classify_is_none_when_every_boundary_passes() {
+        let observation = RegistryResolutionObservation::all_passed(facts());
+        assert!(classify(&observation).is_none());
+    }
+
+    #[test]
+    fn classify_skips_not_evaluated_boundaries() {
+        // A boundary the resolver never reached (or never checks) must not be
+        // reported as the failure; only an actual `Failed` boundary is.
+        let observation = RegistryResolutionObservation::all_passed(facts())
+            .with(
+                RegistryResolutionStage::Signature,
+                BoundaryOutcome::NotEvaluated,
+            )
+            .with(RegistryResolutionStage::Abi, BoundaryOutcome::NotEvaluated)
+            .with(RegistryResolutionStage::Target, BoundaryOutcome::Failed);
+        let diagnostic = classify(&observation).expect("the failed boundary yields a diagnostic");
+        assert_eq!(diagnostic.stage, RegistryResolutionStage::Target);
+    }
+
+    #[test]
+    fn each_boundary_maps_to_its_own_diagnostic() {
+        for stage in RegistryResolutionStage::ALL {
+            let observation = RegistryResolutionObservation::all_passed(facts())
+                .with(stage, BoundaryOutcome::Failed);
+            let diagnostic = classify(&observation).expect("failing boundary yields diagnostic");
+            assert_eq!(diagnostic.stage, stage);
+            assert_eq!(diagnostic.code, stage.proposed_code());
+        }
+    }
+
+    #[test]
+    fn redacted_evidence_carries_only_permitted_fields() {
+        let allowed: BTreeSet<&str> = [
+            "stage",
+            "code",
+            "summary",
+            "namespace",
+            "id",
+            "requested_range",
+            "selected_version",
+            "contract_digest",
+            "artifact_digest",
+            "target",
+        ]
+        .into_iter()
+        .collect();
+        for stage in RegistryResolutionStage::ALL {
+            let observation = RegistryResolutionObservation::all_passed(facts())
+                .with(stage, BoundaryOutcome::Failed);
+            let diagnostic = classify(&observation).expect("failing boundary yields diagnostic");
+            let evidence = diagnostic.redacted_evidence();
+            let object = evidence.as_object().expect("evidence is a JSON object");
+            for key in object.keys() {
+                assert!(
+                    allowed.contains(key.as_str()),
+                    "unexpected evidence field {key}"
+                );
+            }
+            let serialized = serde_json::to_string(&evidence).expect("evidence serializes");
+            assert!(
+                !serialized.contains('/'),
+                "evidence leaked a path/URL: {serialized}"
+            );
+            assert!(
+                !serialized.to_ascii_lowercase().contains("authorization"),
+                "evidence leaked a header: {serialized}"
+            );
+        }
+    }
+
+    #[test]
+    fn assert_redacted_rejects_paths_and_credentials() {
+        let mut leaky = facts();
+        leaky.id = "/home/ci/.traverse/cache/sha256/abcd".to_string();
+        assert_eq!(leaky.assert_redacted(), Err("id".to_string()));
+
+        let mut url = facts();
+        url.target = Some("https://registry.example/download?token=abc".to_string());
+        assert_eq!(url.assert_redacted(), Err("target".to_string()));
+
+        assert!(facts().assert_redacted().is_ok());
+    }
+
+    #[test]
+    fn proposed_map_fixture_matches_the_enum() {
+        let raw = include_str!("../tests/fixtures/registry-resolution/boundary-error-map.json");
+        let map: serde_json::Value = serde_json::from_str(raw).expect("fixture map parses");
+        assert_eq!(map["governing_spec"], "1258-offline-cache-activation");
+        assert_eq!(map["diagnosis_issue"], 1273);
+        assert_eq!(map["implementation_issue"], 1272);
+
+        let boundaries = map["boundaries"]
+            .as_array()
+            .expect("boundaries is an array");
+        assert_eq!(
+            boundaries.len(),
+            RegistryResolutionStage::ALL.len(),
+            "fixture boundary count must match the enum"
+        );
+        for (index, stage) in RegistryResolutionStage::ALL.into_iter().enumerate() {
+            let entry = &boundaries[index];
+            assert_eq!(entry["evaluation_order"], (index as u64) + 1);
+            assert_eq!(
+                entry["stage"],
+                stage.slug(),
+                "stage slug mismatch at {index}"
+            );
+            assert_eq!(
+                entry["proposed_code"],
+                stage.proposed_code(),
+                "proposed_code mismatch for {stage:?}"
+            );
+        }
+
+        let allowed = map["allowed_redacted_evidence_fields"]
+            .as_array()
+            .expect("allowed field list is an array");
+        for field in [
+            "namespace",
+            "id",
+            "requested_range",
+            "stage",
+            "code",
+            "summary",
+        ] {
+            assert!(
+                allowed.iter().any(|value| value == field),
+                "fixture allowed-field list is missing {field}"
+            );
+        }
+    }
+}

--- a/crates/traverse-cli/tests/fixtures/registry-resolution/boundary-error-map.json
+++ b/crates/traverse-cli/tests/fixtures/registry-resolution/boundary-error-map.json
@@ -1,0 +1,130 @@
+{
+  "governing_spec": "1258-offline-cache-activation",
+  "diagnosis_issue": 1273,
+  "implementation_issue": 1272,
+  "description": "Proposed stable, redacted error taxonomy for exact-version registry_ref resolution. `current_code` is what crates/traverse-cli/src/main.rs emits today; every boundary collapses onto the single ApplicationManifestErrorCode::RegistryReferenceRequiresResolution, and the boundaries marked `current_check: none` are not evaluated at all. The successor implementation slice (#1272) MUST surface `proposed_code` per boundary with only `redacted_evidence_fields` in evidence.",
+  "allowed_redacted_evidence_fields": [
+    "namespace",
+    "id",
+    "requested_range",
+    "selected_version",
+    "contract_digest",
+    "artifact_digest",
+    "trust_lifecycle",
+    "abi",
+    "target",
+    "placement",
+    "stage",
+    "code",
+    "summary"
+  ],
+  "forbidden_evidence": [
+    "local cache paths",
+    "artifact or contract URLs",
+    "registry endpoints",
+    "authorization headers or tokens",
+    "connector configuration values",
+    "artifact or contract bytes"
+  ],
+  "boundaries": [
+    {
+      "evaluation_order": 1,
+      "stage": "index_selection",
+      "proposed_code": "registry_index_selection_failed",
+      "current_code": "registry_reference_requires_resolution",
+      "current_check": "partial",
+      "meaning": "No synced public registry state, unreadable/parse-failed/schema-incompatible state, or no record for the requested namespace/id.",
+      "next_slice_contract": "Distinguish missing-sync from present-but-no-record; never emit the state file path."
+    },
+    {
+      "evaluation_order": 2,
+      "stage": "version_range",
+      "proposed_code": "registry_version_range_unsatisfied",
+      "current_code": "registry_reference_requires_resolution",
+      "current_check": "full",
+      "meaning": "An exact `==x.y.z` range matches no synced version. Resolver MUST NOT fall back to a different version.",
+      "next_slice_contract": "Report requested_range and the set of available versions by identity only; keep fail-closed, no fallback."
+    },
+    {
+      "evaluation_order": 3,
+      "stage": "lifecycle",
+      "proposed_code": "registry_lifecycle_rejected",
+      "current_code": "registry_reference_requires_resolution",
+      "current_check": "partial",
+      "meaning": "Selected version is not activatable. Today only the `deprecated` boolean is checked; `lifecycle` in {yanked, draft, inactive} is ignored.",
+      "next_slice_contract": "Gate on the record `lifecycle` field plus `deprecated`; report trust_lifecycle in evidence."
+    },
+    {
+      "evaluation_order": 4,
+      "stage": "contract_retrieval",
+      "proposed_code": "registry_contract_unreachable",
+      "current_code": "registry_reference_requires_resolution",
+      "current_check": "full",
+      "meaning": "Contract fetch failed at the transport/HTTP layer.",
+      "next_slice_contract": "Consume a prepared verified cache entry (spec 1258 FR-001); if a fetch layer remains, carry the HTTP status class and which asset failed, never the URL."
+    },
+    {
+      "evaluation_order": 5,
+      "stage": "contract_digest",
+      "proposed_code": "registry_contract_digest_mismatch",
+      "current_code": "registry_reference_requires_resolution",
+      "current_check": "full",
+      "meaning": "Fetched contract bytes do not match `contract_digest` from the index.",
+      "next_slice_contract": "Report contract_digest (expected) only; the current message leaks `.traverse/cache/sha256/<digest>` and MUST be redacted."
+    },
+    {
+      "evaluation_order": 6,
+      "stage": "artifact_retrieval",
+      "proposed_code": "registry_artifact_unreachable",
+      "current_code": "registry_reference_requires_resolution",
+      "current_check": "full",
+      "meaning": "Artifact fetch failed at the transport/HTTP layer. Today indistinguishable from contract_retrieval: both emit the literal \"registry asset download failed\".",
+      "next_slice_contract": "Separate artifact from contract failures with distinct codes."
+    },
+    {
+      "evaluation_order": 7,
+      "stage": "artifact_digest",
+      "proposed_code": "registry_artifact_digest_mismatch",
+      "current_code": "registry_reference_requires_resolution",
+      "current_check": "full",
+      "meaning": "Fetched artifact bytes do not match `digest` from the index.",
+      "next_slice_contract": "Report artifact_digest (expected) only; redact the cache path as above."
+    },
+    {
+      "evaluation_order": 8,
+      "stage": "signature",
+      "proposed_code": "registry_signature_unverified",
+      "current_code": null,
+      "current_check": "none",
+      "meaning": "The record's signature / trust bundle is missing or fails verification. Not checked anywhere in the CLI resolver today.",
+      "next_slice_contract": "Verify the signed bundle before the artifact is cached as activatable; report trust_lifecycle only."
+    },
+    {
+      "evaluation_order": 9,
+      "stage": "abi",
+      "proposed_code": "registry_abi_incompatible",
+      "current_code": null,
+      "current_check": "none",
+      "meaning": "Artifact Host ABI major version is not supported by this Traverse build. Not checked in the resolver today.",
+      "next_slice_contract": "Compare against SUPPORTED_HOST_ABI_VERSION; report abi (both sides) only."
+    },
+    {
+      "evaluation_order": 10,
+      "stage": "target",
+      "proposed_code": "registry_target_incompatible",
+      "current_code": null,
+      "current_check": "none",
+      "meaning": "The selected version's `permitted_targets` does not include the requested placement target. Not checked in the resolver today.",
+      "next_slice_contract": "Intersect record `permitted_targets` with the manifest placement target; report target and placement only."
+    },
+    {
+      "evaluation_order": 11,
+      "stage": "cache_persistence",
+      "proposed_code": "registry_cache_commit_failed",
+      "current_code": "registry_reference_requires_resolution",
+      "current_check": "full",
+      "meaning": "Verified bytes could not be committed to the content-addressed cache, or a different byte stream is already stored under the same digest key.",
+      "next_slice_contract": "Report the digest key only; keep the cache immutable and digest-keyed (spec 1258 FR-002)."
+    }
+  ]
+}

--- a/docs/registry-resolution-diagnosis.md
+++ b/docs/registry-resolution-diagnosis.md
@@ -1,0 +1,141 @@
+# Exact-version `registry_ref` resolution failure — diagnosis
+
+**Issue**: [#1273](https://github.com/traverse-framework/traverse/issues/1273)
+(diagnosis slice of [#1272](https://github.com/traverse-framework/traverse/issues/1272))
+**Governing spec**: `1258-offline-cache-activation`
+**Status**: diagnosis complete; implementation is the successor slice on #1272
+
+This document records the root cause of the opaque
+
+```json
+{"code":"registry_reference_requires_resolution","message":"registry asset download failed"}
+```
+
+failure reported for an active, signed, exact-version `registry_ref`, and
+proposes the stable redacted error taxonomy the successor slice must implement.
+No credentials, cache paths, authorization headers, endpoints, or artifact bytes
+appear here or in the checked-in fixtures.
+
+## Where resolution happens
+
+`crates/traverse-cli/src/main.rs` — `SyncedRegistryComponentResolver::resolve`,
+invoked from `app validate` and `app register` via
+`load_application_bundle_manifest_with_resolver`. It:
+
+1. calls `traverse_registry::resolve_synced_public_registry_range` (synced-state
+   read + semver selection, never a network call, no fallback);
+2. `cache_registry_asset` for the contract URL — cache-hit check, else
+   `curl -fsSL <url>`, then `cache_verified_public_registry_bytes` (digest
+   check + content-addressed write);
+3. `parse_contract` on the fetched bytes;
+4. `cache_registry_asset` for the artifact URL (same path as step 2).
+
+## Root cause
+
+**Every distinct failure boundary is reported under one error code with an
+unstructured message, and three boundaries are not evaluated at all.**
+
+1. **Code collapse.** `registry_resolution_failure()` hard-codes
+   `ApplicationManifestErrorCode::RegistryReferenceRequiresResolution` for
+   every failure — synced-state read, "no matching version", "deprecated
+   only", contract HTTP failure, artifact HTTP failure, digest mismatch,
+   contract parse failure, and cache write failure all share it. The
+   published `traverse-registry` crate (`=0.18.0`, immutable) also exposes
+   only this single `ApplicationManifestErrorCode` variant for the whole
+   resolution surface, so the finer taxonomy must be produced on the Traverse
+   (CLI) side before the `ApplicationManifestFailure` is constructed.
+2. **Message is free text, and lossy for HTTP failures.** The `curl` branch
+   returns the fixed literal `"registry asset download failed"` for *any*
+   non-zero exit — the exit status, the HTTP status class, and **which asset
+   (contract vs artifact)** are all discarded (`std::process::Command` output
+   is taken but `stderr` is never inspected, and `-f` suppresses the body).
+   A caller cannot tell a 404 on the contract from a 503 on the artifact.
+3. **Cache-path leak.** On a digest mismatch,
+   `cache_verified_public_registry_bytes` builds its message with
+   `path.display()` — the local content-addressed cache path
+   (`…/.traverse/cache/sha256/<digest>`) — and `SyncedRegistryComponentResolver`
+   flattens that straight into user-facing evidence. This violates spec
+   `1258-offline-cache-activation` FR-003 and the constitution's
+   "no credential/path leakage" rule. Characterized by
+   `registry_ref_digest_mismatch_collapses_and_leaks_cache_path`.
+4. **Un-evaluated boundaries.** The resolver performs **no** signature / trust
+   bundle verification, **no** Host ABI compatibility check, and **no**
+   placement-target eligibility check against the record's
+   `permitted_targets`. It also gates only on the `deprecated` boolean, not on
+   the record `lifecycle` field, so a `yanked` / `draft` / `inactive` exact
+   version is not rejected with a distinct reason.
+5. **Un-governed fetch.** Fetching happens through a `curl` subprocess during
+   `app validate` / `app register`. Spec `1258-offline-cache-activation`
+   FR-001 requires preparation/activation to consume an already-verified
+   host-owned cache entry and make no network request; the current path does
+   neither, and network/host/permission policy is not applied to the `curl`
+   call.
+
+The exact-version guarantee itself is intact: `resolve_synced_public_registry_range`
+never substitutes another version for an exact `==x.y.z` miss (verified by
+`exact_version_registry_ref_never_falls_back_to_another_version`).
+
+## Affected host targets
+
+| Target | Resolution path | Affected |
+| --- | --- | --- |
+| Local / native CLI (`app validate`, `app register`) | `SyncedRegistryComponentResolver` + `curl` subprocess | Yes — all findings above |
+| Browser / Web | `traverse-embedder` `registry_cache.rs` (separate) | Must expose equivalent codes/evidence per spec `1258` FR-006 — taxonomy below applies there too |
+| Edge / device | via embedder cache | Same as Web |
+
+## Reproduction (deterministic, offline)
+
+`crates/traverse-cli/src/main.rs` `#[cfg(test)] mod tests`:
+
+- `exact_version_registry_ref_resolves_when_every_boundary_passes` — anchors a
+  fully-valid exact `=1.0.1` fixture (`file://` URLs, real digests).
+- `exact_version_registry_ref_never_falls_back_to_another_version`
+- `registry_ref_contract_and_artifact_fetch_failures_are_indistinguishable`
+- `registry_ref_digest_mismatch_collapses_and_leaks_cache_path` (characterization)
+- `every_registry_resolution_boundary_collapses_to_one_code` — five boundaries,
+  one code.
+
+The taxonomy itself is an executable spec in
+`crates/traverse-cli/src/registry_resolution_diagnostics.rs` (stage enum,
+`classify` returning the first failing boundary in evaluation order, and
+`redacted_evidence` restricted to the permitted field set), with the
+machine-readable map at
+`crates/traverse-cli/tests/fixtures/registry-resolution/boundary-error-map.json`.
+
+## Proposed error-code map (contract for the #1272 implementation slice)
+
+Evaluated in order; the first failing boundary is reported. Evidence may carry
+only: `namespace`, `id`, `requested_range`, `selected_version`,
+`contract_digest`, `artifact_digest`, `trust_lifecycle`, `abi`, `target`,
+`placement`, `stage`, `code`, `summary`.
+
+| # | Stage | Proposed code | Today |
+| --- | --- | --- | --- |
+| 1 | index selection | `registry_index_selection_failed` | collapsed |
+| 2 | version range | `registry_version_range_unsatisfied` | collapsed |
+| 3 | lifecycle | `registry_lifecycle_rejected` | partial (`deprecated` only) |
+| 4 | contract retrieval | `registry_contract_unreachable` | collapsed, message lossy |
+| 5 | contract digest | `registry_contract_digest_mismatch` | collapsed, **path leak** |
+| 6 | artifact retrieval | `registry_artifact_unreachable` | collapsed, message lossy |
+| 7 | artifact digest | `registry_artifact_digest_mismatch` | collapsed, **path leak** |
+| 8 | signature | `registry_signature_unverified` | **not checked** |
+| 9 | ABI | `registry_abi_incompatible` | **not checked** |
+| 10 | target | `registry_target_incompatible` | **not checked** |
+| 11 | cache persistence | `registry_cache_commit_failed` | collapsed |
+
+## Recommendation for the successor slice
+
+1. Introduce a Traverse-side `RegistryResolutionError { stage, code, evidence }`
+   that the resolver produces before mapping to `ApplicationManifestFailure`;
+   keep one manifest-level code but carry the stage/code/redacted evidence in a
+   structured `details` field.
+2. Replace the `curl` subprocess with consumption of a prepared verified cache
+   entry (spec `1258` FR-001/FR-002); if any fetch layer remains, route it
+   through the governed network/host/permission policy and record only the HTTP
+   status class.
+3. Redact `cache_verified_public_registry_bytes` messages — key by digest, never
+   by path — or wrap them at the resolver boundary.
+4. Add the three missing boundaries (signature, ABI, target) and gate on the
+   record `lifecycle` field.
+5. Mirror the taxonomy in the `traverse-embedder` Web resolver so Rust and Web
+   expose equivalent evidence and error semantics (spec `1258` FR-006).


### PR DESCRIPTION
## Summary

Diagnosis slice of #1272. Pins the current behavior of `SyncedRegistryComponentResolver` in `crates/traverse-cli/src/main.rs`: every exact-version `registry_ref` resolution boundary collapses onto the single `ApplicationManifestErrorCode::RegistryReferenceRequiresResolution` code, the `curl` branch returns a fixed `"registry asset download failed"` for any HTTP failure (dropping the status and which asset failed), a contract/artifact digest mismatch leaks the local `.traverse/cache/sha256/<digest>` path into evidence, and signature / Host ABI / placement-target eligibility are not evaluated at all. No resolver or activation semantics change; existing local-component validation is unchanged.

## Governing Spec

- `106-activation-artifact-resolution`
- `125-synced-public-registry-preparation`
- `065-sigstore-bundle-verification`

Immediate governing successor is `1258-offline-cache-activation` (Approved 2026-09-07; extends `106`/`107`) — FR-003 (redacted evidence field set), FR-004 (stable secret-free per-boundary errors), FR-006 (Rust/Web parity). The approved ancestor specs above are what the spec-alignment gate maps to the changed files.

## Project Item

Traverse #1273 — In Progress

## Definition of Done

- [x] Deterministic exact-version reproduction and test fixture exist — `crates/traverse-cli/src/main.rs` `mod tests` (`exact_version_registry_ref_*`, `every_registry_resolution_boundary_collapses_to_one_code`) with checked-in `file://` fixtures, fully offline.
- [x] Each resolution stage has a stable, redacted diagnostic outcome — `crates/traverse-cli/src/registry_resolution_diagnostics.rs` (`RegistryResolutionStage`, `classify`, `redacted_evidence`).
- [x] Root cause and affected host targets documented — `docs/registry-resolution-diagnosis.md` + comment on #1272.
- [x] Proposed error-code map identifies the implementation contract for the next slice — `crates/traverse-cli/tests/fixtures/registry-resolution/boundary-error-map.json`.
- [x] Focused Rust validation/resolver tests pass.
- [x] No fixture stores credentials, local cache paths, authorization headers, or artifact bytes in evidence — enforced by `redacted_evidence_carries_only_permitted_fields` and `assert_redacted_rejects_paths_and_credentials`.
- [x] Existing local-component validation remains unchanged.

## Validation

- `cargo test -p traverse-cli-rs --bin traverse-cli` — 449 passed, 0 failed
- `cargo clippy -p traverse-cli-rs --all-targets` — clean
- `bash scripts/ci/spec_alignment_check.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #1273.
