### PR TITLE
docs: add Callweave registry release proof

### DIFF
--- a/docs/releases/next.md
+++ b/docs/releases/next.md
@@ -1,0 +1,25 @@
+# Next Release Notes
+
+## Verified Registry application references
+
+The next Traverse release after `v0.10.0` includes the verified Registry
+application-reference lifecycle.
+
+- A host prepares an active, signed Registry release and commits its verified
+  contract and WASM bytes under immutable digest keys.
+- `app validate`, `app register`, and `app activate` consume prepared evidence
+  only; they do not fetch from the Registry, replace an exact version, or
+  substitute a local component path.
+- Cache integrity failures are redacted. Operators receive stable lifecycle
+  outcomes rather than endpoints, credentials, headers, cache paths, or raw
+  artifact bytes.
+
+The minimum supported Traverse version is this next release; `v0.10.0` and
+earlier do not provide the complete preparation-to-offline-activation path.
+
+### Downstream proof
+
+The checked-in Callweave `inference.evidence-normalize@1.0.1` signed-release
+fixture proves exact-version validation, registration, and local activation
+using prepared cache bytes. Its fixture contains no credential or private
+endpoint requirement.


### PR DESCRIPTION
## Summary

- record the downstream Callweave signed-release fixture proof
- state the verified Registry lifecycle and minimum supported release accurately

## Governing Spec

- `996-registry-app-preparation`
- `1258-offline-cache-activation`
- `054-public-scope-registry-ref`
- `065-sigstore-bundle-verification`
- `070-runtime-event-sink-boundary`

## Project Item

Closes #1301

## Definition of Done

- [x] Callweave signed-release fixture validates, registers, and activates offline
- [x] Evidence requires no repository credential or private endpoint
- [x] Release note identifies corrected behavior and the minimum supported release

## Validation

- `cargo test -p traverse-cli-rs signed_release_fixture_validates_registers_and_activates_offline -- --nocapture` (passed)
