### PR TITLE
docs: accept registry preparation ADR

### DIFF
--- a/docs/adr/0056-synced-public-registry-bundle-preparation.md
+++ b/docs/adr/0056-synced-public-registry-bundle-preparation.md
@@ -1,7 +1,8 @@
 # ADR-0056: Bridge Synced Public Index State Through an Explicit Prepared Bundle
 
-- Status: Proposed
-- Governing spec: `125-synced-public-registry-preparation` (Draft)
+- Status: Accepted
+- Date: 2026-08-29
+- Governing spec: `125-synced-public-registry-preparation` (Approved)
 - Extends: Specs 055, 118, 120, and 124; ADR-0051 and ADR-0055
 - Related issues: #1211, #1168, #1158, and `traverse-framework/registry` #328
 
@@ -41,3 +42,10 @@ subset of capabilities.
 - Add signature URLs to the registry index first: deferred because immutable
   sibling derivation from the already indexed contract URL is sufficient and
   keeps this slice additive.
+
+## Approval evidence
+
+The maintainer approved Spec 125 on 2026-08-29 after review against the live
+synced-index and published `signature.json` shape. The approved-spec registry
+records `125-synced-public-registry-preparation` at version 0.1.0. This ADR
+records that same approved decision; it does not alter the immutable spec.

--- a/specs/governance/approved-specs.json
+++ b/specs/governance/approved-specs.json
@@ -1660,7 +1660,8 @@
       "path": "specs/125-synced-public-registry-preparation/spec.md",
       "governs": [
         "crates/traverse-cli/",
-        "specs/125-synced-public-registry-preparation/"
+        "specs/125-synced-public-registry-preparation/",
+        "docs/adr/0056-synced-public-registry-bundle-preparation.md"
       ]
     },
     {


### PR DESCRIPTION
## Summary

Reconciles ADR-0056 with the already approved and registered Spec 125.

## Governing Spec

- `125-synced-public-registry-preparation`
- `004-spec-alignment-gate`

## Project Item

- https://github.com/orgs/traverse-framework/projects/1/views/1
- https://github.com/traverse-framework/traverse/issues/1274

## What Changed

- Contracts changed: none.
- Runtime behavior changed: none.
- Compatibility impact: none; records the existing approved decision.
- ADR needed or linked: ADR-0056.

## Validation

- [x] `BASE_SHA=origin/main bash scripts/ci/spec_alignment_check.sh /private/tmp/traverse-pr-1274.md`

## Notes

This governance-only PR keeps the preparation and activation chain in one approved artifact set. It unblocks, but does not close, implementation #1274.
