### PR TITLE
governance: approve specs 131, 130, 1256 and resolve ADR-0059 collision

### DIFF
--- a/docs/adr/0059-mixed-registry-reference-activation.md
+++ b/docs/adr/0059-mixed-registry-reference-activation.md
@@ -1,7 +1,8 @@
 # ADR-0059: Mixed Local and Registry-Reference Activation
 
-- Status: Proposed
-- Proposed governing spec: `130-mixed-registry-reference-activation`
+- Status: Accepted
+- Date: 2026-09-08
+- Governing spec: `130-mixed-registry-reference-activation` (Approved)
 - Related issue: #1258
 
 ## Context
@@ -12,7 +13,7 @@ activation-time artifact selection. Consequently, a mixed application can
 prepare and validate registry dependencies but has no governed offline path to
 activate them alongside local components.
 
-## Proposed Decision
+## Decision
 
 Extend activation with a resolver that treats a prepared verified cache entry
 as the sole admissible candidate for a `registry_ref` component. The host
@@ -39,3 +40,9 @@ certified across the native host matrix.
   obscures provenance and permits an unproven equivalent candidate.
 - Rewrite the application manifest after preparation: rejected because it
   changes portable application intent into host state.
+
+## Approval evidence
+
+The maintainer approved Spec 130 on 2026-09-08. The approved-spec registry
+records `130-mixed-registry-reference-activation` at version 1.0.0. This ADR
+records that approved decision; it does not alter the immutable spec.

--- a/docs/adr/0063-stateful-persistence-host-abi.md
+++ b/docs/adr/0063-stateful-persistence-host-abi.md
@@ -1,0 +1,129 @@
+# ADR-0063: Key-Value WASM Host ABI for Stateful Capability Persistence
+
+- Status: Accepted
+- Date: 2026-09-08
+- Governing spec: `131-stateful-persistence-host-abi` (Approved)
+- Extends: `002-capability-contracts`, `208-service-type-taxonomy` (`014`), `518-durable-local-datastore`
+- Related issue: #1285
+- Related: ADR-0035 (`098` event host ABI, the structural precedent); `docs/decision-log.md` Decision 68
+
+## Context
+
+`service_type: Stateful` has existed on `CapabilityContract` since spec `014`,
+and the placement evaluator already refuses to place a `Stateful` capability on
+`Browser`. But `crates/traverse-runtime/src/executor/host_abi_v1.json` exposes
+no persistence import — only WASI stdio, `traverse_host` environment/metadata
+queries, `emit_event`, and `connector_invoke`. A `Stateful` capability
+therefore cannot actually retain anything, and the Registry's mapped Wave 2
+roster (cart, ticket workspace, approval packet store, challenge session,
+pricing config, and more — registry decision-log entry 92) is blocked from
+publication. Registry decision 92 explicitly rejected "affinity-only /
+`prior_state` + `next_state` theater," so the fix has to be real managed
+persistence, not state threaded through capability I/O.
+
+The closest precedent is the event-publish ABI (spec `098` / ADR-0035): one
+whitelisted `traverse_host` import, a call-time `service_type` gate,
+synchronous validation, guest-memory bounds safety, and no back-compat tax
+(Decision 48). Traverse has no production users or capabilities today.
+
+## Decision
+
+Introduce a key-value host ABI of three flat `traverse_host` imports —
+`state_get`, `state_put`, `state_delete` — callable only by `Stateful`
+capabilities, and fold it into host ABI version 1. The shape follows Decision
+68:
+
+- **Three imports, not a handle table or a multiplexed `state_op`.** A flat KV
+  trio maps 1:1 onto DataStore v2 and spec `094` remote-KV, keeps each import
+  independently whitelisted and bounds-checkable exactly like `emit_event`, and
+  stays idiomatic with the existing `traverse_*` imports. No `list`, no batch,
+  no compare-and-swap in this version.
+- **Host-enforced `capability_id` namespace plus a caller-supplied opaque
+  `partition`.** The runtime composes the real key as
+  `capability_id / partition / key`; the guest never supplies or sees the
+  prefix. One deployed `commerce.cart` serves every shopper because the
+  per-user split is an opaque `partition` argument, while cross-capability and
+  cross-partition isolation is guaranteed by the host, not by guest
+  cooperation.
+- **Per-key `state_delete` only.** Partition-wide teardown stays with the
+  embedder and retention (spec `526`), which is accountable for retention and
+  backup. No `state_clear` import in this version.
+- **Serviced through an abstract host store interface with a written guarantee
+  floor** — integrity-checked reads, atomic writes, read-your-writes within a
+  partition, durability across restart — bound to DataStore v2 by default and
+  substitutable by any implementation meeting the floor. This matches
+  `connector_invoke` mediation and spec `519`'s embedder-owned framing.
+- **Fixed conservative bounds, no quota.** The spec fixes maximum partition
+  length, key length, and value size; the host validates guest pointer/length
+  against linear memory and rejects oversized or malformed input with stable
+  codes without trapping. No per-capability key-count or byte quota in this
+  version.
+- **Per-`(capability_id, partition)` serialization.** The host takes a
+  short-lived lock around each operation so the guest sees a plain sequential
+  model; different partitions and different capabilities are not serialized
+  against each other. This is DataStore's single-writer behavior (spec `518`
+  User Story 4) surfaced as the ABI's concurrency contract.
+- **Trace-journal metadata on mutation.** Each `state_put` / `state_delete`
+  appends an entry with `capability_id`, digested partition, key, value digest,
+  and `execution_id` — never the value. `state_get` is not traced. This gives
+  the audit-sensitive roster (`doc-approval.packet-store`,
+  `doc-approval.policy-store`) a real record without pulling business data into
+  the append-only journal or under spec `527` retention/encryption scope.
+- **`Stateful` + events multi-role is out of scope.** `service_type` is a
+  single enum and `098` FR-003 gates `emit_event` to `Subscribable`; the
+  intersection is a taxonomy question deferred to its own decision.
+
+## Consequences
+
+Host ABI version 1 gains three imports that must be whitelisted and documented
+alongside the existing `traverse_*` set, plus a `StatefulStore`-shaped host
+trait with a stated guarantee floor and a DataStore v2 default binding. The
+runtime gains a per-partition serialization point and a new trace-journal
+entry type. `Stateful` capabilities become executable and the Registry Wave 2
+roster becomes publishable. No migration or deprecation window is provided,
+consistent with Decision 48.
+
+Deferred, each to its own follow-up: a `state_clear(partition)` import, an
+embedder-set quota, `Stateful` on `Browser` via an IndexedDB-backed store,
+cross-execution compare-and-swap, and the `Stateful` + events multi-role
+taxonomy change.
+
+## Alternatives Considered
+
+- **Handle-based ABI** (`state_open` / `read` / `write` / `close` /
+  `dispose`) — rejected: five imports, a per-execution handle table for the
+  host to manage, and more failure modes (stale/double-close), heavier than any
+  existing capability ABI for no roster need.
+- **Single multiplexed `state_op(request_json)` import** — rejected: opaque to
+  static ABI inspection, which defeats the per-function whitelist that
+  `host_abi_v1.json` exists to provide.
+- **`capability_id` namespace only, no partition** — rejected: no structural
+  per-user boundary; a capability that forgets to namespace keys silently
+  shares one user's cart with all, and per-user retention has nothing to
+  target.
+- **Host-pinned scope from `runtime_config`** — rejected: one activation = one
+  scope, so N concurrent users need N activations or per-request rebinding;
+  does not fit a long-lived embedded host.
+- **Mandate DataStore v2 as the backing store** — rejected: couples the ABI to
+  the `518` + `528` + `092` surface, leaves no seam for tests or alternative
+  stores, and contradicts the mediation pattern used elsewhere in the runtime.
+- **Leave persistence entirely unspecified** — rejected: no durability /
+  integrity floor means "Stateful" promises nothing portable and registry
+  decision 92's "real managed persistence" bar goes unenforced.
+- **Expose contention / add compare-and-swap now** — deferred: every `Stateful`
+  capability would have to implement retry/backoff, and CAS widens `get`/`put`
+  with version tokens for a case the roster does not yet need.
+- **Full value in the trace journal** — rejected: doubles storage, brings
+  business data under spec `527` retention/encryption scope, and cuts against
+  the journal's metadata-not-payload intent.
+- **Relax the `Stateful` + `Browser` ban in this slice** — deferred: widens the
+  slice into an amendment of approved spec `014` for a capability class nothing
+  in the roster needs.
+
+## Approval evidence
+
+The maintainer directed on 2026-09-08, immediately after the Decision 68
+`/brainstorm`, that the spec and ADR be authored and approved rather than left
+as drafts. Spec `131-stateful-persistence-host-abi` is recorded in
+`specs/governance/approved-specs.json` at version 0.1.0. This ADR records that
+approved decision; it does not alter the immutable spec.

