### PR TITLE
governance: approve app Registry preparation spec

### DIFF
--- a/specs/996-registry-app-preparation/spec.md
+++ b/specs/996-registry-app-preparation/spec.md
@@ -2,7 +2,9 @@
 
 **Feature Branch**: `codex/issue-1274-verified-registry-preparation`
 **Created**: 2026-09-08
-**Status**: Draft
+**Status**: Approved (2026-09-08)
+**Canonical governing ID**: `996-registry-app-preparation`
+**Version**: 0.1.0
 **Input**: Explicit host-run preparation for application Registry references; validation, activation, and execution remain offline consumers of verified cache evidence.
 
 ## Purpose

--- a/specs/governance/approved-specs.json
+++ b/specs/governance/approved-specs.json
@@ -1745,6 +1745,17 @@
         "specs/1277-browser-local-workflow-composition/",
         "docs/adr/0062-browser-local-workflow-composition.md"
       ]
+    },
+    {
+      "id": "996-registry-app-preparation",
+      "version": "0.1.0",
+      "status": "approved",
+      "immutable": true,
+      "path": "specs/996-registry-app-preparation/spec.md",
+      "governs": [
+        "crates/traverse-cli/",
+        "specs/996-registry-app-preparation/"
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary

Record the maintainer-approved immutable Spec 996 governing the explicit preparation boundary for application Registry references.

## Governing Spec

- `004-spec-alignment-gate`
- `125-synced-public-registry-preparation`
- `1258-offline-cache-activation`
- `996-registry-app-preparation`

## Project Item

- #1274

## Definition of Done

- [x] Maintainer approval records the immutable approved-spec entry.
- [ ] A compatible Registry contract release is published and pinned before implementation.

## Validation

- `git diff --check`
- `bash scripts/ci/spec_alignment_check.sh /private/tmp/issue-1274-pr-body.md`
