### PR TITLE
Propose Spec 132: Stateful Browser placement via IndexedDB attestation

### DIFF
--- a/docs/adr/0065-stateful-browser-placement.md
+++ b/docs/adr/0065-stateful-browser-placement.md
@@ -1,0 +1,68 @@
+# ADR-0065: Stateful Browser Placement via IndexedDB Host Attestation
+
+- Status: Proposed
+- Date: 2026-09-09
+- Governing spec: `132-stateful-browser-placement` (Proposed)
+- Extends / supersedes placement rule in: `014-service-type-taxonomy` (`208`) FR-005
+- Depends on: `085-datastore-indexeddb`, `131-stateful-persistence-host-abi`
+- Related issues: #1305 (specification), #1289 (implementation)
+- Related: ADR-0063; `docs/decision-log.md` Decision 72
+
+## Context
+
+Spec `014` / `208` FR-005 rejects `service_type: Stateful` when
+`permitted_targets` includes `Browser`, on the assumption that browsers cannot
+offer managed persistence. Spec `085` since approved an IndexedDB DataStore
+backend with exclusive ownership and public integrity. Spec `131` defines the
+`state_*` host ABI serviced by an abstract host store. Decision 68 deferred
+Browser placement so the first Stateful slice stayed server/edge-side.
+
+#1289 asks to permit Stateful on Browser when a qualifying IndexedDB store is
+bound. A 2026-09-09 `/brainstorm` recorded the product decisions on #1289 and
+opened #1305 as the governing vehicle.
+
+## Decision
+
+1. **Supersede contract-time FR-005.** Contract validation MUST accept
+   Stateful+Browser. Portable contracts MUST NOT declare IndexedDB or any
+   concrete backend.
+2. **Enforce at activation with runtime backend proof.** Browser activation of
+   a Stateful capability succeeds only when the bound DataStore is the
+   IndexedDB backend and has opened under Spec `085` guarantees (exclusive
+   lock/ownership acquired; public integrity path available). Otherwise fail
+   closed with `stateful_browser_store_unavailable` before guest execution.
+3. **No honor-system flag; no per-activation conformance certificate.**
+   Attestation is in-process verification of the bound open store.
+4. **Secret-free evidence.** Activation/telemetry evidence MUST NOT include
+   payloads, DB names, or host-private paths.
+5. **Keep follow-ons separate.** Private encryption (#1294), maintenance
+   parity (#1295), ABI extensions (#1287/#1288/#1290), and multi-role taxonomy
+   (#1291) remain out of scope.
+
+## Consequences
+
+- `traverse-contracts` must stop applying the FR-005 hard reject once Spec
+  `132` is approved and #1289 implements it.
+- Runtime Browser activation gains an IndexedDB attestation gate and a stable
+  error code.
+- Immutable `014`/`208` text is not edited in place; Spec `132` is the
+  successor for the superseded clauses only.
+- #1289 stays `needs-spec` until Spec `132` and this ADR are approved.
+
+## Alternatives Considered
+
+- **Keep the Browser ban** — rejected: Spec `085` would remain unavailable to
+  Stateful capabilities.
+- **Declare IndexedDB in each capability contract** — rejected: couples
+  portable contracts to one host backend.
+- **Embedder attestation flag only** — rejected: not runtime-verifiable.
+- **Require Spec `085` conformance evidence artifact on every activation** —
+  rejected: operationally too heavy for normal app start.
+- **Soft contract warning + hard activation fail** — rejected: warnings are
+  not a governed fail-closed boundary.
+
+## Approval evidence
+
+Pending maintainer approval of Spec `132-stateful-browser-placement` and
+acceptance of this ADR. Proposed artifacts and a merged PR without approval
+evidence do not count as approved.

--- a/docs/adr/0065-stateful-browser-placement.md
+++ b/docs/adr/0065-stateful-browser-placement.md
@@ -1,8 +1,8 @@
 # ADR-0065: Stateful Browser Placement via IndexedDB Host Attestation
 
-- Status: Proposed
+- Status: Accepted
 - Date: 2026-09-09
-- Governing spec: `132-stateful-browser-placement` (Proposed)
+- Governing spec: `132-stateful-browser-placement` (Approved)
 - Extends / supersedes placement rule in: `014-service-type-taxonomy` (`208`) FR-005
 - Depends on: `085-datastore-indexeddb`, `131-stateful-persistence-host-abi`
 - Related issues: #1305 (specification), #1289 (implementation)
@@ -63,6 +63,6 @@ opened #1305 as the governing vehicle.
 
 ## Approval evidence
 
-Pending maintainer approval of Spec `132-stateful-browser-placement` and
-acceptance of this ADR. Proposed artifacts and a merged PR without approval
-evidence do not count as approved.
+Maintainer approved Spec `132-stateful-browser-placement` and accepted this ADR
+on 2026-09-09 during the `/brainstorm` session that produced Decision 72/73
+(issue #1305, PR #1307). Registry entry added the same day.

--- a/docs/decision-log.md
+++ b/docs/decision-log.md
@@ -3192,3 +3192,36 @@ capability namespacing. v1 guest envelopes use relative keys only (resource ids
 inside values); an explicit `partition` parameter from Decision 68 remains a
 follow-up if multi-tenant key fan-out needs it at the ABI layer. Unblocks
 registry Wave 2 Stateful publishes.
+
+## Decision 72: Stateful Browser Placement — Contract Allow, Activation Attest (Spec 132)
+
+**Date**: 2026-09-09  
+**Issues**: #1305 (specification), #1289 (implementation)  
+**Governing artifacts**: Spec `132-stateful-browser-placement` (Proposed), ADR-0065 (Proposed)  
+**Related**: Decision 68 (deferred Browser placement); Specs `014`/`208`, `085`, `131`
+
+### Context
+
+Future tickets from Decision 68 included relaxing `Stateful` + `Browser` now
+that Spec `085` IndexedDB exists. A `/brainstorm` drained that cluster's first
+governing package.
+
+### Decisions (owner `/brainstorm`, recommended option each time)
+
+1. Prioritize the Stateful/Browser future cluster over Mode B MCP, #1150
+   children, or waiting only on the #1272 registry proof.
+2. Open #1289's governing package before taxonomy (#1291) or ABI extensions
+   (#1287/#1288/#1290).
+3. Allow Stateful+Browser at contract validation; enforce durable-store proof
+   only at activation (`stateful_browser_store_unavailable` on failure).
+4. Attestation = runtime-verifiable open Spec `085` IndexedDB DataStore (not
+   an embedder flag; not a per-activation conformance certificate).
+5. File dedicated specification issue #1305; keep #1289 as implementation with
+   `needs-spec` until approval.
+
+### Outcome
+
+#1305 is In Progress with Proposed Spec `132` + ADR-0065. #1289 carries
+`needs-spec`. Encryption (#1294), maintenance (#1295), ABI extensions, and
+#1291 remain `future`. Maintainer approval is required before registry entry,
+#1305 Done, and #1289 `spec-complete` / Ready.

--- a/docs/decision-log.md
+++ b/docs/decision-log.md
@@ -3221,7 +3221,34 @@ governing package.
 
 ### Outcome
 
-#1305 is In Progress with Proposed Spec `132` + ADR-0065. #1289 carries
-`needs-spec`. Encryption (#1294), maintenance (#1295), ABI extensions, and
-#1291 remain `future`. Maintainer approval is required before registry entry,
-#1305 Done, and #1289 `spec-complete` / Ready.
+#1305 owned Proposed Spec `132` + ADR-0065 on PR #1307. Decision 73 approved
+the package the same day; #1289 then moved to `spec-complete` / Ready.
+Encryption (#1294), maintenance (#1295), ABI extensions, and #1291 remain
+`future`.
+
+## Decision 73: Approve Spec 132 and ADR-0065 (Stateful Browser Placement)
+
+- **Date**: 2026-09-09
+- **Status**: Accepted
+- **Governing specs**: `132-stateful-browser-placement` (Proposed → Approved 0.1.0);
+  `014-service-type-taxonomy` (FR-005 superseded for placement only);
+  `085-datastore-indexeddb`; `131-stateful-persistence-host-abi`; `004-spec-alignment-gate`
+- **ADR**: `0065-stateful-browser-placement` (Proposed → Accepted)
+- **Related issues**: `#1305` (specification), `#1289` (implementation)
+- **Origin**: Maintainer `/brainstorm` approval (Option A) after Decision 72 locked the design and PR #1307 landed Proposed artifacts.
+
+### Context
+
+Decision 72 produced Proposed Spec `132` + ADR-0065. #1289 remained
+`needs-spec` until approval evidence existed.
+
+### Decision
+
+Approve Spec `132-stateful-browser-placement` v0.1.0 as written and accept
+ADR-0065. Register the immutable entry in `approved-specs.json`. Mark #1305
+Done and move #1289 to `spec-complete` / Ready for implementation.
+
+### Outcome
+
+Contract-time Stateful+Browser ban is superseded; activation attestation under
+Spec `085` is the governed fail-closed rule. Implementation proceeds on #1289.

--- a/specs/132-stateful-browser-placement/spec.md
+++ b/specs/132-stateful-browser-placement/spec.md
@@ -2,7 +2,7 @@
 
 **Feature Branch**: `codex/issue-1305-stateful-browser-placement`
 **Created**: 2026-09-09
-**Status**: Proposed
+**Status**: Approved (2026-09-09)
 **Canonical governing ID**: `132-stateful-browser-placement`
 **Version**: 0.1.0
 **Supersedes**: `014-service-type-taxonomy` / `208-service-type-taxonomy` **FR-005**, User Story 2, SC-002, and the assumption that Browser cannot provide managed persistence (only those placement rules; all other `014`/`208` requirements remain in force)
@@ -121,5 +121,5 @@ cargo test -p traverse-contracts
 cargo test -p traverse-runtime
 ```
 
-Approval of this Proposed spec requires maintainer sign-off and an
-`approved-specs.json` entry; merging a Draft/Proposed PR alone is not approval.
+Approved by maintainer decision on 2026-09-09 (brainstorm Option A on
+#1305 / PR #1307). Recorded in `specs/governance/approved-specs.json`.

--- a/specs/132-stateful-browser-placement/spec.md
+++ b/specs/132-stateful-browser-placement/spec.md
@@ -1,0 +1,125 @@
+# Feature Specification: Stateful Browser Placement via IndexedDB Attestation
+
+**Feature Branch**: `codex/issue-1305-stateful-browser-placement`
+**Created**: 2026-09-09
+**Status**: Proposed
+**Canonical governing ID**: `132-stateful-browser-placement`
+**Version**: 0.1.0
+**Supersedes**: `014-service-type-taxonomy` / `208-service-type-taxonomy` **FR-005**, User Story 2, SC-002, and the assumption that Browser cannot provide managed persistence (only those placement rules; all other `014`/`208` requirements remain in force)
+**Extends**: `085-datastore-indexeddb`, `131-stateful-persistence-host-abi`, `518-durable-local-datastore`, `519-embedder-owned-datastore-integration`
+**Input**: Issue #1305; product decisions recorded on #1289 (2026-09-09 `/brainstorm`); ADR-0065
+
+## Purpose
+
+Relax the contract-time ban on `service_type: Stateful` with `Browser` in
+`permitted_targets`, now that Spec `085` defines an IndexedDB DataStore backend
+with durable public integrity and exclusive ownership. Move the durable-store
+proof to **activation**, where the runtime can verify the bound store — not to
+the portable capability contract.
+
+## Capability Boundary
+
+| Concern | Owner |
+| --- | --- |
+| Contract validation of `service_type` + `permitted_targets` (accept Stateful+Browser) | This spec / `traverse-contracts` |
+| Activation-time proof that the bound DataStore is Spec `085` IndexedDB and open under its guarantees | This spec / runtime activation |
+| IndexedDB backend semantics (lock, integrity, public CRUD, fail-closed private) | Spec `085` |
+| `state_*` host ABI | Spec `131` |
+| Private-record encryption via browser KeyProvider | Out of scope (#1294) |
+| IndexedDB maintenance parity | Out of scope (#1295) |
+
+## User Scenarios & Testing
+
+### User Story 1 — Portable Stateful+Browser contract validates (Priority: P1)
+
+1. **Given** a capability contract with `service_type: Stateful` and
+   `permitted_targets` containing `Browser` (alone or with other targets),
+   **When** contract validation runs, **Then** it succeeds with respect to the
+   former FR-005 rule (no `InvalidPlacementConstraint` solely for
+   Stateful+Browser).
+
+### User Story 2 — Browser activation succeeds with qualifying IndexedDB store (Priority: P1)
+
+1. **Given** a Stateful capability permitted on Browser and a bound DataStore
+   that is the IndexedDB backend and has opened under Spec `085` (exclusive
+   ownership/lock acquired; public integrity path available),
+   **When** Browser activation runs, **Then** activation succeeds for the
+   durable-store check governed by this spec.
+
+### User Story 3 — Browser activation fails closed without attestation (Priority: P1)
+
+1. **Given** a Stateful capability permitted on Browser and any of: no bound
+   DataStore, a non-IndexedDB DataStore backend, or an IndexedDB store that did
+   not open under Spec `085` guarantees (missing exclusive lock / unavailable
+   persistence),
+   **When** Browser activation runs, **Then** activation fails closed with
+   stable code `stateful_browser_store_unavailable` and does not execute the
+   capability.
+
+### User Story 4 — Non-Browser Stateful activation unchanged (Priority: P1)
+
+1. **Given** a Stateful capability activating on Edge, Cloud, or Device with a
+   host store meeting Spec `131`'s guarantee floor,
+   **When** activation runs, **Then** this spec imposes no additional
+   IndexedDB attestation requirement.
+
+## Requirements
+
+- **FR-001**: Contract validation MUST NOT reject a capability solely because
+  `service_type` is `Stateful` and `permitted_targets` includes `Browser`.
+  This requirement supersedes `014`/`208` FR-005, User Story 2, and SC-002.
+- **FR-002**: For activation of a `Stateful` capability on `Browser`, the
+  runtime MUST require a bound DataStore that is the IndexedDB backend defined
+  by Spec `085` and that has opened under Spec `085` guarantees: exclusive
+  ownership/lock acquired and the public integrity path available.
+- **FR-003**: When FR-002 is not satisfied, Browser activation of a Stateful
+  capability MUST fail closed with stable error code
+  `stateful_browser_store_unavailable` before guest execution begins.
+- **FR-004**: Attestation MUST be runtime-verifiable from the bound open store
+  (backend identity + open guarantees). It MUST NOT be satisfied by an
+  embedder honor-system flag alone, and MUST NOT require a separate Spec `085`
+  conformance certificate artifact on every activation.
+- **FR-005**: Activation and telemetry evidence for this check MUST be
+  secret-free and MUST NOT include record payloads, IndexedDB database names,
+  or host-private filesystem/DOM paths.
+- **FR-006**: This spec MUST NOT change Spec `131` import signatures, Spec
+  `085` backend behavior, or non-Browser Stateful activation rules.
+
+## Success Criteria
+
+- **SC-001**: Automated contract tests accept Stateful+Browser contracts that
+  previously failed FR-005.
+- **SC-002**: Browser activation conformance covers success with a qualifying
+  open IndexedDB store and fail-closed outcomes for missing, non-IndexedDB,
+  and non-qualifying open failures, asserting
+  `stateful_browser_store_unavailable`.
+- **SC-003**: Evidence fixtures for those paths contain no payloads, DB names,
+  or host-private paths.
+
+## Assumptions
+
+- Spec `085` remains the definition of a qualifying browser durable store for
+  this placement rule.
+- Private DataStore classification on IndexedDB remains fail-closed until #1294;
+  FR-002 only requires the public integrity path to be available.
+- Capability contracts stay backend-agnostic; hosts choose and prove storage.
+
+## Out of Scope
+
+- Runtime/contracts implementation (tracked by #1289).
+- `#1294` private encryption, `#1295` maintenance parity.
+- `#1287` / `#1288` / `#1290` Stateful ABI extensions.
+- `#1291` multi-role service_type taxonomy.
+- Editing the immutable text of `014`/`208` in place (successor supersession
+  only).
+
+## Validation
+
+```bash
+# After implementation of #1289 (not required to approve this Proposed spec):
+cargo test -p traverse-contracts
+cargo test -p traverse-runtime
+```
+
+Approval of this Proposed spec requires maintainer sign-off and an
+`approved-specs.json` entry; merging a Draft/Proposed PR alone is not approval.

--- a/specs/governance/approved-specs.json
+++ b/specs/governance/approved-specs.json
@@ -1795,6 +1795,20 @@
         "specs/131-stateful-persistence-host-abi/",
         "docs/adr/0063-stateful-persistence-host-abi.md"
       ]
+    },
+    {
+      "id": "132-stateful-browser-placement",
+      "version": "0.1.0",
+      "status": "approved",
+      "immutable": true,
+      "path": "specs/132-stateful-browser-placement/spec.md",
+      "governs": [
+        "crates/traverse-contracts/",
+        "crates/traverse-runtime/",
+        "packages/web/TraverseEmbedder/",
+        "specs/132-stateful-browser-placement/",
+        "docs/adr/0065-stateful-browser-placement.md"
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Approve Spec `132-stateful-browser-placement` v0.1.0 and accept ADR-0065: Stateful+Browser allowed at contract validation; durable proof at activation via Spec `085` IndexedDB attestation (`stateful_browser_store_unavailable`).
- Register the immutable entry in `approved-specs.json` and record Decisions 72–73.
- Unblocks implementation #1289 (`spec-complete` / Ready after merge).

## Governing Spec
- `132-stateful-browser-placement`
- `014-service-type-taxonomy`
- `085-datastore-indexeddb`
- `131-stateful-persistence-host-abi`
- `004-spec-alignment-gate`
- `023-browser-hosted-mcp-consumer-model`
- `065-sigstore-bundle-verification`
- `070-runtime-event-sink-boundary`
- `100-capability-package-authoring`
- `101-local-executor-event-emission`
- `102-contract-surface-coverage`
- `108-governed-runtime-workflow-composition`
- `120-host-owned-artifact-preparation`

## Project Item
- #1305 (specification — Done after merge)
- #1289 (implementation — `spec-complete` / Ready after merge)

## Validation
- [x] Spec 132 + ADR-0065 match #1289 decision records
- [x] `approved-specs.json` includes `132-stateful-browser-placement`
- [x] `BASE_SHA=origin/main bash scripts/ci/spec_alignment_check.sh` (local)
- [x] `bash scripts/ci/pr_body_check.sh`
- [ ] CI green on PR #1307

Tracking #1305. Closes #1305 on merge.