--- a/docs/adr/0064-registry-genericity-and-configuration-policy.md
+++ b/docs/adr/0064-registry-genericity-and-configuration-policy.md
@@ -1,9 +1,10 @@
-# ADR-0059: Registry Genericity and Configuration-Evolution Policy
+# ADR-0064: Registry Genericity and Configuration-Evolution Policy
 
-- Status: Proposed
-- Date: 2026-09-07
-- Governing spec: `1256-registry-genericity-policy` (Draft)
+- Status: Accepted
+- Date: 2026-09-08
+- Governing spec: `1256-registry-genericity-policy` (Approved)
 - Related issue: #1256
+- Supersedes numbering: originally filed as ADR-0059, renumbered to 0064 to resolve a collision with `0059-mixed-registry-reference-activation`.
 
 ## Context
 
@@ -46,3 +47,9 @@ records are audited only for confirmed violations.
   portability across materially different contexts.
 - Infer genericity from source code: rejected because it is unreliable and
   would create a false approval signal.
+
+## Approval evidence
+
+The maintainer approved Spec 1256 on 2026-09-08. The approved-spec registry
+records `1256-registry-genericity-policy` at version 0.1.0. This ADR records
+that approved decision; it does not alter the immutable spec.

--- a/docs/decision-log.md
+++ b/docs/decision-log.md
@@ -2794,3 +2794,271 @@ maintainer (none block on the runtime or another ticket):
    and `spec`, and post a closing-of-spec-phase comment linking Spec 129,
    ADR-0058, and PR #1245.
 3. Move the `#1235` project card from **Ready** to the backlog/later column.
