### PR TITLE
feat(runtime): capability state host ABI (state_get/put/delete) (#1285)

### DIFF
--- a/crates/traverse-contracts/src/lib.rs
+++ b/crates/traverse-contracts/src/lib.rs
@@ -994,6 +994,8 @@ pub enum ValidationErrorCode {
     InvalidPlacementConstraint,
     /// `service_type: subscribable` without a non-empty `event_trigger`.
     MissingEventTrigger,
+    /// `service_type: stateful` without a non-empty `state_schema.properties`.
+    MissingStateSchema,
     InvalidConnectorContract,
     InvalidConnectorRequirement,
     /// A manifest-declared risk policy would widen egress beyond what the
@@ -1838,6 +1840,28 @@ fn validate_placement_constraints(
             path: "$.permitted_targets".to_string(),
             severity: ErrorSeverity::Error,
         });
+    }
+    if contract.service_type == ServiceType::Stateful {
+        let properties_empty = contract
+            .state_schema
+            .as_ref()
+            .and_then(|schema| schema.get("properties"))
+            .and_then(Value::as_object)
+            .is_none_or(serde_json::Map::is_empty);
+        let schema_not_object = contract
+            .state_schema
+            .as_ref()
+            .is_none_or(|schema| !schema.is_object());
+        if contract.state_schema.is_none() || schema_not_object || properties_empty {
+            errors.push(ValidationError {
+                code: ValidationErrorCode::MissingStateSchema,
+                message: "Stateful capabilities must declare a non-empty state_schema object \
+                          with at least one property."
+                    .to_string(),
+                path: "$.state_schema".to_string(),
+                severity: ErrorSeverity::Error,
+            });
+        }
     }
     if contract.service_type == ServiceType::Subscribable
         && match contract.event_trigger.as_deref() {

--- a/crates/traverse-contracts/tests/validation.rs
+++ b/crates/traverse-contracts/tests/validation.rs
@@ -1090,6 +1090,12 @@ fn validate_manifest_risk_policy_rejects_any_egress_when_contract_denies_all() -
 fn stateful_with_browser_target_is_rejected() -> Result<(), String> {
     let mut contract = valid_contract();
     contract.service_type = ServiceType::Stateful;
+    contract.state_schema = Some(serde_json::json!({
+        "type": "object",
+        "properties": {
+            "cart": {"type": "object"}
+        }
+    }));
     contract.permitted_targets = vec![ExecutionTarget::Browser, ExecutionTarget::Cloud];
 
     let failure = expect_validation_failure(validate_contract(
@@ -1154,6 +1160,12 @@ fn subscribable_with_event_trigger_passes() -> Result<(), String> {
 fn stateful_without_browser_passes() -> Result<(), String> {
     let mut contract = valid_contract();
     contract.service_type = ServiceType::Stateful;
+    contract.state_schema = Some(serde_json::json!({
+        "type": "object",
+        "properties": {
+            "cart": {"type": "object"}
+        }
+    }));
     contract.permitted_targets = vec![ExecutionTarget::Cloud, ExecutionTarget::Edge];
 
     validate_contract(
@@ -1165,6 +1177,57 @@ fn stateful_without_browser_passes() -> Result<(), String> {
         },
     )
     .map_err(|e| format!("{e:?}"))?;
+    Ok(())
+}
+
+#[test]
+fn stateful_without_state_schema_is_rejected() -> Result<(), String> {
+    let mut contract = valid_contract();
+    contract.service_type = ServiceType::Stateful;
+    contract.state_schema = None;
+    contract.permitted_targets = vec![ExecutionTarget::Cloud];
+
+    let failure = expect_validation_failure(validate_contract(
+        contract,
+        &ValidationContext {
+            governing_spec: GOVERNING_SPEC,
+            validator_version: VALIDATOR_VERSION,
+            existing_published: None,
+        },
+    ))?;
+
+    let codes: Vec<_> = failure.errors.iter().map(|e| &e.code).collect();
+    assert!(
+        codes.contains(&&ValidationErrorCode::MissingStateSchema),
+        "expected MissingStateSchema, got {codes:?}"
+    );
+    Ok(())
+}
+
+#[test]
+fn stateful_with_empty_state_schema_properties_is_rejected() -> Result<(), String> {
+    let mut contract = valid_contract();
+    contract.service_type = ServiceType::Stateful;
+    contract.state_schema = Some(serde_json::json!({
+        "type": "object",
+        "properties": {}
+    }));
+    contract.permitted_targets = vec![ExecutionTarget::Local];
+
+    let failure = expect_validation_failure(validate_contract(
+        contract,
+        &ValidationContext {
+            governing_spec: GOVERNING_SPEC,
+            validator_version: VALIDATOR_VERSION,
+            existing_published: None,
+        },
+    ))?;
+
+    let codes: Vec<_> = failure.errors.iter().map(|e| &e.code).collect();
+    assert!(
+        codes.contains(&&ValidationErrorCode::MissingStateSchema),
+        "expected MissingStateSchema, got {codes:?}"
+    );
     Ok(())
 }
 

--- a/crates/traverse-runtime/src/artifact_router.rs
+++ b/crates/traverse-runtime/src/artifact_router.rs
@@ -84,6 +84,7 @@ impl LocalExecutor for ArtifactRouter {
                     host_abi_version: None,
                     emits: capability.contract.emits.clone(),
                     service_type: capability.contract.service_type.clone(),
+                    state_schema: capability.contract.state_schema.clone(),
                 };
                 // Events emitted via `traverse_host::emit_event` during this
                 // call are returned as real `LocalExecutionOutput.emitted_events`

--- a/crates/traverse-runtime/src/data_store.rs
+++ b/crates/traverse-runtime/src/data_store.rs
@@ -368,6 +368,51 @@ pub trait DataStore {
     fn list_keys(&self) -> Result<Vec<String>, DataStoreError>;
 }
 
+/// Process-local [`DataStore`] backed by a [`BTreeMap`].
+///
+/// Suitable for tests, CI inject, and local tools that need an explicit
+/// in-memory adapter for Stateful host ABI calls (spec
+/// `1285-capability-state-host-abi` FR-006). Does not validate key shape —
+/// callers that need schema/key rules must go through [`RuntimeDataStore`].
+#[derive(Debug, Clone, Default)]
+pub struct InMemoryDataStore {
+    records: BTreeMap<String, StateRecord>,
+}
+
+impl InMemoryDataStore {
+    /// Creates an empty in-memory store.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Returns a snapshot of stored records (test/diagnostic helper).
+    #[must_use]
+    pub fn records(&self) -> &BTreeMap<String, StateRecord> {
+        &self.records
+    }
+}
+
+impl DataStore for InMemoryDataStore {
+    fn read(&self, key: &str) -> Result<Option<StateRecord>, DataStoreError> {
+        Ok(self.records.get(key).cloned())
+    }
+
+    fn write(&mut self, record: StateRecord) -> Result<(), DataStoreError> {
+        self.records.insert(record.key.clone(), record);
+        Ok(())
+    }
+
+    fn delete(&mut self, key: &str) -> Result<(), DataStoreError> {
+        self.records.remove(key);
+        Ok(())
+    }
+
+    fn list_keys(&self) -> Result<Vec<String>, DataStoreError> {
+        Ok(self.records.keys().cloned().collect())
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct LamportClock {
     writer_id: String,
@@ -481,6 +526,81 @@ impl<A: DataStore> RuntimeDataStore<A> {
         self.adapter.delete(key)
     }
 
+    /// Validates `relative_key` against `state_schema`, then writes a stamped
+    /// record under `{capability_id}/{relative_key}` (spec
+    /// `1285-capability-state-host-abi` FR-004/FR-005).
+    ///
+    /// Schema lookup uses the relative key; the adapter storage key is namespaced.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DataStoreError`] when the relative key is invalid, schema
+    /// validation fails, the Lamport clock overflows, or the adapter write fails.
+    pub fn write_namespaced(
+        &mut self,
+        capability_id: &str,
+        state_schema: &Value,
+        relative_key: &str,
+        value: Value,
+    ) -> Result<StateRecord, DataStoreError> {
+        validate_relative_state_key(relative_key)?;
+        validate_state_write_for_schema(capability_id, Some(state_schema), relative_key, &value)?;
+        let record = StateRecord {
+            key: namespaced_state_key(capability_id, relative_key),
+            value,
+            lamport_clock: self.clock.next()?,
+            writer_id: self.clock.writer_id.clone(),
+        };
+        self.adapter.write(record.clone())?;
+        Ok(record)
+    }
+
+    /// Reads a namespaced capability state value, validating against
+    /// `state_schema` with the relative key.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DataStoreError`] when the relative key is invalid, the adapter
+    /// cannot read, or a stored value violates the schema.
+    pub fn read_namespaced(
+        &self,
+        capability_id: &str,
+        state_schema: &Value,
+        relative_key: &str,
+    ) -> Result<Option<Value>, DataStoreError> {
+        validate_relative_state_key(relative_key)?;
+        let storage_key = namespaced_state_key(capability_id, relative_key);
+        self.adapter.read(&storage_key).and_then(|record| {
+            record
+                .map(|record| {
+                    validate_state_write_for_schema(
+                        capability_id,
+                        Some(state_schema),
+                        relative_key,
+                        &record.value,
+                    )?;
+                    Ok(record.value)
+                })
+                .transpose()
+        })
+    }
+
+    /// Deletes a namespaced capability state key after relative-key validation.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DataStoreError`] when the relative key is invalid or the
+    /// adapter cannot delete the key.
+    pub fn delete_namespaced(
+        &mut self,
+        capability_id: &str,
+        relative_key: &str,
+    ) -> Result<(), DataStoreError> {
+        validate_relative_state_key(relative_key)?;
+        self.adapter
+            .delete(&namespaced_state_key(capability_id, relative_key))
+    }
+
     /// Lists state keys.
     ///
     /// # Errors
@@ -505,6 +625,12 @@ impl<A: DataStore> RuntimeDataStore<A> {
 
     pub fn into_inner(self) -> A {
         self.adapter
+    }
+
+    /// Borrow the underlying adapter (tests and host diagnostics).
+    #[must_use]
+    pub fn adapter(&self) -> &A {
+        &self.adapter
     }
 }
 
@@ -1070,12 +1196,27 @@ pub fn validate_state_write(
     key: &str,
     value: &Value,
 ) -> Result<(), DataStoreError> {
+    validate_state_write_for_schema(&contract.id, contract.state_schema.as_ref(), key, value)
+}
+
+/// Validates a state write using an explicit schema value (host ABI path).
+///
+/// # Errors
+///
+/// Returns [`DataStoreError`] when the key is invalid, no schema is declared,
+/// the key is undeclared, or the value violates the key schema.
+pub fn validate_state_write_for_schema(
+    capability_id: &str,
+    state_schema: Option<&Value>,
+    key: &str,
+    value: &Value,
+) -> Result<(), DataStoreError> {
     validate_key(key)?;
-    let schema = contract.state_schema.as_ref().ok_or_else(|| {
+    let schema = state_schema.ok_or_else(|| {
         data_store_error(
             DataStoreErrorCode::NoStateSchemaDeclared,
             "no_state_schema_declared",
-            json!({ "capability_id": contract.id, "key": key }),
+            json!({ "capability_id": capability_id, "key": key }),
         )
     })?;
     let property_schema = schema
@@ -1100,6 +1241,27 @@ pub fn validate_state_write(
             json!({ "key": key, "violations": violations }),
         ))
     }
+}
+
+/// Relative guest state key rules (spec `1285-capability-state-host-abi` FR-004).
+///
+/// # Errors
+///
+/// Returns [`DataStoreError`] when the key is empty, contains `/` or `..`, or
+/// fails the shared ASCII alphanumeric/`_`/`-` key alphabet.
+pub fn validate_relative_state_key(key: &str) -> Result<(), DataStoreError> {
+    if key.is_empty() || key.contains('/') || key.contains("..") {
+        return Err(data_store_error(
+            DataStoreErrorCode::InvalidKey,
+            "relative state key must be non-empty and must not contain '/' or '..'",
+            json!({ "key": key }),
+        ));
+    }
+    validate_key(key)
+}
+
+fn namespaced_state_key(capability_id: &str, relative_key: &str) -> String {
+    format!("{capability_id}/{relative_key}")
 }
 
 fn sync_adapters(
@@ -1269,7 +1431,7 @@ mod tests {
     use uuid::Uuid;
 
     #[derive(Debug, Clone, Default)]
-    struct MemoryDataStore {
+    struct FailingMemoryDataStore {
         records: BTreeMap<String, StateRecord>,
         fail_writes: Cell<bool>,
     }
@@ -1289,7 +1451,7 @@ mod tests {
         }
     }
 
-    impl DataStore for MemoryDataStore {
+    impl DataStore for FailingMemoryDataStore {
         fn read(&self, key: &str) -> Result<Option<StateRecord>, DataStoreError> {
             Ok(self.records.get(key).cloned())
         }
@@ -1367,8 +1529,66 @@ mod tests {
     }
 
     #[test]
+    fn runtime_data_store_namespaced_round_trip_stamps_metadata() {
+        let adapter = InMemoryDataStore::default();
+        let mut store = RuntimeDataStore::new(adapter, "writer-a");
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "cart": {"type": "object"}
+            }
+        });
+
+        let record = store
+            .write_namespaced("commerce.cart", &schema, "cart", json!({"items": []}))
+            .expect("namespaced write should succeed");
+        assert_eq!(record.key, "commerce.cart/cart");
+        assert_eq!(record.lamport_clock, 1);
+        assert_eq!(record.writer_id, "writer-a");
+
+        assert_eq!(
+            store
+                .read_namespaced("commerce.cart", &schema, "cart")
+                .expect("read"),
+            Some(json!({"items": []}))
+        );
+        store
+            .delete_namespaced("commerce.cart", "cart")
+            .expect("delete");
+        assert_eq!(
+            store
+                .read_namespaced("commerce.cart", &schema, "cart")
+                .expect("read after delete"),
+            None
+        );
+
+        let bad = store
+            .write_namespaced("commerce.cart", &schema, "cart/nested", json!({}))
+            .expect_err("slash in relative key");
+        assert_eq!(bad.code, DataStoreErrorCode::InvalidKey);
+
+        let mut seeded = InMemoryDataStore::new();
+        seeded
+            .write(StateRecord {
+                key: "commerce.cart/cart".to_string(),
+                value: json!("not-an-object"),
+                lamport_clock: 1,
+                writer_id: "writer-a".to_string(),
+            })
+            .expect("seed");
+        let store = RuntimeDataStore::new(seeded, "writer-a");
+        let invalid_stored = store
+            .read_namespaced("commerce.cart", &schema, "cart")
+            .expect_err("stored value must fail schema");
+        assert_eq!(
+            invalid_stored.code,
+            DataStoreErrorCode::SchemaValidationError
+        );
+    }
+
+    #[test]
     fn runtime_data_store_rejects_missing_schema_bad_keys_and_schema_violations() {
-        let adapter = MemoryDataStore::default();
+        let adapter = InMemoryDataStore::default();
         let mut store = RuntimeDataStore::new(adapter, "writer-a");
         let no_schema = stateful_contract(None);
         let schema = stateful_contract(Some(json!({
@@ -1411,7 +1631,7 @@ mod tests {
 
     #[test]
     fn lamport_clock_overflow_is_rejected_before_adapter_write() {
-        let adapter = MemoryDataStore::default();
+        let adapter = InMemoryDataStore::default();
         let clock = LamportClock::with_value("writer-a", u64::MAX);
         let mut store = RuntimeDataStore::with_clock(adapter, clock);
         let contract = stateful_contract(Some(json!({
@@ -1431,7 +1651,7 @@ mod tests {
 
     #[test]
     fn runtime_data_store_validates_reads_before_returning_stored_values() {
-        let mut adapter = MemoryDataStore::default();
+        let mut adapter = InMemoryDataStore::default();
         adapter
             .write(record("count", "writer-a", 1, json!("not an integer")))
             .expect("seed should succeed");
@@ -1452,8 +1672,8 @@ mod tests {
 
     #[test]
     fn reconnect_sync_merges_only_local_only_remote_clock_winner_and_writer_tie_breaks() {
-        let mut local = MemoryDataStore::default();
-        let mut remote = MemoryDataStore::default();
+        let mut local = InMemoryDataStore::default();
+        let mut remote = InMemoryDataStore::default();
         local
             .write(record("local_only", "local-a", 1, json!("local")))
             .expect("local write should succeed");
@@ -1500,8 +1720,8 @@ mod tests {
 
     #[test]
     fn sync_failure_restores_local_snapshot() {
-        let mut local = MemoryDataStore::default();
-        let mut remote = MemoryDataStore::default();
+        let mut local = FailingMemoryDataStore::default();
+        let mut remote = FailingMemoryDataStore::default();
         local
             .write(record("shared", "local-a", 2, json!("local")))
             .expect("local write should succeed");
@@ -1538,8 +1758,8 @@ mod tests {
 
     #[test]
     fn helper_paths_cover_remaining_datastore_branches() {
-        let mut local = RuntimeDataStore::new(MemoryDataStore::default(), "local-a");
-        let mut remote = MemoryDataStore::default();
+        let mut local = RuntimeDataStore::new(InMemoryDataStore::default(), "local-a");
+        let mut remote = InMemoryDataStore::default();
         remote
             .write(record("remote_only", "remote-a", 1, json!("remote")))
             .expect("remote seed should succeed");
@@ -1556,9 +1776,9 @@ mod tests {
         );
         assert_eq!(rule, ConflictResolutionRule::WriterIdentityTieBreak);
 
-        let mut failing_local = MemoryDataStore::default();
+        let mut failing_local = FailingMemoryDataStore::default();
         failing_local.fail_writes.set(true);
-        let mut seeded_remote = MemoryDataStore::default();
+        let mut seeded_remote = InMemoryDataStore::default();
         seeded_remote
             .write(record("missing_local", "remote-a", 1, json!("remote")))
             .expect("remote seed should succeed");

--- a/crates/traverse-runtime/src/durable_orchestration.rs
+++ b/crates/traverse-runtime/src/durable_orchestration.rs
@@ -434,8 +434,7 @@ mod tests {
     }
 
     #[test]
-    fn checkpoint_and_recovery_guards_cover_all_fail_closed_paths()
-    -> std::result::Result<(), String> {
+    fn checkpoint_and_recovery_guards_cover_all_fail_closed_paths() {
         let mut store = MemoryCheckpointStore::default();
         let mut incomplete = checkpoint();
         incomplete.snapshots.policy_digest.clear();
@@ -456,9 +455,11 @@ mod tests {
             })
         ));
         assert!(persist_checkpoint(&mut store, checkpoint.clone()).is_ok());
-        let Ok(Some(mut tampered)) = store.load("exec-1") else {
-            return Err("saved checkpoint must remain loadable".to_string());
-        };
+        #[allow(clippy::expect_used)]
+        let mut tampered = store
+            .load("exec-1")
+            .expect("saved checkpoint must load")
+            .expect("saved checkpoint must remain present");
         tampered.authentication_tag = "invalid".to_string();
         store.checkpoints.insert("exec-1".to_string(), tampered);
         assert!(matches!(
@@ -468,7 +469,6 @@ mod tests {
                 ..
             })
         ));
-        Ok(())
     }
 
     #[test]

--- a/crates/traverse-runtime/src/executor/host_abi_v1.json
+++ b/crates/traverse-runtime/src/executor/host_abi_v1.json
@@ -52,6 +52,21 @@
       "module": "traverse_host",
       "name": "connector_invoke",
       "category": "mediated_connector_invocation"
+    },
+    {
+      "module": "traverse_host",
+      "name": "state_get",
+      "category": "managed_state"
+    },
+    {
+      "module": "traverse_host",
+      "name": "state_put",
+      "category": "managed_state"
+    },
+    {
+      "module": "traverse_host",
+      "name": "state_delete",
+      "category": "managed_state"
     }
   ]
 }

--- a/crates/traverse-runtime/src/executor/mod.rs
+++ b/crates/traverse-runtime/src/executor/mod.rs
@@ -67,6 +67,9 @@ pub struct ExecutorCapability {
     /// The capability contract's `service_type`; only `Subscribable` may call
     /// `traverse_host::emit_event` (spec 098-capability-event-host-abi FR-003).
     pub service_type: ServiceType,
+    /// Contract-declared `state_schema` used by `traverse_host::state_*`
+    /// (spec `1285-capability-state-host-abi` FR-003).
+    pub state_schema: Option<Value>,
 }
 
 /// Output of a [`CapabilityExecutor::execute`] call.

--- a/crates/traverse-runtime/src/executor/thread_pool.rs
+++ b/crates/traverse-runtime/src/executor/thread_pool.rs
@@ -145,6 +145,7 @@ mod tests {
             host_abi_version: None,
             emits: Vec::new(),
             service_type: traverse_contracts::ServiceType::Stateless,
+            state_schema: None,
         }
     }
 

--- a/crates/traverse-runtime/src/executor/wasm.rs
+++ b/crates/traverse-runtime/src/executor/wasm.rs
@@ -7,7 +7,7 @@
 use chrono::Utc;
 use semver::{Version, VersionReq};
 use serde::{Deserialize, Serialize};
-use serde_json::Value;
+use serde_json::{Value, json};
 use sha2::{Digest, Sha256};
 use std::collections::{HashMap, VecDeque};
 use std::fmt::Write as _;
@@ -26,6 +26,7 @@ use super::{
     ArtifactType, CapabilityExecutor, ConnectorInvocationEvidence, ExecutorCapability,
     ExecutorError, ExecutorOutput,
 };
+use crate::data_store::{DataStoreErrorCode, InMemoryDataStore, RuntimeDataStore};
 use crate::events::types::{LifecycleStatus, TraverseEvent};
 use traverse_contracts::{ConnectorRequirement, EventReference, ServiceType};
 
@@ -60,6 +61,25 @@ const EMIT_EVENT_ERR_UNDECLARED_EVENT: i32 = -2;
 /// The calling capability's `service_type` is not `Subscribable` (spec 098
 /// FR-003, acceptance scenario 3).
 const EMIT_EVENT_ERR_NOT_SUBSCRIBABLE: i32 = -3;
+
+/// Maximum bytes accepted for one `traverse_host::state_*` envelope
+/// (spec `1285-capability-state-host-abi` FR-007). Same bound as `emit_event`.
+const MAX_STATE_ENVELOPE_BYTES: usize = 64 * 1024;
+
+/// `traverse_host::state_*` succeeded (spec 1285 FR-009: get may write
+/// `{"found":false}` with this status).
+const STATE_OK: i32 = 0;
+/// Guest pointer/length invalid, envelope oversized/malformed, or get out
+/// buffer missing/insufficient (spec 1285 FR-007/FR-009).
+const STATE_ERR_INVALID_PAYLOAD: i32 = -1;
+/// Calling capability is not `Stateful` (spec 1285 FR-002).
+const STATE_ERR_NOT_STATEFUL: i32 = -2;
+/// No `DataStore` was injected for this run (spec 1285 FR-006).
+const STATE_ERR_NO_STORE: i32 = -3;
+/// Schema missing/empty, undeclared key, or value schema violation (spec 1285 FR-003).
+const STATE_ERR_SCHEMA: i32 = -5;
+/// Adapter/store failure after validation (spec 1285).
+const STATE_ERR_STORE: i32 = -6;
 
 /// `traverse_host::connector_invoke` is unavailable unless the embedding host
 /// supplies an activated, capability-authorized connector binding. The default
@@ -178,12 +198,28 @@ pub fn verify_wasm_host_abi_bytes(
 /// Executes `.wasm32-wasi` capability binaries via Wasmtime.
 ///
 /// Every invocation creates a fresh Wasmtime `Store` — no state leaks between calls.
-#[derive(Debug)]
 pub struct WasmExecutor {
     engine: Engine,
     limits: WasmExecutionLimits,
     module_cache: Mutex<CompiledModuleCache>,
     binary_cache: Mutex<LoadedBinaryCache>,
+    /// Optional injected `DataStore` for Stateful `state_*` host ABI calls
+    /// (spec `1285-capability-state-host-abi` FR-006). Absent means
+    /// `STATE_ERR_NO_STORE` — never an ambient fallback.
+    data_store: Option<Arc<Mutex<RuntimeDataStore<InMemoryDataStore>>>>,
+}
+
+impl std::fmt::Debug for WasmExecutor {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("WasmExecutor")
+            .field("engine", &self.engine)
+            .field("limits", &self.limits)
+            .field("module_cache", &self.module_cache)
+            .field("binary_cache", &self.binary_cache)
+            .field("data_store_configured", &self.data_store.is_some())
+            .finish()
+    }
 }
 
 impl WasmExecutor {
@@ -223,7 +259,30 @@ impl WasmExecutor {
             limits,
             module_cache: Mutex::new(CompiledModuleCache::new(cache_config.max_entries)),
             binary_cache: Mutex::new(LoadedBinaryCache::new(cache_config.max_entries)),
+            data_store: None,
         })
+    }
+
+    /// Injects a `DataStore` used by `traverse_host::state_*` during [`CapabilityExecutor::execute`].
+    #[must_use]
+    pub fn with_data_store(mut self, store: RuntimeDataStore<InMemoryDataStore>) -> Self {
+        self.data_store = Some(Arc::new(Mutex::new(store)));
+        self
+    }
+
+    /// Injects a shared `DataStore` handle (tests can inspect records after execution).
+    #[must_use]
+    pub fn with_shared_data_store(
+        mut self,
+        store: Arc<Mutex<RuntimeDataStore<InMemoryDataStore>>>,
+    ) -> Self {
+        self.data_store = Some(store);
+        self
+    }
+
+    /// Replaces or clears the injected `DataStore` for subsequent executions.
+    pub fn set_data_store(&mut self, store: Option<RuntimeDataStore<InMemoryDataStore>>) {
+        self.data_store = store.map(|store| Arc::new(Mutex::new(store)));
     }
 
     /// Return current compiled-module cache counters.
@@ -471,6 +530,10 @@ struct WasmStoreState {
     capability_id: String,
     emits: Vec<EventReference>,
     service_type: ServiceType,
+    /// Contract `state_schema` for `traverse_host::state_*` (spec 1285 FR-003).
+    state_schema: Option<Value>,
+    /// Injected store for `traverse_host::state_*` (spec 1285 FR-006).
+    data_store: Option<Arc<Mutex<RuntimeDataStore<InMemoryDataStore>>>>,
     /// Events accepted via `traverse_host::emit_event` during this call.
     emitted_events: Vec<TraverseEvent>,
     connector_context: Option<MediatedConnectorContext>,
@@ -516,6 +579,8 @@ impl CapabilityExecutor for WasmExecutor {
             &capability.capability_id,
             &capability.emits,
             capability.service_type.clone(),
+            capability.state_schema.clone(),
+            self.data_store.clone(),
             None,
             Some(&binary.checksum),
         )
@@ -557,6 +622,8 @@ impl WasmExecutor {
             "test-capability",
             &[],
             ServiceType::Stateless,
+            None,
+            None,
         )
         .map(|output| output.value)
     }
@@ -576,6 +643,31 @@ impl WasmExecutor {
         emits: &[EventReference],
         service_type: ServiceType,
     ) -> Result<ExecutorOutput, ExecutorError> {
+        self.run_bytes_with_capability_state(
+            wasm_bytes,
+            input,
+            capability_id,
+            emits,
+            service_type,
+            None,
+        )
+    }
+
+    /// Like [`run_bytes_with_capability`], with an optional contract `state_schema`
+    /// for `traverse_host::state_*` (uses the executor's injected `DataStore` if any).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ExecutorError`] if ABI validation fails or execution cannot complete.
+    pub fn run_bytes_with_capability_state(
+        &self,
+        wasm_bytes: &[u8],
+        input: &Value,
+        capability_id: &str,
+        emits: &[EventReference],
+        service_type: ServiceType,
+        state_schema: Option<Value>,
+    ) -> Result<ExecutorOutput, ExecutorError> {
         self.run_wasm(
             wasm_bytes,
             input,
@@ -583,6 +675,61 @@ impl WasmExecutor {
             capability_id,
             emits,
             service_type,
+            state_schema,
+            self.data_store.clone(),
+        )
+    }
+
+    /// Execute a Stateful capability with an explicit injected `DataStore` and
+    /// `state_schema` (spec `1285-capability-state-host-abi`).
+    ///
+    /// Pass a shared [`Arc`] so callers can inspect store contents after the run.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ExecutorError`] if ABI validation fails or execution cannot complete.
+    pub fn run_bytes_with_stateful_store(
+        &self,
+        wasm_bytes: &[u8],
+        input: &Value,
+        capability_id: &str,
+        state_schema: Value,
+        data_store: Arc<Mutex<RuntimeDataStore<InMemoryDataStore>>>,
+    ) -> Result<ExecutorOutput, ExecutorError> {
+        self.run_wasm(
+            wasm_bytes,
+            input,
+            SUPPORTED_HOST_ABI_VERSION,
+            capability_id,
+            &[],
+            ServiceType::Stateful,
+            Some(state_schema),
+            Some(data_store),
+        )
+    }
+
+    /// Execute as Stateful with `state_schema` but no injected `DataStore`
+    /// (spec `1285-capability-state-host-abi` FR-006).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ExecutorError`] if ABI validation fails or execution cannot complete.
+    pub fn run_bytes_with_stateful_schema(
+        &self,
+        wasm_bytes: &[u8],
+        input: &Value,
+        capability_id: &str,
+        state_schema: Value,
+    ) -> Result<ExecutorOutput, ExecutorError> {
+        self.run_wasm(
+            wasm_bytes,
+            input,
+            SUPPORTED_HOST_ABI_VERSION,
+            capability_id,
+            &[],
+            ServiceType::Stateful,
+            Some(state_schema),
+            None,
         )
     }
 
@@ -608,6 +755,8 @@ impl WasmExecutor {
             capability_id,
             &[],
             ServiceType::Stateless,
+            None,
+            None,
             Some(connector_context),
             None,
         )
@@ -622,6 +771,8 @@ impl WasmExecutor {
         capability_id: &str,
         emits: &[EventReference],
         service_type: ServiceType,
+        state_schema: Option<Value>,
+        data_store: Option<Arc<Mutex<RuntimeDataStore<InMemoryDataStore>>>>,
     ) -> Result<ExecutorOutput, ExecutorError> {
         self.run_wasm_with_connectors(
             wasm_bytes,
@@ -630,6 +781,8 @@ impl WasmExecutor {
             capability_id,
             emits,
             service_type,
+            state_schema,
+            data_store,
             None,
             None,
         )
@@ -644,6 +797,8 @@ impl WasmExecutor {
         capability_id: &str,
         emits: &[EventReference],
         service_type: ServiceType,
+        state_schema: Option<Value>,
+        data_store: Option<Arc<Mutex<RuntimeDataStore<InMemoryDataStore>>>>,
         connector_context: Option<MediatedConnectorContext>,
         checksum: Option<&str>,
     ) -> Result<ExecutorOutput, ExecutorError> {
@@ -674,6 +829,16 @@ impl WasmExecutor {
         linker
             .func_wrap("traverse_host", "connector_invoke", handle_connector_invoke)
             .expect("connector_invoke host function registration should not conflict");
+        linker
+            .func_wrap("traverse_host", "state_get", handle_state_get)
+            .map_err(|e| ExecutorError::RuntimeSetupFailed(format!("func_wrap state_get: {e}")))?;
+        linker
+            .func_wrap("traverse_host", "state_put", handle_state_put)
+            .map_err(|e| ExecutorError::RuntimeSetupFailed(format!("func_wrap state_put: {e}")))?;
+        #[allow(clippy::expect_used)]
+        linker
+            .func_wrap("traverse_host", "state_delete", handle_state_delete)
+            .expect("state_delete host function registration should not conflict");
 
         let mut store = Store::new(
             &self.engine,
@@ -683,6 +848,8 @@ impl WasmExecutor {
                 capability_id: capability_id.to_string(),
                 emits: emits.to_vec(),
                 service_type,
+                state_schema,
+                data_store,
                 emitted_events: Vec::new(),
                 connector_context,
                 connector_invocation_evidence: Vec::new(),
@@ -814,6 +981,206 @@ fn binary_file_identity(
     Ok(BinaryFileIdentity { len, modified })
 }
 
+/// Host implementation of `traverse_host::state_get` (spec
+/// `1285-capability-state-host-abi`). Guest envelope:
+/// `{"key":"<relative>","out_ptr":N,"out_max":M}`. On success writes
+/// `{"found":true,"value":...}` or `{"found":false}` into the out buffer.
+fn handle_state_get(mut caller: Caller<'_, WasmStoreState>, ptr: i32, len: i32) -> i32 {
+    if caller.data().service_type != ServiceType::Stateful {
+        return STATE_ERR_NOT_STATEFUL;
+    }
+    let Some(store) = caller.data().data_store.clone() else {
+        return STATE_ERR_NO_STORE;
+    };
+
+    let Some((memory, envelope)) = read_state_envelope(&mut caller, ptr, len) else {
+        return STATE_ERR_INVALID_PAYLOAD;
+    };
+    let Some(key) = envelope
+        .get("key")
+        .and_then(Value::as_str)
+        .map(str::to_string)
+    else {
+        return STATE_ERR_INVALID_PAYLOAD;
+    };
+    let Some(out_ptr) = envelope.get("out_ptr").and_then(Value::as_i64) else {
+        return STATE_ERR_INVALID_PAYLOAD;
+    };
+    let Some(out_max) = envelope.get("out_max").and_then(Value::as_i64) else {
+        return STATE_ERR_INVALID_PAYLOAD;
+    };
+    if out_ptr < 0 || out_max < 0 {
+        return STATE_ERR_INVALID_PAYLOAD;
+    }
+    #[allow(clippy::cast_sign_loss, clippy::cast_possible_truncation)]
+    let (out_ptr, out_max) = (out_ptr as usize, out_max as usize);
+    if out_max > MAX_STATE_ENVELOPE_BYTES {
+        return STATE_ERR_INVALID_PAYLOAD;
+    }
+
+    let Some(state_schema) = caller.data().state_schema.clone() else {
+        return STATE_ERR_SCHEMA;
+    };
+    if state_schema
+        .get("properties")
+        .and_then(Value::as_object)
+        .is_none_or(serde_json::Map::is_empty)
+    {
+        return STATE_ERR_SCHEMA;
+    }
+
+    let capability_id = caller.data().capability_id.clone();
+    let read_result = {
+        let guard = store
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        guard.read_namespaced(&capability_id, &state_schema, &key)
+    };
+    let response = match read_result {
+        Ok(Some(value)) => json!({ "found": true, "value": value }),
+        Ok(None) => json!({ "found": false }),
+        Err(error) => return map_state_store_error(error.code),
+    };
+
+    match serde_json::to_vec(&response) {
+        Ok(bytes) if bytes.len() <= out_max => {
+            if memory.write(&mut caller, out_ptr, &bytes).is_err() {
+                return STATE_ERR_INVALID_PAYLOAD;
+            }
+            STATE_OK
+        }
+        _ => STATE_ERR_INVALID_PAYLOAD,
+    }
+}
+
+/// Host implementation of `traverse_host::state_put` (spec
+/// `1285-capability-state-host-abi`). Guest envelope:
+/// `{"key":"<relative>","value":<json>}`. Host stamps Lamport metadata.
+fn handle_state_put(mut caller: Caller<'_, WasmStoreState>, ptr: i32, len: i32) -> i32 {
+    if caller.data().service_type != ServiceType::Stateful {
+        return STATE_ERR_NOT_STATEFUL;
+    }
+    let Some(store) = caller.data().data_store.clone() else {
+        return STATE_ERR_NO_STORE;
+    };
+
+    let Some((_memory, envelope)) = read_state_envelope(&mut caller, ptr, len) else {
+        return STATE_ERR_INVALID_PAYLOAD;
+    };
+    let Some(key) = envelope
+        .get("key")
+        .and_then(Value::as_str)
+        .map(str::to_string)
+    else {
+        return STATE_ERR_INVALID_PAYLOAD;
+    };
+    let Some(value) = envelope.get("value").cloned() else {
+        return STATE_ERR_INVALID_PAYLOAD;
+    };
+
+    let Some(state_schema) = caller.data().state_schema.clone() else {
+        return STATE_ERR_SCHEMA;
+    };
+    if state_schema
+        .get("properties")
+        .and_then(Value::as_object)
+        .is_none_or(serde_json::Map::is_empty)
+    {
+        return STATE_ERR_SCHEMA;
+    }
+
+    let capability_id = caller.data().capability_id.clone();
+    let write_result = {
+        let mut guard = store
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        guard.write_namespaced(&capability_id, &state_schema, &key, value)
+    };
+    match write_result {
+        Ok(_) => STATE_OK,
+        Err(error) => map_state_store_error(error.code),
+    }
+}
+
+/// Host implementation of `traverse_host::state_delete` (spec
+/// `1285-capability-state-host-abi`). Guest envelope: `{"key":"<relative>"}`.
+fn handle_state_delete(mut caller: Caller<'_, WasmStoreState>, ptr: i32, len: i32) -> i32 {
+    if caller.data().service_type != ServiceType::Stateful {
+        return STATE_ERR_NOT_STATEFUL;
+    }
+    let Some(store) = caller.data().data_store.clone() else {
+        return STATE_ERR_NO_STORE;
+    };
+
+    let Some((_memory, envelope)) = read_state_envelope(&mut caller, ptr, len) else {
+        return STATE_ERR_INVALID_PAYLOAD;
+    };
+    let Some(key) = envelope
+        .get("key")
+        .and_then(Value::as_str)
+        .map(str::to_string)
+    else {
+        return STATE_ERR_INVALID_PAYLOAD;
+    };
+    if caller.data().state_schema.as_ref().is_none_or(|schema| {
+        schema
+            .get("properties")
+            .and_then(Value::as_object)
+            .is_none_or(serde_json::Map::is_empty)
+    }) {
+        return STATE_ERR_SCHEMA;
+    }
+
+    let capability_id = caller.data().capability_id.clone();
+    let delete_result = {
+        let mut guard = store
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        guard.delete_namespaced(&capability_id, &key)
+    };
+    match delete_result {
+        Ok(()) => STATE_OK,
+        Err(error) => map_state_store_error(error.code),
+    }
+}
+
+fn read_state_envelope(
+    caller: &mut Caller<'_, WasmStoreState>,
+    ptr: i32,
+    len: i32,
+) -> Option<(wasmtime::Memory, Value)> {
+    if ptr < 0 || len < 0 {
+        return None;
+    }
+    #[allow(clippy::cast_sign_loss)]
+    let (ptr, len) = (ptr as usize, len as usize);
+    if len > MAX_STATE_ENVELOPE_BYTES {
+        return None;
+    }
+    let Some(Extern::Memory(memory)) = caller.get_export("memory") else {
+        return None;
+    };
+    let mut buffer = vec![0_u8; len];
+    if memory.read(&*caller, ptr, &mut buffer).is_err() {
+        return None;
+    }
+    let envelope = serde_json::from_slice::<Value>(&buffer).ok()?;
+    if !envelope.is_object() {
+        return None;
+    }
+    Some((memory, envelope))
+}
+
+fn map_state_store_error(code: DataStoreErrorCode) -> i32 {
+    match code {
+        DataStoreErrorCode::NoStateSchemaDeclared | DataStoreErrorCode::SchemaValidationError => {
+            STATE_ERR_SCHEMA
+        }
+        DataStoreErrorCode::InvalidKey => STATE_ERR_INVALID_PAYLOAD,
+        _ => STATE_ERR_STORE,
+    }
+}
+
 /// Host implementation of `traverse_host::emit_event` (spec
 /// 098-capability-event-host-abi FR-001). The guest passes a pointer/length
 /// into its own linear memory holding a JSON payload shaped
@@ -902,7 +1269,6 @@ fn handle_emit_event(mut caller: Caller<'_, WasmStoreState>, ptr: i32, len: i32)
     caller.data_mut().emitted_events.push(event);
     EMIT_EVENT_OK
 }
-
 /// Fail closed until an embedding host supplies an active application binding.
 ///
 /// The four integers are the versioned ABI's request pointer/length and

--- a/crates/traverse-runtime/src/lib.rs
+++ b/crates/traverse-runtime/src/lib.rs
@@ -1876,6 +1876,7 @@ fn executor_capability_for(
         host_abi_version: None,
         emits: selected.contract.emits.clone(),
         service_type: selected.contract.service_type.clone(),
+        state_schema: selected.contract.state_schema.clone(),
     }
 }
 

--- a/crates/traverse-runtime/tests/executor_tests.rs
+++ b/crates/traverse-runtime/tests/executor_tests.rs
@@ -5,6 +5,9 @@ use std::fmt::Write as _;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use traverse_contracts::{ConnectorRequirement, EventReference, ServiceType};
+use traverse_runtime::data_store::{
+    DataStore, InMemoryDataStore, LamportClock, RuntimeDataStore, StateRecord,
+};
 use traverse_runtime::executor::{
     ActivatedConnector, ArtifactType, CapabilityExecutor, ConnectorInvokeRequest,
     ConnectorInvokeResponse, ExecutorCapability, ExecutorError, ExecutorOutput, MediatedConnector,
@@ -65,6 +68,7 @@ fn native_executor_rejects_wasm_artifact_type() -> Result<(), String> {
         host_abi_version: None,
         emits: Vec::new(),
         service_type: ServiceType::Stateless,
+        state_schema: None,
     };
     let err = expect_err(executor.execute(&cap, &json!({})), "expected type error")?;
 
@@ -111,6 +115,7 @@ fn wasm_executor_errors_when_no_path_set() -> Result<(), String> {
         host_abi_version: None,
         emits: Vec::new(),
         service_type: ServiceType::Stateless,
+        state_schema: None,
     };
     let err = expect_err(
         executor.execute(&cap, &json!({})),
@@ -136,6 +141,7 @@ fn wasm_executor_errors_on_missing_file() -> Result<(), String> {
         host_abi_version: None,
         emits: Vec::new(),
         service_type: ServiceType::Stateless,
+        state_schema: None,
     };
     let err = expect_err(
         executor.execute(&cap, &json!({})),
@@ -175,6 +181,7 @@ fn wasm_executor_detects_checksum_mismatch() -> Result<(), String> {
         host_abi_version: None,
         emits: Vec::new(),
         service_type: ServiceType::Stateless,
+        state_schema: None,
     };
 
     let err = expect_err(
@@ -1899,6 +1906,7 @@ fn wasm_executor_full_execute_path_via_disk() -> Result<(), String> {
         host_abi_version: None,
         emits: Vec::new(),
         service_type: ServiceType::Stateless,
+        state_schema: None,
     };
 
     let input = json!({ "disk": true });
@@ -1958,6 +1966,7 @@ fn wasm_executor_execute_with_matching_checksum_succeeds() -> Result<(), String>
         host_abi_version: Some("1.0.0".to_string()),
         emits: Vec::new(),
         service_type: ServiceType::Stateless,
+        state_schema: None,
     };
 
     let result = executor
@@ -1991,6 +2000,7 @@ fn wasm_executor_reuses_unchanged_binary_without_reading_or_hashing_again() -> R
         host_abi_version: None,
         emits: Vec::new(),
         service_type: ServiceType::Stateless,
+        state_schema: None,
     };
 
     let first_input = json!({ "call": 1 });
@@ -2044,6 +2054,7 @@ fn wasm_executor_binary_cache_evicts_oldest_path_deterministically() -> Result<(
         host_abi_version: None,
         emits: Vec::new(),
         service_type: ServiceType::Stateless,
+        state_schema: None,
     };
 
     executor
@@ -2097,6 +2108,7 @@ fn wasm_executor_cached_module_does_not_bypass_checksum_mismatch() -> Result<(),
         host_abi_version: Some("1.0.0".to_string()),
         emits: Vec::new(),
         service_type: ServiceType::Stateless,
+        state_schema: None,
     };
 
     let input = json!({ "cache": true });
@@ -2136,6 +2148,7 @@ fn wasm_executor_invalid_binary_triggers_runtime_setup_failed() -> Result<(), St
         host_abi_version: None,
         emits: Vec::new(),
         service_type: ServiceType::Stateless,
+        state_schema: None,
     };
 
     let err = expect_err(executor.execute(&cap, &json!({})), "expected error")?;
@@ -2558,6 +2571,531 @@ fn core_transition_action_status_does_not_emit_on_rejected_transition() -> Resul
     Ok(())
 }
 
+// --- `traverse_host::state_*` host ABI tests (spec 1285-capability-state-host-abi) ---
+
+fn cart_state_schema() -> Value {
+    json!({
+        "type": "object",
+        "properties": {
+            "cart": {
+                "type": "object",
+                "properties": {
+                    "items": { "type": "array" }
+                }
+            }
+        }
+    })
+}
+
+#[test]
+fn wasm_executor_state_put_get_round_trip_for_stateful_capability() -> Result<(), String> {
+    let put_payload = r#"{"key":"cart","value":{"items":[1]}}"#;
+    let get_payload = r#"{"key":"cart","out_ptr":2000,"out_max":512}"#;
+    let wasm_bytes = wat::parse_str(state_put_then_get_wat(put_payload, get_payload))
+        .map_err(|e| format!("{e}"))?;
+    let store = Arc::new(Mutex::new(RuntimeDataStore::new(
+        InMemoryDataStore::new(),
+        "test-writer",
+    )));
+    let executor = WasmExecutor::new().map_err(|e| format!("{e:?}"))?;
+    let output = executor
+        .run_bytes_with_stateful_store(
+            &wasm_bytes,
+            &json!({}),
+            "commerce.cart",
+            cart_state_schema(),
+            Arc::clone(&store),
+        )
+        .map_err(|e| format!("{e:?}"))?;
+
+    assert_eq!(output.value["found"], json!(true));
+    assert_eq!(output.value["value"], json!({"items":[1]}));
+
+    let guard = store.lock().map_err(|e| format!("poisoned store: {e}"))?;
+    let records = guard.adapter().records();
+    assert!(
+        records.contains_key("commerce.cart/cart"),
+        "expected namespaced key, got {:?}",
+        records.keys().collect::<Vec<_>>()
+    );
+    let record = &records["commerce.cart/cart"];
+    assert_eq!(record.writer_id, "test-writer");
+    assert_eq!(record.lamport_clock, 1);
+    Ok(())
+}
+
+#[test]
+fn wasm_executor_state_put_rejected_for_non_stateful_capability() -> Result<(), String> {
+    let payload = r#"{"key":"cart","value":{"items":[]}}"#;
+    let wasm_bytes =
+        wat::parse_str(state_op_wat("state_put", payload)).map_err(|e| format!("{e}"))?;
+    let executor = WasmExecutor::new().map_err(|e| format!("{e:?}"))?;
+    executor
+        .run_bytes_with_capability(
+            &wasm_bytes,
+            &json!({}),
+            "commerce.cart",
+            &[],
+            ServiceType::Stateless,
+        )
+        .map_err(|e| format!("{e:?}"))?;
+    Ok(())
+}
+
+#[test]
+fn wasm_executor_state_put_rejected_when_data_store_not_configured() -> Result<(), String> {
+    let payload = r#"{"key":"cart","value":{"items":[]}}"#;
+    let wasm_bytes =
+        wat::parse_str(state_op_wat("state_put", payload)).map_err(|e| format!("{e}"))?;
+    let executor = WasmExecutor::new().map_err(|e| format!("{e:?}"))?;
+    executor
+        .run_bytes_with_stateful_schema(
+            &wasm_bytes,
+            &json!({}),
+            "commerce.cart",
+            cart_state_schema(),
+        )
+        .map_err(|e| format!("{e:?}"))?;
+    Ok(())
+}
+
+#[test]
+fn wasm_executor_state_put_rejected_for_oversized_and_oob_payload() -> Result<(), String> {
+    let executor = WasmExecutor::new().map_err(|e| format!("{e:?}"))?;
+    let store = Arc::new(Mutex::new(RuntimeDataStore::new(
+        InMemoryDataStore::new(),
+        "test-writer",
+    )));
+    let oversized_claim = 65 * 1024;
+    let wasm_over = wat::parse_str(state_op_wat_with_len(
+        "state_put",
+        r#"{"key":"cart","value":{}}"#,
+        oversized_claim,
+    ))
+    .map_err(|e| format!("{e}"))?;
+    executor
+        .run_bytes_with_stateful_store(
+            &wasm_over,
+            &json!({}),
+            "commerce.cart",
+            cart_state_schema(),
+            Arc::clone(&store),
+        )
+        .map_err(|e| format!("{e:?}"))?;
+    let wasm_oob = wat::parse_str(state_op_wat_with_ptr_len("state_put", 200_000, 10))
+        .map_err(|e| format!("{e}"))?;
+    executor
+        .run_bytes_with_stateful_store(
+            &wasm_oob,
+            &json!({}),
+            "commerce.cart",
+            cart_state_schema(),
+            Arc::clone(&store),
+        )
+        .map_err(|e| format!("{e:?}"))?;
+    let keys = store
+        .lock()
+        .map_err(|e| format!("{e}"))?
+        .list_keys()
+        .map_err(|e| format!("{e:?}"))?;
+    assert!(
+        keys.is_empty(),
+        "rejected puts must not write, got {keys:?}"
+    );
+    Ok(())
+}
+
+#[test]
+fn wasm_executor_state_put_rejected_for_undeclared_key() -> Result<(), String> {
+    let payload = r#"{"key":"other","value":{"items":[]}}"#;
+    let wasm_bytes =
+        wat::parse_str(state_op_wat("state_put", payload)).map_err(|e| format!("{e}"))?;
+    let store = Arc::new(Mutex::new(RuntimeDataStore::new(
+        InMemoryDataStore::new(),
+        "test-writer",
+    )));
+    let executor = WasmExecutor::new().map_err(|e| format!("{e:?}"))?;
+    executor
+        .run_bytes_with_stateful_store(
+            &wasm_bytes,
+            &json!({}),
+            "commerce.cart",
+            cart_state_schema(),
+            Arc::clone(&store),
+        )
+        .map_err(|e| format!("{e:?}"))?;
+    let guard = store.lock().map_err(|e| format!("{e}"))?;
+    assert!(
+        guard.adapter().records().is_empty(),
+        "undeclared key must not write"
+    );
+    Ok(())
+}
+
+#[test]
+fn wasm_executor_state_put_rejected_for_empty_state_schema_properties() -> Result<(), String> {
+    let payload = r#"{"key":"cart","value":{"items":[]}}"#;
+    let wasm_bytes =
+        wat::parse_str(state_op_wat("state_put", payload)).map_err(|e| format!("{e}"))?;
+    let store = Arc::new(Mutex::new(RuntimeDataStore::new(
+        InMemoryDataStore::new(),
+        "test-writer",
+    )));
+    let executor = WasmExecutor::new().map_err(|e| format!("{e:?}"))?;
+    executor
+        .run_bytes_with_stateful_store(
+            &wasm_bytes,
+            &json!({}),
+            "commerce.cart",
+            json!({"type":"object","properties":{}}),
+            Arc::clone(&store),
+        )
+        .map_err(|e| format!("{e:?}"))?;
+    let guard = store.lock().map_err(|e| format!("{e}"))?;
+    assert!(
+        guard.adapter().records().is_empty(),
+        "empty state_schema.properties must fail closed"
+    );
+    Ok(())
+}
+
+#[test]
+#[allow(clippy::too_many_lines)]
+fn wasm_executor_state_get_delete_and_inject_api_cover_remaining_branches() -> Result<(), String> {
+    let executor = WasmExecutor::new().map_err(|e| format!("{e:?}"))?;
+    let _ = format!("{executor:?}");
+
+    // get not-found
+    let get_payload = r#"{"key":"cart","out_ptr":2000,"out_max":512}"#;
+    let expected_miss = br#"{"found":false}"#;
+    let wasm_get = wat::parse_str(state_get_wat(get_payload, expected_miss.len()))
+        .map_err(|e| format!("{e}"))?;
+    let store = Arc::new(Mutex::new(RuntimeDataStore::new(
+        InMemoryDataStore::new(),
+        "test-writer",
+    )));
+    let missed = executor
+        .run_bytes_with_stateful_store(
+            &wasm_get,
+            &json!({}),
+            "commerce.cart",
+            cart_state_schema(),
+            Arc::clone(&store),
+        )
+        .map_err(|e| format!("{e:?}"))?;
+    assert_eq!(missed.value, json!({"found": false}));
+
+    // put then delete then confirm gone
+    store
+        .lock()
+        .map_err(|e| format!("{e}"))?
+        .write_namespaced(
+            "commerce.cart",
+            &cart_state_schema(),
+            "cart",
+            json!({"items": [1]}),
+        )
+        .map_err(|e| format!("{e:?}"))?;
+    let wasm_del = wat::parse_str(state_op_wat("state_delete", r#"{"key":"cart"}"#))
+        .map_err(|e| format!("{e}"))?;
+    executor
+        .run_bytes_with_stateful_store(
+            &wasm_del,
+            &json!({}),
+            "commerce.cart",
+            cart_state_schema(),
+            Arc::clone(&store),
+        )
+        .map_err(|e| format!("{e:?}"))?;
+    assert!(
+        store
+            .lock()
+            .map_err(|e| format!("{e}"))?
+            .adapter()
+            .records()
+            .is_empty()
+    );
+
+    // get rejected when not Stateful / no store / bad envelopes
+    let wasm_get_op =
+        wat::parse_str(state_op_wat("state_get", get_payload)).map_err(|e| format!("{e}"))?;
+    executor
+        .run_bytes_with_capability(
+            &wasm_get_op,
+            &json!({}),
+            "commerce.cart",
+            &[],
+            ServiceType::Stateless,
+        )
+        .map_err(|e| format!("{e:?}"))?;
+    executor
+        .run_bytes_with_capability_state(
+            &wasm_get_op,
+            &json!({}),
+            "commerce.cart",
+            &[],
+            ServiceType::Stateful,
+            Some(cart_state_schema()),
+        )
+        .map_err(|e| format!("{e:?}"))?;
+    for payload in [
+        r#"{"out_ptr":2000,"out_max":512}"#,
+        r#"{"key":"cart","out_max":512}"#,
+        r#"{"key":"cart","out_ptr":2000}"#,
+        r#"{"key":"cart","out_ptr":-1,"out_max":512}"#,
+        r#"{"key":"cart","out_ptr":2000,"out_max":70000}"#,
+        "[]",
+    ] {
+        let wasm =
+            wat::parse_str(state_op_wat("state_get", payload)).map_err(|e| format!("{e}"))?;
+        executor
+            .run_bytes_with_stateful_store(
+                &wasm,
+                &json!({}),
+                "commerce.cart",
+                cart_state_schema(),
+                Arc::clone(&store),
+            )
+            .map_err(|e| format!("{e:?}"))?;
+    }
+
+    // get with tiny out_max after seeding a value
+    store
+        .lock()
+        .map_err(|e| format!("{e}"))?
+        .write_namespaced(
+            "commerce.cart",
+            &cart_state_schema(),
+            "cart",
+            json!({"items": [1, 2, 3]}),
+        )
+        .map_err(|e| format!("{e:?}"))?;
+    let tiny = r#"{"key":"cart","out_ptr":2000,"out_max":1}"#;
+    let wasm_tiny = wat::parse_str(state_op_wat("state_get", tiny)).map_err(|e| format!("{e}"))?;
+    executor
+        .run_bytes_with_stateful_store(
+            &wasm_tiny,
+            &json!({}),
+            "commerce.cart",
+            cart_state_schema(),
+            Arc::clone(&store),
+        )
+        .map_err(|e| format!("{e:?}"))?;
+
+    // put missing fields / invalid relative key / missing schema / lamport overflow
+    for payload in [
+        r#"{"value":{}}"#,
+        r#"{"key":"cart"}"#,
+        r#"{"key":"bad.key","value":{}}"#,
+    ] {
+        let wasm =
+            wat::parse_str(state_op_wat("state_put", payload)).map_err(|e| format!("{e}"))?;
+        executor
+            .run_bytes_with_stateful_store(
+                &wasm,
+                &json!({}),
+                "commerce.cart",
+                cart_state_schema(),
+                Arc::clone(&store),
+            )
+            .map_err(|e| format!("{e:?}"))?;
+    }
+    let wasm_put = wat::parse_str(state_op_wat(
+        "state_put",
+        r#"{"key":"cart","value":{"items":[]}}"#,
+    ))
+    .map_err(|e| format!("{e}"))?;
+    WasmExecutor::new()
+        .map_err(|e| format!("{e:?}"))?
+        .with_shared_data_store(Arc::clone(&store))
+        .run_bytes_with_capability_state(
+            &wasm_put,
+            &json!({}),
+            "commerce.cart",
+            &[],
+            ServiceType::Stateful,
+            None,
+        )
+        .map_err(|e| format!("{e:?}"))?;
+
+    let overflow_store = Arc::new(Mutex::new(RuntimeDataStore::with_clock(
+        InMemoryDataStore::new(),
+        LamportClock::with_value("test-writer", u64::MAX),
+    )));
+    executor
+        .run_bytes_with_stateful_store(
+            &wasm_put,
+            &json!({}),
+            "commerce.cart",
+            cart_state_schema(),
+            Arc::clone(&overflow_store),
+        )
+        .map_err(|e| format!("{e:?}"))?;
+
+    // delete branches
+    let wasm_del_bad = wat::parse_str(state_op_wat("state_delete", r#"{"nope":1}"#))
+        .map_err(|e| format!("{e}"))?;
+    executor
+        .run_bytes_with_capability(
+            &wasm_del,
+            &json!({}),
+            "commerce.cart",
+            &[],
+            ServiceType::Stateless,
+        )
+        .map_err(|e| format!("{e:?}"))?;
+    executor
+        .run_bytes_with_capability_state(
+            &wasm_del,
+            &json!({}),
+            "commerce.cart",
+            &[],
+            ServiceType::Stateful,
+            Some(cart_state_schema()),
+        )
+        .map_err(|e| format!("{e:?}"))?;
+    executor
+        .run_bytes_with_stateful_store(
+            &wasm_del_bad,
+            &json!({}),
+            "commerce.cart",
+            cart_state_schema(),
+            Arc::clone(&store),
+        )
+        .map_err(|e| format!("{e:?}"))?;
+    executor
+        .run_bytes_with_stateful_store(
+            &wasm_del,
+            &json!({}),
+            "commerce.cart",
+            json!({"type":"object","properties":{}}),
+            Arc::clone(&store),
+        )
+        .map_err(|e| format!("{e:?}"))?;
+    let wasm_del_slash = wat::parse_str(state_op_wat("state_delete", r#"{"key":"a/b"}"#))
+        .map_err(|e| format!("{e}"))?;
+    executor
+        .run_bytes_with_stateful_store(
+            &wasm_del_slash,
+            &json!({}),
+            "commerce.cart",
+            cart_state_schema(),
+            Arc::clone(&store),
+        )
+        .map_err(|e| format!("{e:?}"))?;
+
+    // inject API setters
+    let mut mutable = WasmExecutor::new()
+        .map_err(|e| format!("{e:?}"))?
+        .with_data_store(RuntimeDataStore::new(InMemoryDataStore::new(), "w"));
+    let _ = format!("{mutable:?}");
+    mutable.set_data_store(None);
+
+    // get empty schema + get without schema
+    executor
+        .run_bytes_with_stateful_store(
+            &wasm_get_op,
+            &json!({}),
+            "commerce.cart",
+            json!({"type":"object","properties":{}}),
+            Arc::clone(&store),
+        )
+        .map_err(|e| format!("{e:?}"))?;
+    WasmExecutor::new()
+        .map_err(|e| format!("{e:?}"))?
+        .with_shared_data_store(Arc::clone(&store))
+        .run_bytes_with_capability_state(
+            &wasm_get_op,
+            &json!({}),
+            "commerce.cart",
+            &[],
+            ServiceType::Stateful,
+            None,
+        )
+        .map_err(|e| format!("{e:?}"))?;
+
+    // get with out_ptr beyond memory (large out_max so write path is reached)
+    let wasm_oob_get = wat::parse_str(state_op_wat(
+        "state_get",
+        r#"{"key":"cart","out_ptr":200000,"out_max":512}"#,
+    ))
+    .map_err(|e| format!("{e}"))?;
+    executor
+        .run_bytes_with_stateful_store(
+            &wasm_oob_get,
+            &json!({}),
+            "commerce.cart",
+            cart_state_schema(),
+            Arc::clone(&store),
+        )
+        .map_err(|e| format!("{e:?}"))?;
+
+    // get schema-invalid stored value
+    {
+        let mut guard = store.lock().map_err(|e| format!("{e}"))?;
+        let _ = guard.delete_namespaced("commerce.cart", "cart");
+        drop(guard);
+    }
+    {
+        let mut adapter = InMemoryDataStore::new();
+        adapter
+            .write(StateRecord {
+                key: "commerce.cart/cart".to_string(),
+                value: json!("bad"),
+                lamport_clock: 1,
+                writer_id: "w".to_string(),
+            })
+            .map_err(|e| format!("{e:?}"))?;
+        let bad_store = Arc::new(Mutex::new(RuntimeDataStore::new(adapter, "w")));
+        executor
+            .run_bytes_with_stateful_store(
+                &wasm_get_op,
+                &json!({}),
+                "commerce.cart",
+                cart_state_schema(),
+                bad_store,
+            )
+            .map_err(|e| format!("{e:?}"))?;
+    }
+
+    // delete envelope / negative pointer / no memory
+    let wasm_del_oob = wat::parse_str(state_op_wat_with_raw_ptr_len("state_delete", -1, 4))
+        .map_err(|e| format!("{e}"))?;
+    executor
+        .run_bytes_with_stateful_store(
+            &wasm_del_oob,
+            &json!({}),
+            "commerce.cart",
+            cart_state_schema(),
+            Arc::clone(&store),
+        )
+        .map_err(|e| format!("{e:?}"))?;
+    let wasm_no_mem = wat::parse_str(
+        r#"
+        (module
+            (import "traverse_host" "state_delete"
+                (func $state_delete (param i32 i32) (result i32)))
+            (import "wasi_snapshot_preview1" "fd_write"
+                (func $fd_write (param i32 i32 i32 i32) (result i32)))
+            (func $_start (export "_start")
+                (drop (call $state_delete (i32.const 0) (i32.const 2)))
+                (unreachable)
+            )
+        )
+        "#,
+    )
+    .map_err(|e| format!("{e}"))?;
+    let _ = executor.run_bytes_with_stateful_store(
+        &wasm_no_mem,
+        &json!({}),
+        "commerce.cart",
+        cart_state_schema(),
+        Arc::clone(&store),
+    );
+
+    Ok(())
+}
+
 // --- helpers ---
 
 fn native_capability(id: &str) -> ExecutorCapability {
@@ -2569,6 +3107,7 @@ fn native_capability(id: &str) -> ExecutorCapability {
         host_abi_version: None,
         emits: Vec::new(),
         service_type: ServiceType::Stateless,
+        state_schema: None,
     }
 }
 
@@ -2611,15 +3150,10 @@ fn wat_escape(payload: &str) -> String {
     payload.replace('\\', "\\\\").replace('"', "\\\"")
 }
 
-/// A WASM module that writes `payload` into linear memory at offset 100,
-/// calls `traverse_host::emit_event(100, payload.len())`, then writes `{}`
-/// to stdout (a minimal valid JSON output, unrelated to the emit call).
 fn emit_event_wat(payload: &str) -> String {
     emit_event_wat_with_len(payload, payload.len())
 }
 
-/// As [`emit_event_wat`], but the guest claims `claimed_len` bytes instead
-/// of `payload.len()` — used to simulate an oversized length claim.
 fn emit_event_wat_with_len(payload: &str, claimed_len: usize) -> String {
     format!(
         r#"
@@ -2643,9 +3177,6 @@ fn emit_event_wat_with_len(payload: &str, claimed_len: usize) -> String {
     )
 }
 
-/// A WASM module that calls `traverse_host::emit_event(ptr, len)` directly
-/// with caller-supplied coordinates, ignoring what (if anything) is actually
-/// at that memory location — used to exercise the guest-memory bounds check.
 fn emit_event_wat_with_ptr_len(ptr: usize, len: usize) -> String {
     emit_event_wat_with_raw_ptr_len(
         i32::try_from(ptr).unwrap_or(i32::MAX),
@@ -2653,8 +3184,6 @@ fn emit_event_wat_with_ptr_len(ptr: usize, len: usize) -> String {
     )
 }
 
-/// As [`emit_event_wat_with_ptr_len`], but accepts raw `i32` coordinates
-/// directly — used to exercise a negative pointer or length.
 fn emit_event_wat_with_raw_ptr_len(ptr: i32, len: i32) -> String {
     format!(
         r#"
@@ -2676,7 +3205,116 @@ fn emit_event_wat_with_raw_ptr_len(ptr: i32, len: i32) -> String {
     )
 }
 
-/// Assert that `result` is `Err`, returning the error value or a descriptive `String` failure.
+fn state_op_wat(import_name: &str, payload: &str) -> String {
+    state_op_wat_with_len(import_name, payload, payload.len())
+}
+
+fn state_op_wat_with_len(import_name: &str, payload: &str, claimed_len: usize) -> String {
+    format!(
+        r#"
+        (module
+            (import "traverse_host" "{import_name}"
+                (func $state_op (param i32 i32) (result i32)))
+            (import "wasi_snapshot_preview1" "fd_write"
+                (func $fd_write (param i32 i32 i32 i32) (result i32)))
+            (memory (export "memory") 2)
+            (data (i32.const 100) "{payload}")
+            (data (i32.const 300) "{{}}")
+            (func $_start (export "_start")
+                (drop (call $state_op (i32.const 100) (i32.const {claimed_len})))
+                (i32.store (i32.const 0) (i32.const 300))
+                (i32.store (i32.const 4) (i32.const 2))
+                (drop (call $fd_write (i32.const 1) (i32.const 0) (i32.const 1) (i32.const 4100)))
+            )
+        )
+        "#,
+        payload = wat_escape(payload),
+    )
+}
+
+fn state_op_wat_with_ptr_len(import_name: &str, ptr: usize, len: usize) -> String {
+    state_op_wat_with_raw_ptr_len(
+        import_name,
+        i32::try_from(ptr).unwrap_or(i32::MAX),
+        i32::try_from(len).unwrap_or(i32::MAX),
+    )
+}
+
+fn state_op_wat_with_raw_ptr_len(import_name: &str, ptr: i32, len: i32) -> String {
+    format!(
+        r#"
+        (module
+            (import "traverse_host" "{import_name}"
+                (func $state_op (param i32 i32) (result i32)))
+            (import "wasi_snapshot_preview1" "fd_write"
+                (func $fd_write (param i32 i32 i32 i32) (result i32)))
+            (memory (export "memory") 1)
+            (data (i32.const 300) "{{}}")
+            (func $_start (export "_start")
+                (drop (call $state_op (i32.const {ptr}) (i32.const {len})))
+                (i32.store (i32.const 0) (i32.const 300))
+                (i32.store (i32.const 4) (i32.const 2))
+                (drop (call $fd_write (i32.const 1) (i32.const 0) (i32.const 1) (i32.const 4100)))
+            )
+        )
+        "#,
+    )
+}
+
+fn state_put_then_get_wat(put_payload: &str, get_payload: &str) -> String {
+    let expected = r#"{"found":true,"value":{"items":[1]}}"#;
+    let out_len = expected.len();
+    format!(
+        r#"
+        (module
+            (import "traverse_host" "state_put"
+                (func $state_put (param i32 i32) (result i32)))
+            (import "traverse_host" "state_get"
+                (func $state_get (param i32 i32) (result i32)))
+            (import "wasi_snapshot_preview1" "fd_write"
+                (func $fd_write (param i32 i32 i32 i32) (result i32)))
+            (memory (export "memory") 2)
+            (data (i32.const 100) "{put_payload}")
+            (data (i32.const 500) "{get_payload}")
+            (func $_start (export "_start")
+                (drop (call $state_put (i32.const 100) (i32.const {put_len})))
+                (drop (call $state_get (i32.const 500) (i32.const {get_len})))
+                (i32.store (i32.const 0) (i32.const 2000))
+                (i32.store (i32.const 4) (i32.const {out_len}))
+                (drop (call $fd_write (i32.const 1) (i32.const 0) (i32.const 1) (i32.const 4100)))
+            )
+        )
+        "#,
+        put_payload = wat_escape(put_payload),
+        get_payload = wat_escape(get_payload),
+        put_len = put_payload.len(),
+        get_len = get_payload.len(),
+    )
+}
+
+fn state_get_wat(get_payload: &str, out_len: usize) -> String {
+    format!(
+        r#"
+        (module
+            (import "traverse_host" "state_get"
+                (func $state_get (param i32 i32) (result i32)))
+            (import "wasi_snapshot_preview1" "fd_write"
+                (func $fd_write (param i32 i32 i32 i32) (result i32)))
+            (memory (export "memory") 2)
+            (data (i32.const 500) "{get_payload}")
+            (func $_start (export "_start")
+                (drop (call $state_get (i32.const 500) (i32.const {get_len})))
+                (i32.store (i32.const 0) (i32.const 2000))
+                (i32.store (i32.const 4) (i32.const {out_len}))
+                (drop (call $fd_write (i32.const 1) (i32.const 0) (i32.const 1) (i32.const 4100)))
+            )
+        )
+        "#,
+        get_payload = wat_escape(get_payload),
+        get_len = get_payload.len(),
+    )
+}
+
 fn expect_err<T: std::fmt::Debug, E>(result: Result<T, E>, msg: &str) -> Result<E, String> {
     match result {
         Err(e) => Ok(e),

--- a/crates/traverse-runtime/tests/expedition_wasm_tests.rs
+++ b/crates/traverse-runtime/tests/expedition_wasm_tests.rs
@@ -282,6 +282,7 @@ fn expedition_wasm_execution_writes_trace() -> Result<(), String> {
             host_abi_version: None,
             emits: Vec::new(),
             service_type: ServiceType::Stateless,
+            state_schema: None,
         },
         trace_id_override: None,
     };
@@ -403,6 +404,7 @@ fn run_expedition_via_router(wasm_bytes: &[u8], tmp_path: &str) -> Result<Router
             host_abi_version: None,
             emits: Vec::new(),
             service_type: ServiceType::Stateless,
+            state_schema: None,
         },
         trace_id_override: None,
     };

--- a/crates/traverse-runtime/tests/router_tests.rs
+++ b/crates/traverse-runtime/tests/router_tests.rs
@@ -130,6 +130,7 @@ fn native_executor_capability(capability_id: &str) -> ExecutorCapability {
         // are never consulted for validation (only `WasmExecutor` does).
         emits: Vec::new(),
         service_type: ServiceType::Stateless,
+        state_schema: None,
     }
 }
 

--- a/crates/traverse-runtime/tests/thread_pool_integration.rs
+++ b/crates/traverse-runtime/tests/thread_pool_integration.rs
@@ -126,6 +126,7 @@ fn executor_cap(artifact_type: ArtifactType) -> ExecutorCapability {
         host_abi_version: None,
         emits: Vec::new(),
         service_type: ServiceType::Stateless,
+        state_schema: None,
     }
 }
 

--- a/crates/traverse-runtime/tests/thread_pool_stress.rs
+++ b/crates/traverse-runtime/tests/thread_pool_stress.rs
@@ -28,6 +28,7 @@ fn native_capability() -> ExecutorCapability {
         host_abi_version: None,
         emits: Vec::new(),
         service_type: traverse_contracts::ServiceType::Stateless,
+        state_schema: None,
     }
 }
 

--- a/crates/traverse-runtime/tests/workload_conformance.rs
+++ b/crates/traverse-runtime/tests/workload_conformance.rs
@@ -148,6 +148,7 @@ fn capability() -> ExecutorCapability {
         host_abi_version: None,
         emits: Vec::new(),
         service_type: traverse_contracts::ServiceType::Stateless,
+        state_schema: None,
     }
 }
 

--- a/docs/decision-log.md
+++ b/docs/decision-log.md
@@ -3158,3 +3158,37 @@ dependency. Remaining actions (none on the maintainer):
    implementation arc against Specs 996 and 130.
 3. Board changes from Decisions 2-5 applied to `#1272`, `#1274`, `#1275`,
    `#1168` directly on GitHub.
+
+## Decision 71: Implement Spec 1285 State Host ABI (Relative-Key v1)
+
+**Date**: 2026-09-08  
+**Issue**: #1285  
+**Spec**: `specs/1285-capability-state-host-abi/spec.md` (Draft)
+**Supersedes / refines**: Decision 68 partition field deferred in v1
+
+### Context
+
+Registry Wave 2 needs honest UMA Stateful capabilities. Host ABI 1.0.0 had
+`emit_event` for Subscribable but no guest import for managed persistence,
+despite `DataStore` / `RuntimeDataStore` already existing in-tree.
+
+### Decisions (owner `/brainstorm`, recommended option each time)
+
+1. Wire existing DataStore into `traverse_host` (not connector-only, not a parallel session ABI).
+2. Three imports only: `state_get`, `state_put`, `state_delete`.
+3. Host prefixes keys with `{capability_id}/`.
+4. Missing injected store → hard fail (`data_store_not_configured`); explicit in-memory inject for tests.
+5. Host stamps lamport/writer; guest sends `{key,value}` only.
+6. Fixed `state_schema.properties` keys; resource ids inside values.
+7. Stateful contracts require non-empty `state_schema`; Browser still forbidden.
+8. Ship Traverse ABI before registry Wave 2 publishes.
+9. New focused spec (098 playbook), not taxonomy-only amend.
+10. Extend `host_abi_v1` / ABI `1.0.0` whitelist (optional imports).
+
+### Outcome
+
+Landed Spec 1285 + `state_*` in `traverse-runtime` with Decision 68's trio and
+capability namespacing. v1 guest envelopes use relative keys only (resource ids
+inside values); an explicit `partition` parameter from Decision 68 remains a
+follow-up if multi-tenant key fan-out needs it at the ABI layer. Unblocks
+registry Wave 2 Stateful publishes.

--- a/specs/1285-capability-state-host-abi/spec.md
+++ b/specs/1285-capability-state-host-abi/spec.md
@@ -1,0 +1,108 @@
+# Feature Specification: Capability-Side WASM Host ABI for Managed State
+
+**Status**: Draft (co-designed with repo owner via `/brainstorm`; awaiting formal approval / move to `approved`)
+**Canonical governing ID**: `1285-capability-state-host-abi`
+**Version**: 1.0.0
+**Extends**: `002-capability-contracts`, `014-service-type-taxonomy` (Traverse Spec ID 014 / issue 208), `RuntimeDataStore` / DataStore surface
+**Input**: Issue #1285; registry decision-log entry 93; `/brainstorm` session (host storage unlock for UMA Stateful).
+
+## Purpose
+
+Define a WASM host-function ABI that lets a **Stateful** capability read and
+write managed persistence during execution, via the existing host
+`DataStore` / `RuntimeDataStore` stack. Today Stateful is declared on
+contracts and placement-constrained (no Browser), but guests have no
+whitelisted import to touch durable state — so the registry cannot publish
+honest Stateful capabilities (UMA §5.1.2).
+
+This mirrors `098-capability-event-host-abi` (`emit_event` for Subscribable):
+synchronous, deny-by-default, call-time validation, no panic/trap on bad
+guest pointers.
+
+## Capability Boundary
+
+Governs host-function import signatures, calling convention, synchronous
+validation, key namespacing, and whitelist membership on Host ABI `1.0.0`
+(`host_abi_v1.json`). Does **not** redesign `DataStore` sync/merge/crypto;
+does **not** add list/query imports in v1; does **not** publish registry
+capabilities (follow-on once this ABI is callable).
+
+## Requirements
+
+- **FR-001**: Host ABI `1.0.0` MUST whitelist three `traverse_host` imports:
+  `state_get`, `state_put`, and `state_delete`. Each takes `(ptr: i32, len: i32) -> i32`
+  where `ptr`/`len` address a JSON envelope in guest linear memory.
+- **FR-002**: Only capabilities with `service_type == Stateful` MAY succeed
+  on these calls. Any other service type MUST be rejected at call time with a
+  stable negative status (before guest memory is read for put/delete; get MAY
+  also reject before read).
+- **FR-003**: The calling capability's contract MUST declare a non-empty
+  `state_schema`. Writes MUST pass existing `RuntimeDataStore` /
+  `validate_state_write` rules (exact `state_schema.properties[key]`). Missing
+  schema MUST fail the call (not silently no-op).
+- **FR-004**: Guest envelopes:
+  - `state_put`: `{"key":"<relative>","value":<json>}`
+  - `state_get` / `state_delete`: `{"key":"<relative>"}`
+  Relative keys MUST NOT contain `/` or `..`. The host MUST persist under
+  `{capability_id}/{relative_key}` (capability isolation).
+- **FR-005**: On put, the host MUST stamp `StateRecord` metadata
+  (`lamport_clock`, `writer_id`) via `RuntimeDataStore`; the guest MUST NOT
+  supply clock/writer fields.
+- **FR-006**: If no `DataStore` is injected into the executor for this run,
+  state_* MUST return a stable `data_store_not_configured` error. The host
+  MUST NOT silently fall back to an ambient in-memory store. Tests and local
+  tools MAY inject an explicit in-memory adapter.
+- **FR-007**: Memory bounds and a maximum envelope size (same order as
+  `emit_event`, 64 KiB) MUST be enforced before deserializing. Malformed or
+  out-of-bounds requests MUST return an error code — no panic, trap, or
+  out-of-bounds read.
+- **FR-008**: Contract validation MUST reject `service_type: stateful` when
+  `state_schema` is missing/empty, and MUST continue to reject Stateful +
+  Browser in `permitted_targets` (taxonomy FR-005).
+- **FR-009**: `state_get` MUST distinguish not-found from errors via stable
+  status codes; on success, the host writes a JSON result envelope into a
+  guest-provided out-buffer **or** returns the value through a documented
+  in-memory result channel consistent with other host helpers — v1 MUST
+  document one approach and test it. Prefer: put response bytes at an
+  `out_ptr`/`out_len` pair if the signature stays two i32s…  
+
+  **v1 decision (brainstorm follow-through):** keep `(ptr,len)->i32` like
+  `emit_event`. For `state_get`, the guest envelope MAY include
+  `"out_ptr"` / `"out_max"` integers; on success the host writes
+  `{"found":true,"value":...}` or `{"found":false}` into that out region and
+  returns `0`. If `out_ptr`/`out_max` are absent or insufficient, return
+  invalid-payload.
+
+## Acceptance Scenarios
+
+1. Given a Stateful capability with `state_schema.properties.cart` and an
+   injected store, when it `state_put`s `{"key":"cart","value":{...}}`, then
+   the host stores under `{capability_id}/cart` with stamped metadata and
+   returns OK.
+2. Given the same capability `state_get`s `{"key":"cart",...}`, then it
+   receives the stored value (`found: true`).
+3. Given a Stateless capability calls `state_put`, then the call is rejected
+   regardless of payload.
+4. Given Stateful but no injected store, when `state_put` is called, then the
+   host returns `data_store_not_configured` (or equivalent stable code).
+5. Given an oversized or out-of-bounds pointer, when any state_* is called,
+   then the host returns an error without panicking or reading past guest
+   memory.
+6. Given Stateful without `state_schema`, when the contract is validated or
+   when `state_put` runs, then the operation fails closed.
+
+## Out of Scope
+
+- `state_list` / prefix query (deferred).
+- Cross-capability shared keys.
+- Browser ephemeral stores.
+- Registry Wave 2 capability publishes (blocked on this ABI landing).
+
+## Success Criteria
+
+- **SC-001**: `host_abi_v1.json` lists `state_get`, `state_put`, `state_delete`.
+- **SC-002**: Executor tests cover scenarios 1–5 (happy put/get, wrong
+  service type, no store, bounds, schema miss).
+- **SC-003**: `cargo test -p traverse-runtime` passes.
+- **SC-004**: Spec alignment / approved-specs registration completed when
+  the owner approves this Draft.


### PR DESCRIPTION
## Summary
- Whitelist and implement `traverse_host::state_get` / `state_put` / `state_delete` on Host ABI `1.0.0`, backed by injected `RuntimeDataStore` with `{capability_id}/{key}` namespacing and host-stamped Lamport metadata.
- Require non-empty `state_schema` for `service_type: stateful` at contract validation time.
- Add Draft companion `specs/1285-capability-state-host-abi/` and Decision 71; executor tests cover put/get/delete happy and fail-closed paths.

Closes #1285.

## Governing Spec
- `131-stateful-persistence-host-abi`
- `098-capability-event-host-abi`
- `002-capability-contracts`
- `003-event-contracts`
- `014-service-type-taxonomy`
- `025-wasm-executor-adapter`
- `032-universal-data-access`
- `047-thread-pool-executor`
- `101-local-executor-event-emission`
- `120-host-owned-artifact-preparation`
- `518-durable-local-datastore`

## Project Item
- https://github.com/traverse-framework/traverse/issues/1285

## Validation
- [x] Local preflight passed (fmt, expedition smoke, repository checks, coverage gate for `traverse-runtime`, web-embedder conformance)
- [x] `cargo test -p traverse-runtime --features wasmtime-executor --test executor_tests` (state_* matrix)
- [ ] CI green on this PR

## Test plan
- [x] Executor state put/get/delete happy paths + fail-closed (no store, non-Stateful, schema violations)
- [ ] CI green on this PR