+
+## Decision 68: Capability-Side WASM Host ABI for Stateful Persistence — New Spec, Key-Value Trio, Host-Isolated Partitions
+
+- **Date**: 2026-09-08
+- **Status**: Accepted; new governing spec + ADR to be drafted from this log
+- **Governing spec**: new spec (working title "Capability-Side WASM Host ABI for
+  Stateful Persistence"), extends `002-capability-contracts`,
+  `208-service-type-taxonomy` (canonical `014`), `518-durable-local-datastore`;
+  paired new ADR. Precedent: `098-capability-event-host-abi` / ADR-0035 /
+  Decisions 48–49.
+- **Related issues**: `#1285`
+- **Origin**: `/brainstorm` on `#1285` ("Host storage/lifecycle ABI needed for
+  UMA Stateful capabilities"), filed 2026-09-08 with no governing spec, no ADR,
+  no labels, and not on Project 1. Registry decision-log entry 92 (registry
+  repo) mapped ≥10 real Stateful capabilities (cart, ticket workspace, approval
+  packet store, challenge session, …) whose publication is blocked because
+  `host_abi_v1.json` exposes no managed-persistence import — only WASI stdio,
+  `traverse_host` environment/metadata queries, `emit_event`, and
+  `connector_invoke`. Owner-participated brainstorm; Enrico deferred each
+  sub-call to the recommendation.
+
+### Context
+
+`service_type: Stateful` already exists on `CapabilityContract` (spec
+`208`/`014`) and the placement evaluator already excludes `Browser` for it
+(`208` FR-005). What is missing is the runtime surface: a Stateful capability
+has no way to actually persist or read state during execution. The closest
+precedent is the event-publish ABI (`098`): one whitelisted `traverse_host`
+import, a call-time `service_type` gate, synchronous validation, guest-memory
+bounds safety (`098` FR-008), and no back-compat tax (Decision 48). Separately,
+DataStore v2 (`518` + `519`/`528`) is a mature host-side storage subsystem, but
+`518` is explicitly *embedder*-facing and states it does not add a capability
+contract or a global runtime storage policy.
+
+### Decision
+
+1. **Governance vehicle**: a new standalone spec + new ADR, mirroring how
+   `098`/ADR-0035 landed the event ABI. Not an amendment of `098` (tightly
+   scoped to event pub/sub, Approved v1.1.0) and not an addendum to `518`
+   (whose stated boundary explicitly excludes a capability-facing contract).
+2. **ABI surface**: a key-value trio of flat `traverse_host` imports —
+   `state_get`, `state_put`, `state_delete` — whitelisted and documented the
+   same way as existing `traverse_*` imports. No `list`, no batch, no
+   multiplexed single-import. Maps 1:1 onto DataStore v2 and `530` remote-KV.
+   List/batch may be added later as explicit named imports if a real capability
+   needs them.
+3. **Key scoping**: the host always prefixes storage with the calling
+   `capability_id` (guest cannot escape it or read another capability's state).
+   Within that, the guest passes an opaque `partition` (user id, session id, …)
+   per call and the host composes `capability_id / partition / key`. Call
+   signatures are `state_get(partition, key)`, `state_put(partition, key,
+   value)`, `state_delete(partition, key)`. The guest never sees raw storage
+   paths. This lets one `commerce.cart` deployment serve every shopper without
+   per-user activation; a guest partition bug can cross users *within its own
+   namespace* but never outside it.
+4. **Teardown**: per-key `state_delete` only in v1. Partition-wide clear is not
+   in the ABI — wholesale teardown stays with the embedder (retention spec
+   `526`), which is accountable for retention/backup. Roster's real "forget"
+   case (`identity.challenge-session`) writes few keys per partition. A
+   `state_clear(partition)` import may be added later if N-call cleanup proves a
+   problem.
+5. **Backing store**: the spec defines an abstract `StatefulStore`-shaped host
+   trait with a written guarantee floor — integrity-checked, atomic write,
+   read-your-writes within a partition, durable across restart. The embedded
+   host binds it to DataStore v2 by default; a host may substitute (in-memory
+   for tests, `530` remote-KV, Redis) provided the substitute meets the floor.
+   Matches `connector_invoke` mediation and `519`'s embedder-owned framing.
+6. **Bounds & quota**: the spec fixes conservative caps — max key length, max
+   partition length, max value size (≈1 MiB) — and the host validates the
+   guest-supplied pointer/length is within linear memory, rejects oversized
+   input with a stable error code, and never traps or panics (mirrors `098`
+   FR-008). No per-capability key-count or total-bytes quota in v1; an
+   embedder-set quota is a clean follow-up once real workloads exist to size
+   against (same reasoning spec `050` used).
+7. **Browser placement**: `208` FR-005's `Stateful` + `Browser` →
+   `InvalidPlacementConstraint` rule is left untouched in this slice. The
+   IndexedDB-backed relaxation (`Stateful` on `Browser` when a `528` DataStore
+   is bound) is recorded as an explicit follow-up, not done here — the entire
+   `#1285` roster is server/edge-side.
+8. **Concurrency**: the host takes a short-lived per-`(capability_id,
+   partition)` lock around each get/put/delete; the guest sees a plain
+   sequential model and never sees contention. Matches DataStore's single-writer
+   design (`518` US4). No compare-and-swap / version tokens in v1 — a
+   read-modify-write split across two executions still races unless done within
+   one execution; CAS is a follow-up if a capability needs cross-execution
+   optimistic concurrency.
+9. **Trace journal**: each `state_put` / `state_delete` appends a trace entry
+   carrying `capability_id`, digested `partition`, `key`, value `digest`, and
+   `execution_id` — never the value itself. `state_get` is not traced. Gives the
+   audit-sensitive roster items (`doc-approval.packet-store`,
+   `doc-approval.policy-store`) a real record without copying business data into
+   the append-only journal or bringing it under `527` retention/encryption
+   scope.
+10. **Stateful + events (multi-role)**: explicitly out of scope. `service_type`
+    is a single enum and `098` FR-003 gates `emit_event` to `Subscribable`
+    only, so a Stateful capability cannot emit/receive events. The spec gates
+    `state_*` to `service_type: Stateful` and records the multi-role gap
+    (session-flavored capabilities wanting both) as a known limitation deferred
+    to its own decision. The bulk of the roster is pure-Stateful.
+
+Inherited from the `098` precedent and baked into the spec without a separate
+sub-decision: call-time `service_type: Stateful` gate with synchronous
+rejection; stable, secret-free error codes returned to the guest; host never
+traps/panics; whitelist entries documented alongside the existing native-bridge
+ABI whitelist; folded into ABI v1 with no back-compat tax (Decision 48).
+
+### Alternatives Considered
+
+- **Amend `098` to cover storage too** — rejected; `098` is Approved v1.1.0 and
+  tightly scoped to event pub/sub, and widening it mixes two concerns in one
+  amendment of an approved spec.
+- **Fold into `518` as a capability-facing addendum** — rejected; `518`
+  explicitly does not add a capability contract or a global runtime storage
+  policy and is embedder-owned — a direct boundary contradiction.
+- **Handle-based ABI** (`state_open`/`read`/`write`/`close`/`dispose`) —
+  rejected; 5 imports vs 3, a per-execution handle table for the host to
+  manage, and more failure modes (stale/double-close), heavier than any
+  existing capability ABI for no roster need.
+- **Single multiplexed `state_op(request_json)` import** — rejected; opaque to
+  static ABI inspection, which defeats the per-function whitelist that
+  `host_abi_v1.json` exists to provide.
+- **`capability_id` namespace only, no partition** — rejected; no structural
+  per-user boundary, so a capability that forgets to namespace keys silently
+  shares one user's cart with all, and per-user retention/dispose has nothing
+  to target.
+- **Host-pinned scope from `runtime_config`** — rejected; one activation = one
+  scope, so N concurrent users need N activations or per-request rebinding;
+  does not fit a long-lived embedded host.
+- **Add `state_clear(partition)` now** (plain or contract-opt-in) — deferred;
+  overlaps embedder retention responsibility and adds ABI/contract surface the
+  roster does not yet need.
+- **Mandate DataStore v2 as the backing store** — rejected; couples the ABI to
+  the `518`+`528`+`522` surface, leaves no seam for tests or alternative
+  stores, and contradicts the mediation pattern used elsewhere in the runtime.
+- **Leave persistence entirely unspecified in v1** — rejected; no durability /
+  integrity floor means "Stateful" promises nothing portable and registry
+  decision-92's "real managed persistence" bar goes unenforced.
+- **`runtime_config`-driven quota in v1** — deferred; real Stateful workloads
+  do not exist yet to size a quota against.
+- **Relax the `Stateful` + `Browser` ban in this slice** — deferred; widens the
+  slice into an amendment of Approved spec `208`/`014` for a capability class
+  nothing in the roster needs.
+- **Expose contention / add CAS** — deferred; every Stateful capability would
+  have to implement retry/backoff, and CAS widens get/put with version tokens.
+- **Full value in the trace journal** — rejected; doubles storage, brings
+  business data under `527` retention/encryption scope, and cuts against the
+  journal's metadata-not-payload intent.
+- **Gate `state_*` on a contract `uses_storage` flag instead of the enum** —
+  rejected; adds a second axis beside `service_type`, and `208`'s placement
+  constraints are written against `service_type`, so a `Subscribable`+storage
+  capability would not inherit Stateful target rules — a real placement hole.
+- **Address multi-role (Stateful + events) here** — rejected; turns a focused
+  storage-ABI slice into a `service_type` taxonomy change touching Approved
+  specs `208`/`014` and `098`.
+
+### Outcome
+
+The design `#1285` asked for is settled. Remaining actions, all on the
+maintainer (none block on the runtime or another ticket):
+
+1. Draft the new governing spec from points 1–10 above (FRs for the three
+   imports, the `StatefulStore` guarantee floor, bounds, the call-time gate,
+   the trace-entry type) and its paired ADR; assign the canonical governing ID
+   at draft time.
+2. Triage `#1285` into a proper spec ticket: add it to Project 1, label it
+   `spec` / `runtime` / `security`, and give it a real Definition of Done
+   (spec + ADR approved, then the three imports implemented and whitelisted,
+   per-partition serialization, trace entries, negative fixtures for the gate /
+   bounds / wrong-`service_type` / missing-store cases).
+3. File follow-up tickets for the deferred items: `state_clear`, embedder
+   quota, `Stateful`+`Browser` via IndexedDB, cross-execution CAS, and the
+   multi-role (Stateful + events) taxonomy question.
+
+## Decision 69: Approve Specs 131, 130, and 1256; Resolve the ADR-0059 Numbering Collision
+
+- **Date**: 2026-09-08
+- **Status**: Accepted
+- **Governing specs**: `131-stateful-persistence-host-abi` (new, Approved);
+  `130-mixed-registry-reference-activation` (Draft → Approved 1.0.0);
+  `1256-registry-genericity-policy` (Draft → Approved 0.1.0); `004-spec-alignment-gate`
+- **ADRs**: `0063-stateful-persistence-host-abi` (new, Accepted); `0059-mixed-registry-reference-activation` (Proposed → Accepted); `0064-registry-genericity-and-configuration-policy` (renumbered from a second `0059`, Proposed → Accepted)
+- **Related issues**: `#1285` (Project Item), `#1258`, `#1256`
+- **Origin**: Maintainer instruction immediately after the Decision 68
+  `/brainstorm`: author the `#1285` spec + ADR and merge them rather than leave
+  drafts, and approve the outstanding Draft specs and their ADRs in the same
+  pass. Surfaced by the `status-check` run earlier in the same session, which
+  flagged `130` and `1256` as Draft-pending-approval and the duplicate ADR
+  number as an untracked fix.
+
+### Context
+
+Three governance items were open at once:
+
+1. `#1285` needed a governing spec + ADR; Decision 68 settled the full design
+   but left authoring and approval as maintainer to-dos.
+2. `130-mixed-registry-reference-activation` (proposed via `#1258`, ADR-0059)
+   was `Draft` and is the named governing surface in `#1275`'s Definition of
+   Done, which blocks `#1275` → `#1276`.
+3. `1256-registry-genericity-policy` (drafted via `#1263`) was `Draft` with a
+   paired `Proposed` ADR.
+
+Two ADR files both carried the number `0059`
+(`0059-mixed-registry-reference-activation` and
+`0059-registry-genericity-and-configuration-policy`), a real collision on the
+sequential ADR index.
+
+### Decision
+
+1. **Author and approve `131-stateful-persistence-host-abi` (v0.1.0)** directly
+   from Decision 68's ten points, with new ADR `0063-stateful-persistence-host-abi`
+   (Accepted). Recorded in `approved-specs.json` as immutable, governing
+   `crates/traverse-runtime/src/executor/`,
+   `crates/traverse-runtime/src/trace_journal.rs`, `crates/traverse-contracts/`,
+   the spec directory, and the ADR.
+2. **Approve `130-mixed-registry-reference-activation`** as-is at v1.0.0
+   (`1.0.0-draft` → `1.0.0`); flip ADR-0059 (mixed) `Proposed` → `Accepted`
+   with an approval-evidence section. The spec is additive, extends the already
+   approved `106`/`107`, and matches its ADR; no content change on approval.
+3. **Approve `1256-registry-genericity-policy`** as-is at v0.1.0; flip its ADR
+   `Proposed` → `Accepted`. The spec is an additive Registry admission policy
+   with no Traverse-repo code surface, scoped in the manifest to its own spec
+   directory and ADR (the same shape as `1259-portable-authority-contracts`).
+4. **Resolve the ADR-0059 collision** by keeping `0059` for the
+   earlier-committed mixed-registry ADR (`#1258`, commit `26f7d33`, before the
+   genericity draft `86a74ff`) and renumbering the genericity ADR to the next
+   free index, `0064` (0060–0062 already taken). A note in the renumbered file
+   records the original number.
+5. **Bundle all of the above into one PR** rather than three. Every change is a
+   spec header, an ADR status line, a manifest entry, or a decision-log entry;
+   one squashed commit keeps the CI cost and the revert surface to a single
+   unit. The PR declares `004-spec-alignment-gate` plus the three approved spec
+   IDs in its `## Governing Spec` section (the manifest file is governed by
+   `004`).
+
+### Alternatives Considered
+
+- **Leave `131` as an unmerged draft** — rejected; the maintainer explicitly
+  asked for create-and-merge, and Decision 68 already fixed every design point a
+  draft-review would surface.
+- **Three separate PRs (one per spec)** — rejected; each would trip the full CI
+  matrix (the manifest lives under `specs/governance/`, which forces
+  `full_ci=true`), tripling the wall-clock and rate-limit cost for changes that
+  are entirely documentation and a JSON registry.
+- **Renumber the mixed-registry ADR instead of the genericity one** — rejected;
+  the mixed-registry ADR was committed first and is already referenced by name
+  in `130`'s header, so moving it churns more references.
+- **Approve `130`/`1256` without recording a decision-log entry** — rejected;
+  neither had a prior decision-log entry (only issue-comment decision records),
+  so this entry is where their approval and coherence review is captured, in the
+  style of Decisions 63–65.
+- **Hold `130`/`1256` for a fuller re-review** — rejected; both are additive,
+  internally coherent with their ADRs and cited decision records, and `130` is
+  actively blocking `#1275`.
+
+### Outcome
+
+Specs `131`, `130`, and `1256` are Approved and immutable in
+`approved-specs.json`; ADRs `0063`, `0059` (mixed), and `0064` are Accepted; the
+ADR index no longer has a duplicate `0059`. Follow-ups:
+
+1. `#1275` can proceed on its `130` governing-surface Definition-of-Done item;
+   `#1276` unblocks once `#1274`/`#1275` implementation lands.
+2. `#1285` still needs the three imports implemented and whitelisted, the
+   per-partition serialization, the trace-entry type, and negative fixtures —
+   plus triage onto Project 1 with a `spec`/`runtime`/`security` label set and
+   the deferred-item follow-up tickets from Decision 68.
+3. Registry genericity enforcement (`1256`) and its audit of existing records
+   are downstream registry-repo work.

--- a/specs/1256-registry-genericity-policy/spec.md
+++ b/specs/1256-registry-genericity-policy/spec.md
@@ -1,9 +1,9 @@
 # Feature Specification: Registry Genericity, Naming, and Configuration Policy
 
-**Status**: Draft
+**Status**: Approved (2026-09-08)
 **Canonical governing ID**: `1256-registry-genericity-policy`
 **Version**: 0.1.0
-**Decision evidence**: Traverse #1256 decision record (2026-09-07).
+**Decision evidence**: Traverse #1256 decision record (2026-09-07); ADR-0064.
 
 ## Purpose
 

--- a/specs/130-mixed-registry-reference-activation/spec.md
+++ b/specs/130-mixed-registry-reference-activation/spec.md
@@ -1,11 +1,11 @@
 # Feature Specification: Mixed Local and Registry-Reference Activation
 
-**Status**: Draft
+**Status**: Approved (2026-09-08)
 **Canonical governing ID**: `130-mixed-registry-reference-activation`
-**Version**: 1.0.0-draft
+**Version**: 1.0.0
 **Extends**: `106-activation-artifact-resolution`,
 `107-cross-host-embedded-registry-cache`
-**Input**: #1258; ADR-0059.
+**Input**: #1258; ADR-0059 (`0059-mixed-registry-reference-activation`).
 
 ## Purpose
 

--- a/specs/131-stateful-persistence-host-abi/spec.md
+++ b/specs/131-stateful-persistence-host-abi/spec.md
@@ -1,0 +1,288 @@
+# Feature Specification: Capability-Side WASM Host ABI for Stateful Persistence
+
+**Feature Branch**: `governance/stateful-abi-registry-spec-approvals`
+**Created**: 2026-09-08
+**Status**: Approved (2026-09-08)
+**Canonical governing ID**: `131-stateful-persistence-host-abi`
+**Version**: 0.1.0
+**Extends**: `002-capability-contracts`, `208-service-type-taxonomy` (canonical `014`), `518-durable-local-datastore`
+**Input**: Issue #1285; ADR-0063; `/brainstorm` session recorded as Decision 68 in `docs/decision-log.md`. Precedent: `098-capability-event-host-abi` / ADR-0035 / Decisions 48-49.
+
+## Purpose
+
+Define a WASM host-function ABI that lets a `Stateful` capability persist and
+retrieve named state during execution, and the host-side contract that services
+it. Today `service_type: Stateful` exists on `CapabilityContract` (spec `014`)
+and the placement evaluator already excludes `Browser` for it, but the runtime
+exposes no managed-persistence import in `host_abi_v1.json` — only WASI stdio,
+`traverse_host` environment/metadata queries, `emit_event`, and
+`connector_invoke`. Without this surface, no `Stateful` capability can actually
+run, and the mapped Registry roster (cart, ticket workspace, approval packet
+store, challenge session, pricing config, and more) cannot be published.
+
+This spec governs the host-function ABI surface (import signatures, calling
+convention, synchronous validation, scoping, and failure semantics) and the
+abstract host store contract it is serviced by. It does not include the
+implementation, fixture authoring, or any change to `service_type` taxonomy or
+the `Stateful` + `Browser` placement rule.
+
+## Capability Boundary
+
+| Concern | Owner |
+| --- | --- |
+| The three `state_*` import signatures, calling convention, and validation | This spec / Traverse runtime |
+| Composing the real storage key from `capability_id` + partition + key | Traverse runtime (guest never sees raw paths) |
+| Per-`(capability_id, partition)` serialization of state operations | Traverse runtime |
+| Recording mutation metadata to the trace journal | Traverse runtime |
+| Durable byte storage, integrity, atomicity, encryption, retention, backup | Host (DataStore v2 by default; substitutable) |
+| Partition-wide teardown, quota, and lifecycle scheduling | Host / embedder (retention spec `526`) |
+
+## User Scenarios & Testing
+
+### User Story 1 — A Stateful capability persists and reads its own state (Priority: P1)
+
+A `Stateful` capability writes a value under a partition and key during one
+execution and reads the same value back in a later execution, without the
+guest ever handling a storage path.
+
+**Why this priority**: This is the entire reason the ABI exists; every roster
+capability depends on it.
+
+**Independent Test**: Execute a `Stateful` fixture that calls `state_put(p, k,
+v)`; execute it again with the same partition and key calling `state_get(p, k)`;
+assert the returned bytes equal `v`.
+
+**Acceptance Scenarios**:
+
+1. **Given** a `Stateful` capability, **when** it calls `state_put` then
+   `state_get` for the same partition and key within one execution, **then**
+   `state_get` returns the just-written value (read-your-writes).
+2. **Given** a value written in a prior execution, **when** a later execution of
+   the same capability calls `state_get` with the same partition and key,
+   **then** it returns that value after a host restart.
+3. **Given** a key that was never written, **when** `state_get` is called,
+   **then** it returns an explicit absent result, not an error.
+4. **Given** a key holding a value, **when** `state_delete` is called for it and
+   then `state_get`, **then** `state_get` returns an absent result.
+
+---
+
+### User Story 2 — Cross-capability and cross-partition isolation (Priority: P1)
+
+State written by one capability under one partition is never readable by another
+capability, or under another partition, through this ABI.
+
+**Why this priority**: One deployed capability instance serves many end users;
+isolation must be host-guaranteed, not guest-cooperative.
+
+**Independent Test**: Write a value as capability A under partition `x`; from
+capability B (any partition) and from capability A under partition `y`, call
+`state_get` for the same key; assert both see an absent result.
+
+**Acceptance Scenarios**:
+
+1. **Given** capability A wrote `(x, k) -> v`, **when** capability B calls
+   `state_get(x, k)`, **then** the result is absent — B cannot address A's
+   namespace.
+2. **Given** capability A wrote `(x, k) -> v`, **when** capability A calls
+   `state_get(y, k)` with a different partition `y`, **then** the result is
+   absent.
+3. **Given** any `state_*` call, **when** the runtime composes the storage key,
+   **then** the calling `capability_id` is the enforced prefix and the guest
+   cannot supply, override, or observe it.
+
+---
+
+### User Story 3 — Only `Stateful` capabilities may call the ABI (Priority: P1)
+
+A capability whose `service_type` is not `Stateful` is rejected at call time if
+it invokes any `state_*` import.
+
+**Why this priority**: Mirrors `098` FR-003 (only `Subscribable` may emit) and
+keeps the persistence surface bound to the placement constraints written against
+`Stateful`.
+
+**Acceptance Scenarios**:
+
+1. **Given** a `Stateless` or `Subscribable` capability, **when** it calls
+   `state_get`, `state_put`, or `state_delete`, **then** the host rejects the
+   call synchronously with a stable error code and performs no storage
+   operation.
+
+---
+
+### User Story 4 — Bounds and malformed input fail closed (Priority: P1)
+
+Oversized or out-of-bounds guest input is rejected with a stable error; the host
+never traps, panics, or reads past guest memory.
+
+**Independent Test**: Call `state_put` with a value length exceeding the maximum,
+and separately with a pointer/length pair outside guest linear memory; assert a
+stable error code each time and that the store is unchanged.
+
+**Acceptance Scenarios**:
+
+1. **Given** a `state_put` whose value exceeds the maximum value size, **when**
+   the call is made, **then** it is rejected with `state_value_too_large` and no
+   write occurs.
+2. **Given** a `state_*` call whose key or partition exceeds its maximum length,
+   **when** the call is made, **then** it is rejected with
+   `state_key_invalid` and no operation occurs.
+3. **Given** a `state_*` call whose payload pointer/length falls outside guest
+   linear memory, **when** the call is made, **then** the host returns
+   `state_payload_invalid` without trapping or reading out of bounds.
+
+---
+
+### User Story 5 — Concurrent executions on one partition are serialized (Priority: P2)
+
+Two concurrent executions of the same capability targeting the same partition
+see a sequential, non-interleaved view of state.
+
+**Acceptance Scenarios**:
+
+1. **Given** two concurrent executions of capability A both writing
+   `(x, k)`, **when** both complete, **then** one write is fully applied, the
+   other is fully applied after it, and no partial or interleaved value is
+   observable.
+2. **Given** executions targeting different partitions or different
+   capabilities, **when** they run concurrently, **then** they are not
+   serialized against each other.
+
+---
+
+### User Story 6 — Mutations are auditable without leaking payloads (Priority: P2)
+
+Every `state_put` and `state_delete` leaves a trace-journal record identifying
+what changed, without the value itself entering the journal.
+
+**Acceptance Scenarios**:
+
+1. **Given** a `state_put`, **when** it succeeds, **then** the trace journal
+   gains an entry with `capability_id`, a digest of the partition, the key, a
+   digest of the value, and the `execution_id` — and not the value bytes.
+2. **Given** a `state_get`, **when** it runs, **then** no trace-journal entry is
+   produced (reads are not mutations).
+
+### Edge Cases
+
+- A `state_get` for an absent key is an absent result, never
+  `integrity_check_failed`.
+- A value that fails the host store's integrity check on read surfaces the
+  store's stable integrity failure to the guest, not a partial value.
+- A `state_put` that would exceed a host-configured quota (when a host enforces
+  one) fails closed with a stable code; v0.1.0 defines no quota of its own.
+- `Browser` remains excluded for `Stateful` by spec `014` FR-005; this ABI adds
+  no path that circumvents that rule.
+
+## Requirements
+
+### Functional Requirements
+
+- **FR-001**: The runtime MUST expose exactly three new `traverse_host` imports —
+  `state_get`, `state_put`, and `state_delete` — versioned and whitelisted the
+  same way as the existing `traverse_*` bridge functions
+  (`host_abi_whitelist` / `HOST_ABI_V1_WHITELIST`), and documented in the same
+  location as the rest of the ABI-version import set.
+- **FR-002**: Each import MUST take a caller-supplied opaque `partition` byte
+  string and a `key` byte string. `state_put` additionally takes a `value` byte
+  string. `state_get` MUST return either the stored value or an explicit absent
+  indicator. The guest MUST NOT supply, override, or observe the storage
+  namespace prefix.
+- **FR-003**: The host MUST compose the real storage key as
+  `capability_id / partition / key` using the calling capability's authenticated
+  `capability_id`. State written by one `capability_id` MUST NOT be readable or
+  deletable through this ABI by any other `capability_id`, and state under one
+  partition MUST NOT be addressable under another.
+- **FR-004**: The host MUST reject any `state_*` call from a capability whose
+  `service_type` is not `Stateful`, synchronously at call time, returning a
+  stable error to the guest and performing no storage operation.
+- **FR-005**: The host MUST validate that the guest-supplied pointer/length
+  pairs lie within the guest's linear memory and MUST enforce fixed maximums for
+  partition length, key length, and value size before any storage operation. A
+  malformed or oversized input MUST be rejected with a stable, secret-free error
+  code; the host MUST NOT trap, panic, or read outside guest memory.
+- **FR-006**: `state_get` for a key that holds no value MUST return the absent
+  indicator, not an error. A value that fails the backing store's integrity
+  check MUST surface that store's stable integrity failure and no partial value.
+- **FR-007**: The host MUST serialize `state_get` / `state_put` / `state_delete`
+  per `(capability_id, partition)` so that a guest observes a sequential,
+  non-interleaved view including read-your-writes within a partition.
+  Operations on distinct partitions or distinct capabilities MUST NOT be
+  serialized against each other. This ABI version defines no compare-and-swap or
+  version-token operation.
+- **FR-008**: Every successful `state_put` and `state_delete` MUST append a
+  trace-journal entry containing `capability_id`, a digest of the partition, the
+  key, a digest of the resulting value (or a tombstone marker for delete), and
+  the `execution_id`. The value bytes MUST NOT be written to the trace journal.
+  `state_get` MUST NOT produce a trace-journal entry.
+- **FR-009**: The three imports MUST be serviced through an abstract host store
+  interface with a documented guarantee floor: integrity-checked reads, atomic
+  writes, read-your-writes within a partition, and durability across host
+  restart. The embedded host MUST bind this interface to the spec `518`
+  DataStore v2 by default; a host MAY substitute another implementation that
+  meets the guarantee floor.
+- **FR-010**: Guest-visible outcomes and the trace-journal entries MUST NOT
+  contain storage paths, credentials, endpoints, encryption material, or
+  host-private configuration values.
+- **FR-011**: The ABI MUST fold into host ABI version 1 with no parallel or
+  deprecated compatibility path, consistent with Decision 48 (no back-compat tax
+  before production use).
+- **FR-012**: Existing `Stateless` and `Subscribable` capability behavior, the
+  `emit_event` / `connector_invoke` imports, and the `service_type` taxonomy
+  MUST remain unchanged.
+
+### Key Entities
+
+- **Partition**: an opaque caller-supplied byte string (for example an end-user
+  or session identifier) that subdivides a capability's namespace. The host
+  treats it as opaque and digests it for trace records.
+- **StatefulStore interface**: the abstract host contract servicing the three
+  imports, with the FR-009 guarantee floor; DataStore v2 is the default binding.
+- **State mutation record**: the trace-journal entry produced by `state_put` /
+  `state_delete` — identity, digests, and `execution_id`, never the value.
+
+## Success Criteria
+
+### Measurable Outcomes
+
+- **SC-001**: A `Stateful` fixture writes and reads back a value across two
+  executions and a simulated restart, with zero raw storage paths visible to the
+  guest.
+- **SC-002**: Isolation tests prove no cross-`capability_id` and no
+  cross-partition read or delete is possible through the ABI.
+- **SC-003**: A non-`Stateful` capability calling any `state_*` import is
+  rejected synchronously in an automated test, with no storage side effect.
+- **SC-004**: Oversized value, oversized key/partition, and out-of-bounds
+  pointer inputs each produce their distinct stable error code and leave the
+  store unchanged; no test induces a host trap or panic.
+- **SC-005**: A concurrency test shows two same-partition executions apply
+  fully and sequentially with no interleaved or partial value, while
+  different-partition executions are observed to run without mutual
+  serialization.
+- **SC-006**: Trace-journal assertions confirm a metadata-plus-digest entry for
+  every `state_put` / `state_delete`, no entry for `state_get`, and no value
+  bytes or host-private values in any entry.
+
+## Compatibility and Scope
+
+This specification is additive to host ABI version 1. It does not modify the
+`service_type` enum, the `Stateful` + `Browser` placement rule in spec `014`
+FR-005, the `emit_event` ABI (`098`), `connector_invoke` (`104`), or the
+embedder-owned DataStore surface (`518` / `519` / `528`). It does not add a
+partition-wide clear import, a per-capability quota, a compare-and-swap
+operation, a key-enumeration import, or any Stateful + event multi-role
+mechanism — each is recorded as deferred follow-up work in Decision 68.
+
+## Assumptions
+
+- Hosts own durable storage location, integrity mechanism, encryption,
+  retention, backup, and any quota; none are surfaced to the guest or in trace
+  records.
+- The default binding is DataStore v2; substitutes are the host's
+  responsibility to keep within the FR-009 guarantee floor.
+- Partition-wide teardown and lifecycle scheduling remain an embedder/retention
+  concern under spec `526`.
+- Traverse has no production users or production capabilities today
+  (`docs/decision-log.md` Decision 48), so the ABI is introduced without a
+  compatibility shim.

--- a/specs/governance/approved-specs.json
+++ b/specs/governance/approved-specs.json
@@ -1756,6 +1756,45 @@
         "crates/traverse-cli/",
         "specs/996-registry-app-preparation/"
       ]
+    },
+    {
+      "id": "130-mixed-registry-reference-activation",
+      "version": "1.0.0",
+      "status": "approved",
+      "immutable": true,
+      "path": "specs/130-mixed-registry-reference-activation/spec.md",
+      "governs": [
+        "crates/traverse-runtime/",
+        "crates/traverse-embedder/",
+        "crates/traverse-registry/",
+        "specs/130-mixed-registry-reference-activation/",
+        "docs/adr/0059-mixed-registry-reference-activation.md"
+      ]
+    },
+    {
+      "id": "1256-registry-genericity-policy",
+      "version": "0.1.0",
+      "status": "approved",
+      "immutable": true,
+      "path": "specs/1256-registry-genericity-policy/spec.md",
+      "governs": [
+        "specs/1256-registry-genericity-policy/",
+        "docs/adr/0064-registry-genericity-and-configuration-policy.md"
+      ]
+    },
+    {
+      "id": "131-stateful-persistence-host-abi",
+      "version": "0.1.0",
+      "status": "approved",
+      "immutable": true,
+      "path": "specs/131-stateful-persistence-host-abi/spec.md",
+      "governs": [
+        "crates/traverse-runtime/src/executor/",
+        "crates/traverse-runtime/src/trace_journal.rs",
+        "crates/traverse-contracts/",
+        "specs/131-stateful-persistence-host-abi/",
+        "docs/adr/0063-stateful-persistence-host-abi.md"
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary

Approve three governing specs and resolve an ADR numbering collision, following
`docs/decision-log.md` Decisions 68 and 69.

- **New — `131-stateful-persistence-host-abi` (v0.1.0)** + ADR-0063: the
  capability-side WASM host ABI (`state_get` / `state_put` / `state_delete`)
  that lets `Stateful` capabilities persist state. Authored directly from the
  Decision 68 `/brainstorm` on #1285. Host-enforced `capability_id` namespace +
  caller-supplied opaque partition, per-key delete only, abstract `StatefulStore`
  trait with DataStore v2 as the default binding, fixed bounds and no quota,
  per-`(capability_id, partition)` serialization, mutation-metadata trace
  entries, `Stateful`+events left out of scope.
- **`130-mixed-registry-reference-activation` Draft → Approved (v1.0.0)** +
  ADR-0059 Proposed → Accepted. Named governing surface in #1275's DoD.
- **`1256-registry-genericity-policy` Draft → Approved (v0.1.0)** + its ADR
  Proposed → Accepted.
- **ADR-0059 collision fixed**: two files shared `0059`. The earlier-committed
  mixed-registry ADR keeps `0059`; the genericity ADR is renumbered to `0064`.

No code changes. Spec headers, ADR status lines, `approved-specs.json` entries,
and decision-log Decisions 68–69 only.

## Governing Spec

- `004-spec-alignment-gate`
- `131-stateful-persistence-host-abi`
- `130-mixed-registry-reference-activation`
- `1256-registry-genericity-policy`
- `108-governed-runtime-workflow-composition`

`004` (v1.0.0) governs `specs/governance/approved-specs.json`. `131` (v0.1.0),
`130` (v1.0.0), and `1256` (v0.1.0) are approved in this PR and govern their own
spec directories and ADRs. `108` (v1.0.0) is declared to cover the
`docs/decision-log.md` Decisions 68-69 entries, the same convention as PR #1253.

## Project Item

- #1285
- Related: #1258, #1256

## What Changed

- Contracts changed: none.
- Runtime behavior changed: none (governing specs only; `131` implementation is follow-up work on #1285).
- Compatibility impact: additive. `131` folds into host ABI v1 with no back-compat path (Decision 48). `130` and `1256` are additive and were approved as-is.
- ADR needed or linked: ADR-0063 (new, Accepted); ADR-0059 mixed-registry (Accepted); ADR-0064 registry-genericity (renumbered from 0059, Accepted).

## Validation

- [x] Spec alignment checked (`bash scripts/ci/spec_alignment_check.sh` locally)
- [x] Contract alignment checked (no contracts touched)
- [x] Tests updated and passing (no code paths changed)
- [x] Core coverage preserved (no code paths changed)
- [x] Required validation gates passing

## Notes

- One PR instead of three: the manifest lives under `specs/governance/`, which
  forces the full CI matrix regardless, so three PRs would triple the cost for
  documentation-only changes (Decision 69).
- `130` and `1256` had no prior decision-log entry — Decision 69 records their
  approval and the coherence review, in the style of Decisions 63–65.
- #1285 still needs implementation + Project 1 triage + the Decision 68
  deferred-item follow-up tickets.
