### PR TITLE
feat: Stateful Browser placement via IndexedDB attestation (#1289)

### DIFF
--- a/crates/traverse-contracts/src/lib.rs
+++ b/crates/traverse-contracts/src/lib.rs
@@ -990,7 +990,8 @@ pub enum ValidationErrorCode {
     PortabilityExceptionRequired,
     ImmutableVersionConflict,
     InvalidDependencyRef,
-    /// `service_type: stateful` combined with `Browser` in `permitted_targets`.
+    /// Reserved for placement-constraint violations other than Stateful+Browser
+    /// (Stateful+Browser is allowed under Spec `132-stateful-browser-placement`).
     InvalidPlacementConstraint,
     /// `service_type: subscribable` without a non-empty `event_trigger`.
     MissingEventTrigger,
@@ -1827,20 +1828,9 @@ fn validate_placement_constraints(
     contract: &CapabilityContract,
     errors: &mut Vec<ValidationError>,
 ) {
-    if contract.service_type == ServiceType::Stateful
-        && contract
-            .permitted_targets
-            .contains(&ExecutionTarget::Browser)
-    {
-        errors.push(ValidationError {
-            code: ValidationErrorCode::InvalidPlacementConstraint,
-            message: "Stateful capabilities cannot target Browser environments; browsers cannot \
-                      provide managed persistence guarantees."
-                .to_string(),
-            path: "$.permitted_targets".to_string(),
-            severity: ErrorSeverity::Error,
-        });
-    }
+    // Spec `132-stateful-browser-placement` FR-001 supersedes `014`/`208` FR-005:
+    // Stateful + Browser is valid at contract time; durable-store proof is an
+    // activation concern (`stateful_browser_store_unavailable`).
     if contract.service_type == ServiceType::Stateful {
         let properties_empty = contract
             .state_schema

--- a/crates/traverse-contracts/tests/validation.rs
+++ b/crates/traverse-contracts/tests/validation.rs
@@ -1087,7 +1087,7 @@ fn validate_manifest_risk_policy_rejects_any_egress_when_contract_denies_all() -
 }
 
 #[test]
-fn stateful_with_browser_target_is_rejected() -> Result<(), String> {
+fn stateful_with_browser_target_is_accepted() -> Result<(), String> {
     let mut contract = valid_contract();
     contract.service_type = ServiceType::Stateful;
     contract.state_schema = Some(serde_json::json!({
@@ -1098,19 +1098,22 @@ fn stateful_with_browser_target_is_rejected() -> Result<(), String> {
     }));
     contract.permitted_targets = vec![ExecutionTarget::Browser, ExecutionTarget::Cloud];
 
-    let failure = expect_validation_failure(validate_contract(
+    let result = validate_contract(
         contract,
         &ValidationContext {
             governing_spec: GOVERNING_SPEC,
             validator_version: VALIDATOR_VERSION,
             existing_published: None,
         },
-    ))?;
+    )
+    .map_err(|failure| format!("expected Stateful+Browser to validate: {failure:?}"))?;
 
-    let codes: Vec<_> = failure.errors.iter().map(|e| &e.code).collect();
+    assert_eq!(result.evidence.status, EvidenceStatus::Passed);
     assert!(
-        codes.contains(&&ValidationErrorCode::InvalidPlacementConstraint),
-        "expected InvalidPlacementConstraint, got {codes:?}"
+        result
+            .normalized
+            .permitted_targets
+            .contains(&ExecutionTarget::Browser)
     );
     Ok(())
 }

--- a/crates/traverse-runtime/src/lib.rs
+++ b/crates/traverse-runtime/src/lib.rs
@@ -19,6 +19,8 @@ pub mod placement;
 pub mod proposal;
 pub mod router;
 pub mod security;
+/// Spec `132` Stateful Browser activation attestation.
+pub mod stateful_browser;
 pub mod trace;
 
 use chrono::Utc;

--- a/crates/traverse-runtime/src/placement/mod.rs
+++ b/crates/traverse-runtime/src/placement/mod.rs
@@ -4,12 +4,12 @@
 //!
 //! Applies three tiers in order:
 //! 1. Caller hint — accept if provided and in permitted targets
-//! 2. Contract constraints — filter by permitted targets and service-type rules
+//! 2. Contract constraints — filter by permitted targets
 //! 3. Heuristics — select lowest-load eligible target from runtime snapshot
 
 use std::collections::HashMap;
 
-use traverse_contracts::{CapabilityContract, ExecutionTarget, ServiceType};
+use traverse_contracts::{CapabilityContract, ExecutionTarget};
 
 /// A snapshot of runtime target load at a point in time.
 pub struct RuntimeSnapshot {
@@ -93,16 +93,9 @@ impl PlacementConstraintEvaluator {
         }
 
         // --- Tier 2: Contract constraints ---
-        // Start from the contract's permitted targets, then enforce service-type rules.
-        let mut eligible: Vec<ExecutionTarget> = contract
-            .permitted_targets
-            .iter()
-            .filter(|t| {
-                // Stateful services cannot run in Browser.
-                !(contract.service_type == ServiceType::Stateful && **t == ExecutionTarget::Browser)
-            })
-            .cloned()
-            .collect();
+        // Start from the contract's permitted targets. Spec `132` allows
+        // Stateful+Browser here; IndexedDB attestation is an activation gate.
+        let mut eligible: Vec<ExecutionTarget> = contract.permitted_targets.clone();
 
         // --- Tier 3: Heuristics ---
         // Remove overloaded targets (load > 0.9).

--- a/crates/traverse-runtime/src/stateful_browser.rs
+++ b/crates/traverse-runtime/src/stateful_browser.rs
@@ -28,9 +28,9 @@ pub struct IndexedDbOpenAttestation {
 /// Bound store presented for Browser Stateful activation.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum StatefulBrowserBoundStore {
-    /// No DataStore is bound to the activation.
+    /// No `DataStore` is bound to the activation.
     Missing,
-    /// A non-`IndexedDB` DataStore backend is bound.
+    /// A non-`IndexedDB` `DataStore` backend is bound.
     NonIndexedDb,
     /// `IndexedDB` backend with open-guarantee facts.
     IndexedDb(IndexedDbOpenAttestation),
@@ -241,5 +241,41 @@ mod tests {
             assert!(!text.contains("/var/"));
             assert!(!text.contains("indexeddb://"));
         }
+    }
+
+    #[test]
+    fn public_types_round_trip_debug_clone_and_equality() {
+        let facts = IndexedDbOpenAttestation {
+            exclusive_lock_held: true,
+            public_integrity_available: true,
+        };
+        let copied = facts;
+        assert_eq!(facts, copied);
+        assert_eq!(
+            StatefulBrowserBoundStore::IndexedDb(facts),
+            StatefulBrowserBoundStore::IndexedDb(copied)
+        );
+        assert_ne!(
+            StatefulBrowserBoundStore::Missing,
+            StatefulBrowserBoundStore::NonIndexedDb
+        );
+
+        let evidence = StatefulBrowserActivationEvidence {
+            governing_spec: "132-stateful-browser-placement",
+            backend: "indexeddb",
+            exclusive_lock_held: true,
+            public_integrity_available: true,
+            outcome: "attested",
+        };
+        let cloned = evidence.clone();
+        assert_eq!(evidence, cloned);
+        assert!(format!("{evidence:?}").contains("attested"));
+        assert!(to_value(&evidence).is_ok());
+
+        let error = activation_error("missing_bound_store");
+        let cloned_error = error.clone();
+        assert_eq!(error, cloned_error);
+        assert!(format!("{error:?}").contains(STATEFUL_BROWSER_STORE_UNAVAILABLE));
+        assert!(to_value(&error).is_ok());
     }
 }

--- a/crates/traverse-runtime/src/stateful_browser.rs
+++ b/crates/traverse-runtime/src/stateful_browser.rs
@@ -4,6 +4,8 @@
 //! execution on Browser, the host must prove a Spec `085` IndexedDB DataStore
 //! is bound and open under its exclusive-lock and public-integrity guarantees.
 //! Failures use the stable code `stateful_browser_store_unavailable`.
+//!
+//! Spec `132` activation attestation.
 
 use serde::Serialize;
 use traverse_contracts::{ExecutionTarget, ServiceType};

--- a/crates/traverse-runtime/src/stateful_browser.rs
+++ b/crates/traverse-runtime/src/stateful_browser.rs
@@ -7,7 +7,7 @@
 //!
 //! Spec `132` activation attestation.
 
-use serde::Serialize;
+use serde_json::{Value, json};
 use traverse_contracts::{ExecutionTarget, ServiceType};
 
 /// Stable activation failure code (Spec 132 FR-003).
@@ -37,7 +37,7 @@ pub enum StatefulBrowserBoundStore {
 }
 
 /// Secret-free evidence for a successful Spec 132 activation check (FR-005).
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct StatefulBrowserActivationEvidence {
     pub governing_spec: &'static str,
     pub backend: &'static str,
@@ -47,12 +47,39 @@ pub struct StatefulBrowserActivationEvidence {
 }
 
 /// Fail-closed activation error (Spec 132 FR-003/FR-005).
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct StatefulBrowserActivationError {
     pub code: &'static str,
     pub governing_spec: &'static str,
     pub outcome: &'static str,
     pub reason: &'static str,
+}
+
+impl StatefulBrowserActivationEvidence {
+    /// Secret-free JSON projection (Spec 132 FR-005).
+    #[must_use]
+    pub fn to_secret_free_json(&self) -> Value {
+        json!({
+            "governing_spec": self.governing_spec,
+            "backend": self.backend,
+            "exclusive_lock_held": self.exclusive_lock_held,
+            "public_integrity_available": self.public_integrity_available,
+            "outcome": self.outcome,
+        })
+    }
+}
+
+impl StatefulBrowserActivationError {
+    /// Secret-free JSON projection (Spec 132 FR-005).
+    #[must_use]
+    pub fn to_secret_free_json(&self) -> Value {
+        json!({
+            "code": self.code,
+            "governing_spec": self.governing_spec,
+            "outcome": self.outcome,
+            "reason": self.reason,
+        })
+    }
 }
 
 /// Attests Browser activation of a Stateful capability against a bound store.
@@ -109,7 +136,6 @@ fn activation_error(reason: &'static str) -> StatefulBrowserActivationError {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use serde_json::to_value;
 
     fn qualifying() -> StatefulBrowserBoundStore {
         StatefulBrowserBoundStore::IndexedDb(IndexedDbOpenAttestation {
@@ -118,148 +144,36 @@ mod tests {
         })
     }
 
+    fn denied(reason: &'static str) -> StatefulBrowserActivationError {
+        activation_error(reason)
+    }
+
     #[test]
     fn non_browser_stateful_is_unchanged() {
-        let result = attest_stateful_browser_activation(
-            &ServiceType::Stateful,
-            &ExecutionTarget::Local,
-            StatefulBrowserBoundStore::Missing,
+        assert_eq!(
+            attest_stateful_browser_activation(
+                &ServiceType::Stateful,
+                &ExecutionTarget::Local,
+                StatefulBrowserBoundStore::Missing,
+            ),
+            Ok(None)
         );
-        assert_eq!(result, Ok(None));
     }
 
     #[test]
     fn non_stateful_browser_is_unchanged() {
-        let result = attest_stateful_browser_activation(
-            &ServiceType::Stateless,
-            &ExecutionTarget::Browser,
-            StatefulBrowserBoundStore::Missing,
+        assert_eq!(
+            attest_stateful_browser_activation(
+                &ServiceType::Stateless,
+                &ExecutionTarget::Browser,
+                StatefulBrowserBoundStore::Missing,
+            ),
+            Ok(None)
         );
-        assert_eq!(result, Ok(None));
     }
 
     #[test]
     fn qualifying_indexeddb_attests() {
-        let result = attest_stateful_browser_activation(
-            &ServiceType::Stateful,
-            &ExecutionTarget::Browser,
-            qualifying(),
-        );
-        assert!(matches!(
-            result,
-            Ok(Some(StatefulBrowserActivationEvidence {
-                backend: "indexeddb",
-                outcome: "attested",
-                exclusive_lock_held: true,
-                public_integrity_available: true,
-                ..
-            }))
-        ));
-        if let Ok(Some(evidence)) = result {
-            let serialized = to_value(&evidence);
-            assert!(serialized.is_ok());
-            if let Ok(value) = serialized {
-                let text = value.to_string();
-                assert!(!text.contains("database"));
-                assert!(!text.contains('/'));
-                assert!(!text.contains("payload"));
-            }
-        }
-    }
-
-    #[test]
-    fn missing_store_fails_closed() {
-        let result = attest_stateful_browser_activation(
-            &ServiceType::Stateful,
-            &ExecutionTarget::Browser,
-            StatefulBrowserBoundStore::Missing,
-        );
-        assert!(result.is_err());
-        if let Err(error) = result {
-            assert_eq!(error.code, STATEFUL_BROWSER_STORE_UNAVAILABLE);
-            assert_eq!(error.reason, "missing_bound_store");
-        }
-    }
-
-    #[test]
-    fn non_indexeddb_fails_closed() {
-        let result = attest_stateful_browser_activation(
-            &ServiceType::Stateful,
-            &ExecutionTarget::Browser,
-            StatefulBrowserBoundStore::NonIndexedDb,
-        );
-        assert!(result.is_err());
-        if let Err(error) = result {
-            assert_eq!(error.code, STATEFUL_BROWSER_STORE_UNAVAILABLE);
-            assert_eq!(error.reason, "non_indexeddb_backend");
-        }
-    }
-
-    #[test]
-    fn open_without_lock_fails_closed() {
-        let result = attest_stateful_browser_activation(
-            &ServiceType::Stateful,
-            &ExecutionTarget::Browser,
-            StatefulBrowserBoundStore::IndexedDb(IndexedDbOpenAttestation {
-                exclusive_lock_held: false,
-                public_integrity_available: true,
-            }),
-        );
-        assert!(result.is_err());
-        if let Err(error) = result {
-            assert_eq!(error.code, STATEFUL_BROWSER_STORE_UNAVAILABLE);
-            assert_eq!(error.reason, "exclusive_lock_not_held");
-        }
-    }
-
-    #[test]
-    fn open_without_public_integrity_fails_closed() {
-        let result = attest_stateful_browser_activation(
-            &ServiceType::Stateful,
-            &ExecutionTarget::Browser,
-            StatefulBrowserBoundStore::IndexedDb(IndexedDbOpenAttestation {
-                exclusive_lock_held: true,
-                public_integrity_available: false,
-            }),
-        );
-        assert!(result.is_err());
-        if let Err(error) = result {
-            assert_eq!(error.code, STATEFUL_BROWSER_STORE_UNAVAILABLE);
-            assert_eq!(error.reason, "public_integrity_unavailable");
-        }
-    }
-
-    #[test]
-    fn denial_evidence_is_secret_free() {
-        let error = activation_error("missing_bound_store");
-        let serialized = to_value(&error);
-        assert!(serialized.is_ok());
-        if let Ok(value) = serialized {
-            let text = value.to_string();
-            assert!(!text.contains("payload"));
-            assert!(!text.contains("databaseName"));
-            assert!(!text.contains("/var/"));
-            assert!(!text.contains("indexeddb://"));
-        }
-    }
-
-    #[test]
-    fn public_types_round_trip_debug_clone_and_equality() {
-        let facts = IndexedDbOpenAttestation {
-            exclusive_lock_held: true,
-            public_integrity_available: true,
-        };
-        let copied = facts;
-        assert_eq!(facts, copied);
-        assert_eq!(
-            StatefulBrowserBoundStore::IndexedDb(facts),
-            StatefulBrowserBoundStore::IndexedDb(copied)
-        );
-        assert_ne!(
-            StatefulBrowserBoundStore::Missing,
-            StatefulBrowserBoundStore::NonIndexedDb
-        );
-
         let evidence = StatefulBrowserActivationEvidence {
             governing_spec: "132-stateful-browser-placement",
             backend: "indexeddb",
@@ -267,15 +181,97 @@ mod tests {
             public_integrity_available: true,
             outcome: "attested",
         };
-        let cloned = evidence.clone();
-        assert_eq!(evidence, cloned);
+        assert_eq!(
+            attest_stateful_browser_activation(
+                &ServiceType::Stateful,
+                &ExecutionTarget::Browser,
+                qualifying(),
+            ),
+            Ok(Some(evidence.clone()))
+        );
+        let text = evidence.to_secret_free_json().to_string();
+        assert!(!text.contains("database"));
+        assert!(!text.contains('/'));
+        assert!(!text.contains("payload"));
         assert!(format!("{evidence:?}").contains("attested"));
-        assert!(to_value(&evidence).is_ok());
+    }
 
-        let error = activation_error("missing_bound_store");
-        let cloned_error = error.clone();
-        assert_eq!(error, cloned_error);
+    #[test]
+    fn missing_store_fails_closed() {
+        assert_eq!(
+            attest_stateful_browser_activation(
+                &ServiceType::Stateful,
+                &ExecutionTarget::Browser,
+                StatefulBrowserBoundStore::Missing,
+            ),
+            Err(denied("missing_bound_store"))
+        );
+    }
+
+    #[test]
+    fn non_indexeddb_fails_closed() {
+        assert_eq!(
+            attest_stateful_browser_activation(
+                &ServiceType::Stateful,
+                &ExecutionTarget::Browser,
+                StatefulBrowserBoundStore::NonIndexedDb,
+            ),
+            Err(denied("non_indexeddb_backend"))
+        );
+    }
+
+    #[test]
+    fn open_without_lock_fails_closed() {
+        assert_eq!(
+            attest_stateful_browser_activation(
+                &ServiceType::Stateful,
+                &ExecutionTarget::Browser,
+                StatefulBrowserBoundStore::IndexedDb(IndexedDbOpenAttestation {
+                    exclusive_lock_held: false,
+                    public_integrity_available: true,
+                }),
+            ),
+            Err(denied("exclusive_lock_not_held"))
+        );
+    }
+
+    #[test]
+    fn open_without_public_integrity_fails_closed() {
+        assert_eq!(
+            attest_stateful_browser_activation(
+                &ServiceType::Stateful,
+                &ExecutionTarget::Browser,
+                StatefulBrowserBoundStore::IndexedDb(IndexedDbOpenAttestation {
+                    exclusive_lock_held: true,
+                    public_integrity_available: false,
+                }),
+            ),
+            Err(denied("public_integrity_unavailable"))
+        );
+    }
+
+    #[test]
+    fn denial_evidence_is_secret_free() {
+        let error = denied("missing_bound_store");
+        let text = error.to_secret_free_json().to_string();
+        assert!(!text.contains("payload"));
+        assert!(!text.contains("databaseName"));
+        assert!(!text.contains("/var/"));
+        assert!(!text.contains("indexeddb://"));
+        assert_eq!(error, error.clone());
         assert!(format!("{error:?}").contains(STATEFUL_BROWSER_STORE_UNAVAILABLE));
-        assert!(to_value(&error).is_ok());
+        assert_ne!(
+            StatefulBrowserBoundStore::Missing,
+            StatefulBrowserBoundStore::NonIndexedDb
+        );
+        let facts = IndexedDbOpenAttestation {
+            exclusive_lock_held: true,
+            public_integrity_available: true,
+        };
+        assert_eq!(facts, facts);
+        assert_eq!(
+            StatefulBrowserBoundStore::IndexedDb(facts),
+            StatefulBrowserBoundStore::IndexedDb(facts)
+        );
     }
 }

--- a/crates/traverse-runtime/src/stateful_browser.rs
+++ b/crates/traverse-runtime/src/stateful_browser.rs
@@ -1,0 +1,220 @@
+//! Stateful Browser activation attestation (Spec `132-stateful-browser-placement`).
+//!
+//! Contract validation may permit `Stateful` + `Browser`. Before guest
+//! execution on Browser, the host must prove a Spec `085` IndexedDB DataStore
+//! is bound and open under its exclusive-lock and public-integrity guarantees.
+//! Failures use the stable code `stateful_browser_store_unavailable`.
+
+use serde::Serialize;
+use traverse_contracts::{ExecutionTarget, ServiceType};
+
+/// Stable activation failure code (Spec 132 FR-003).
+pub const STATEFUL_BROWSER_STORE_UNAVAILABLE: &str = "stateful_browser_store_unavailable";
+
+/// Runtime-verifiable facts about a bound open store (Spec 132 FR-004).
+///
+/// Callers MUST derive these from the live store handle. An embedder honor
+/// flag alone is not attestation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct IndexedDbOpenAttestation {
+    /// Exclusive Web Lock / ownership acquired for this open handle.
+    pub exclusive_lock_held: bool,
+    /// Public integrity envelope path is available on this open handle.
+    pub public_integrity_available: bool,
+}
+
+/// Bound store presented for Browser Stateful activation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StatefulBrowserBoundStore {
+    /// No DataStore is bound to the activation.
+    Missing,
+    /// A non-IndexedDB DataStore backend is bound.
+    NonIndexedDb,
+    /// IndexedDB backend with open-guarantee facts.
+    IndexedDb(IndexedDbOpenAttestation),
+}
+
+/// Secret-free evidence for a successful Spec 132 activation check (FR-005).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct StatefulBrowserActivationEvidence {
+    pub governing_spec: &'static str,
+    pub backend: &'static str,
+    pub exclusive_lock_held: bool,
+    pub public_integrity_available: bool,
+    pub outcome: &'static str,
+}
+
+/// Fail-closed activation error (Spec 132 FR-003/FR-005).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct StatefulBrowserActivationError {
+    pub code: &'static str,
+    pub governing_spec: &'static str,
+    pub outcome: &'static str,
+    pub reason: &'static str,
+}
+
+/// Attests Browser activation of a Stateful capability against a bound store.
+///
+/// Non-Browser targets and non-Stateful service types are no-ops (Spec 132
+/// FR-006 / User Story 4).
+///
+/// # Errors
+///
+/// Returns [`StatefulBrowserActivationError`] with
+/// [`STATEFUL_BROWSER_STORE_UNAVAILABLE`] when Browser Stateful activation
+/// lacks a qualifying open IndexedDB store.
+pub fn attest_stateful_browser_activation(
+    service_type: &ServiceType,
+    target: &ExecutionTarget,
+    bound_store: StatefulBrowserBoundStore,
+) -> Result<Option<StatefulBrowserActivationEvidence>, StatefulBrowserActivationError> {
+    if *service_type != ServiceType::Stateful || *target != ExecutionTarget::Browser {
+        return Ok(None);
+    }
+
+    match bound_store {
+        StatefulBrowserBoundStore::IndexedDb(facts)
+            if facts.exclusive_lock_held && facts.public_integrity_available =>
+        {
+            Ok(Some(StatefulBrowserActivationEvidence {
+                governing_spec: "132-stateful-browser-placement",
+                backend: "indexeddb",
+                exclusive_lock_held: true,
+                public_integrity_available: true,
+                outcome: "attested",
+            }))
+        }
+        StatefulBrowserBoundStore::Missing => Err(activation_error("missing_bound_store")),
+        StatefulBrowserBoundStore::NonIndexedDb => Err(activation_error("non_indexeddb_backend")),
+        StatefulBrowserBoundStore::IndexedDb(facts) if !facts.exclusive_lock_held => {
+            Err(activation_error("exclusive_lock_not_held"))
+        }
+        StatefulBrowserBoundStore::IndexedDb(_) => {
+            Err(activation_error("public_integrity_unavailable"))
+        }
+    }
+}
+
+fn activation_error(reason: &'static str) -> StatefulBrowserActivationError {
+    StatefulBrowserActivationError {
+        code: STATEFUL_BROWSER_STORE_UNAVAILABLE,
+        governing_spec: "132-stateful-browser-placement",
+        outcome: "denied",
+        reason,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::to_value;
+
+    fn qualifying() -> StatefulBrowserBoundStore {
+        StatefulBrowserBoundStore::IndexedDb(IndexedDbOpenAttestation {
+            exclusive_lock_held: true,
+            public_integrity_available: true,
+        })
+    }
+
+    #[test]
+    fn non_browser_stateful_is_unchanged() {
+        let result = attest_stateful_browser_activation(
+            &ServiceType::Stateful,
+            &ExecutionTarget::Local,
+            StatefulBrowserBoundStore::Missing,
+        );
+        assert_eq!(result, Ok(None));
+    }
+
+    #[test]
+    fn non_stateful_browser_is_unchanged() {
+        let result = attest_stateful_browser_activation(
+            &ServiceType::Stateless,
+            &ExecutionTarget::Browser,
+            StatefulBrowserBoundStore::Missing,
+        );
+        assert_eq!(result, Ok(None));
+    }
+
+    #[test]
+    fn qualifying_indexeddb_attests() {
+        let evidence = attest_stateful_browser_activation(
+            &ServiceType::Stateful,
+            &ExecutionTarget::Browser,
+            qualifying(),
+        )
+        .expect("qualifying store must attest")
+        .expect("evidence required");
+        assert_eq!(evidence.backend, "indexeddb");
+        assert_eq!(evidence.outcome, "attested");
+        let value = to_value(&evidence).expect("serialize");
+        let text = value.to_string();
+        assert!(!text.contains("database"));
+        assert!(!text.contains('/'));
+        assert!(!text.contains("payload"));
+    }
+
+    #[test]
+    fn missing_store_fails_closed() {
+        let error = attest_stateful_browser_activation(
+            &ServiceType::Stateful,
+            &ExecutionTarget::Browser,
+            StatefulBrowserBoundStore::Missing,
+        )
+        .expect_err("missing store must fail");
+        assert_eq!(error.code, STATEFUL_BROWSER_STORE_UNAVAILABLE);
+        assert_eq!(error.reason, "missing_bound_store");
+    }
+
+    #[test]
+    fn non_indexeddb_fails_closed() {
+        let error = attest_stateful_browser_activation(
+            &ServiceType::Stateful,
+            &ExecutionTarget::Browser,
+            StatefulBrowserBoundStore::NonIndexedDb,
+        )
+        .expect_err("non-indexeddb must fail");
+        assert_eq!(error.code, STATEFUL_BROWSER_STORE_UNAVAILABLE);
+        assert_eq!(error.reason, "non_indexeddb_backend");
+    }
+
+    #[test]
+    fn open_without_lock_fails_closed() {
+        let error = attest_stateful_browser_activation(
+            &ServiceType::Stateful,
+            &ExecutionTarget::Browser,
+            StatefulBrowserBoundStore::IndexedDb(IndexedDbOpenAttestation {
+                exclusive_lock_held: false,
+                public_integrity_available: true,
+            }),
+        )
+        .expect_err("lock required");
+        assert_eq!(error.code, STATEFUL_BROWSER_STORE_UNAVAILABLE);
+        assert_eq!(error.reason, "exclusive_lock_not_held");
+    }
+
+    #[test]
+    fn open_without_public_integrity_fails_closed() {
+        let error = attest_stateful_browser_activation(
+            &ServiceType::Stateful,
+            &ExecutionTarget::Browser,
+            StatefulBrowserBoundStore::IndexedDb(IndexedDbOpenAttestation {
+                exclusive_lock_held: true,
+                public_integrity_available: false,
+            }),
+        )
+        .expect_err("public integrity required");
+        assert_eq!(error.code, STATEFUL_BROWSER_STORE_UNAVAILABLE);
+        assert_eq!(error.reason, "public_integrity_unavailable");
+    }
+
+    #[test]
+    fn denial_evidence_is_secret_free() {
+        let error = activation_error("missing_bound_store");
+        let text = to_value(&error).expect("serialize").to_string();
+        assert!(!text.contains("payload"));
+        assert!(!text.contains("databaseName"));
+        assert!(!text.contains("/var/"));
+        assert!(!text.contains("indexeddb://"));
+    }
+}

--- a/crates/traverse-runtime/src/stateful_browser.rs
+++ b/crates/traverse-runtime/src/stateful_browser.rs
@@ -1,7 +1,7 @@
 //! Stateful Browser activation attestation (Spec `132-stateful-browser-placement`).
 //!
 //! Contract validation may permit `Stateful` + `Browser`. Before guest
-//! execution on Browser, the host must prove a Spec `085` IndexedDB DataStore
+//! execution on Browser, the host must prove a Spec `085` `IndexedDB` DataStore
 //! is bound and open under its exclusive-lock and public-integrity guarantees.
 //! Failures use the stable code `stateful_browser_store_unavailable`.
 //!
@@ -30,9 +30,9 @@ pub struct IndexedDbOpenAttestation {
 pub enum StatefulBrowserBoundStore {
     /// No DataStore is bound to the activation.
     Missing,
-    /// A non-IndexedDB DataStore backend is bound.
+    /// A non-`IndexedDB` DataStore backend is bound.
     NonIndexedDb,
-    /// IndexedDB backend with open-guarantee facts.
+    /// `IndexedDB` backend with open-guarantee facts.
     IndexedDb(IndexedDbOpenAttestation),
 }
 
@@ -64,7 +64,7 @@ pub struct StatefulBrowserActivationError {
 ///
 /// Returns [`StatefulBrowserActivationError`] with
 /// [`STATEFUL_BROWSER_STORE_UNAVAILABLE`] when Browser Stateful activation
-/// lacks a qualifying open IndexedDB store.
+/// lacks a qualifying open `IndexedDB` store.
 pub fn attest_stateful_browser_activation(
     service_type: &ServiceType,
     target: &ExecutionTarget,
@@ -140,83 +140,106 @@ mod tests {
 
     #[test]
     fn qualifying_indexeddb_attests() {
-        let evidence = attest_stateful_browser_activation(
+        let result = attest_stateful_browser_activation(
             &ServiceType::Stateful,
             &ExecutionTarget::Browser,
             qualifying(),
-        )
-        .expect("qualifying store must attest")
-        .expect("evidence required");
-        assert_eq!(evidence.backend, "indexeddb");
-        assert_eq!(evidence.outcome, "attested");
-        let value = to_value(&evidence).expect("serialize");
-        let text = value.to_string();
-        assert!(!text.contains("database"));
-        assert!(!text.contains('/'));
-        assert!(!text.contains("payload"));
+        );
+        assert!(matches!(
+            result,
+            Ok(Some(StatefulBrowserActivationEvidence {
+                backend: "indexeddb",
+                outcome: "attested",
+                exclusive_lock_held: true,
+                public_integrity_available: true,
+                ..
+            }))
+        ));
+        if let Ok(Some(evidence)) = result {
+            let serialized = to_value(&evidence);
+            assert!(serialized.is_ok());
+            if let Ok(value) = serialized {
+                let text = value.to_string();
+                assert!(!text.contains("database"));
+                assert!(!text.contains('/'));
+                assert!(!text.contains("payload"));
+            }
+        }
     }
 
     #[test]
     fn missing_store_fails_closed() {
-        let error = attest_stateful_browser_activation(
+        let result = attest_stateful_browser_activation(
             &ServiceType::Stateful,
             &ExecutionTarget::Browser,
             StatefulBrowserBoundStore::Missing,
-        )
-        .expect_err("missing store must fail");
-        assert_eq!(error.code, STATEFUL_BROWSER_STORE_UNAVAILABLE);
-        assert_eq!(error.reason, "missing_bound_store");
+        );
+        assert!(result.is_err());
+        if let Err(error) = result {
+            assert_eq!(error.code, STATEFUL_BROWSER_STORE_UNAVAILABLE);
+            assert_eq!(error.reason, "missing_bound_store");
+        }
     }
 
     #[test]
     fn non_indexeddb_fails_closed() {
-        let error = attest_stateful_browser_activation(
+        let result = attest_stateful_browser_activation(
             &ServiceType::Stateful,
             &ExecutionTarget::Browser,
             StatefulBrowserBoundStore::NonIndexedDb,
-        )
-        .expect_err("non-indexeddb must fail");
-        assert_eq!(error.code, STATEFUL_BROWSER_STORE_UNAVAILABLE);
-        assert_eq!(error.reason, "non_indexeddb_backend");
+        );
+        assert!(result.is_err());
+        if let Err(error) = result {
+            assert_eq!(error.code, STATEFUL_BROWSER_STORE_UNAVAILABLE);
+            assert_eq!(error.reason, "non_indexeddb_backend");
+        }
     }
 
     #[test]
     fn open_without_lock_fails_closed() {
-        let error = attest_stateful_browser_activation(
+        let result = attest_stateful_browser_activation(
             &ServiceType::Stateful,
             &ExecutionTarget::Browser,
             StatefulBrowserBoundStore::IndexedDb(IndexedDbOpenAttestation {
                 exclusive_lock_held: false,
                 public_integrity_available: true,
             }),
-        )
-        .expect_err("lock required");
-        assert_eq!(error.code, STATEFUL_BROWSER_STORE_UNAVAILABLE);
-        assert_eq!(error.reason, "exclusive_lock_not_held");
+        );
+        assert!(result.is_err());
+        if let Err(error) = result {
+            assert_eq!(error.code, STATEFUL_BROWSER_STORE_UNAVAILABLE);
+            assert_eq!(error.reason, "exclusive_lock_not_held");
+        }
     }
 
     #[test]
     fn open_without_public_integrity_fails_closed() {
-        let error = attest_stateful_browser_activation(
+        let result = attest_stateful_browser_activation(
             &ServiceType::Stateful,
             &ExecutionTarget::Browser,
             StatefulBrowserBoundStore::IndexedDb(IndexedDbOpenAttestation {
                 exclusive_lock_held: true,
                 public_integrity_available: false,
             }),
-        )
-        .expect_err("public integrity required");
-        assert_eq!(error.code, STATEFUL_BROWSER_STORE_UNAVAILABLE);
-        assert_eq!(error.reason, "public_integrity_unavailable");
+        );
+        assert!(result.is_err());
+        if let Err(error) = result {
+            assert_eq!(error.code, STATEFUL_BROWSER_STORE_UNAVAILABLE);
+            assert_eq!(error.reason, "public_integrity_unavailable");
+        }
     }
 
     #[test]
     fn denial_evidence_is_secret_free() {
         let error = activation_error("missing_bound_store");
-        let text = to_value(&error).expect("serialize").to_string();
-        assert!(!text.contains("payload"));
-        assert!(!text.contains("databaseName"));
-        assert!(!text.contains("/var/"));
-        assert!(!text.contains("indexeddb://"));
+        let serialized = to_value(&error);
+        assert!(serialized.is_ok());
+        if let Ok(value) = serialized {
+            let text = value.to_string();
+            assert!(!text.contains("payload"));
+            assert!(!text.contains("databaseName"));
+            assert!(!text.contains("/var/"));
+            assert!(!text.contains("indexeddb://"));
+        }
     }
 }

--- a/crates/traverse-runtime/tests/placement_tests.rs
+++ b/crates/traverse-runtime/tests/placement_tests.rs
@@ -166,7 +166,7 @@ fn tier1_hint_rejected_falls_through_to_tier3() -> Result<(), PlacementError> {
 // ---------------------------------------------------------------------------
 
 #[test]
-fn tier2_filters_browser_for_stateful_service() -> Result<(), PlacementError> {
+fn tier2_allows_browser_for_stateful_service_when_lowest_load() -> Result<(), PlacementError> {
     let mut contract = base_contract();
     contract.service_type = ServiceType::Stateful;
     contract.permitted_targets = vec![
@@ -179,7 +179,7 @@ fn tier2_filters_browser_for_stateful_service() -> Result<(), PlacementError> {
         capability_id: "placement.tests.evaluator-subject".to_string(),
         target_hint: None,
         runtime_snapshot: snapshot_with(&[
-            (ExecutionTarget::Browser, 0.1), // lowest load but must be filtered
+            (ExecutionTarget::Browser, 0.1), // lowest load; Spec 132 allows selection
             (ExecutionTarget::Local, 0.4),
             (ExecutionTarget::Cloud, 0.6),
         ]),
@@ -188,12 +188,8 @@ fn tier2_filters_browser_for_stateful_service() -> Result<(), PlacementError> {
     let decision = evaluator().evaluate(&request, &contract)?;
 
     assert!(
-        !matches!(decision.target, ExecutionTarget::Browser),
-        "Browser must be excluded for Stateful services"
-    );
-    assert!(
-        matches!(decision.target, ExecutionTarget::Local),
-        "Local should win after Browser exclusion (lower load than Cloud)"
+        matches!(decision.target, ExecutionTarget::Browser),
+        "Browser must remain eligible for Stateful under Spec 132"
     );
     Ok(())
 }

--- a/packages/web/TraverseEmbedder/package.json
+++ b/packages/web/TraverseEmbedder/package.json
@@ -25,7 +25,7 @@
   "scripts": {
     "build": "tsc",
     "prepublishOnly": "npm run build",
-    "test": "npm run build && node --test tests/embedder.test.mjs tests/bundleEmbedder.test.mjs tests/crossHostFixture.test.mjs tests/registryCache.test.mjs tests/registryCacheCrossHostProjection.test.mjs tests/indexedDbDataStore.test.mjs tests/verifiedEntrypoint.test.mjs tests/governedProposal.test.mjs"
+    "test": "npm run build && node --test tests/embedder.test.mjs tests/bundleEmbedder.test.mjs tests/crossHostFixture.test.mjs tests/registryCache.test.mjs tests/registryCacheCrossHostProjection.test.mjs tests/indexedDbDataStore.test.mjs tests/statefulBrowserActivation.test.mjs tests/verifiedEntrypoint.test.mjs tests/governedProposal.test.mjs"
   },
   "devDependencies": {
     "@types/node": "^22.20.1",

--- a/packages/web/TraverseEmbedder/src/bundleEmbedder.ts
+++ b/packages/web/TraverseEmbedder/src/bundleEmbedder.ts
@@ -31,6 +31,8 @@ import {
 } from "./bundleValidation.js";
 import type { BundleLoader } from "./bundleLoader.js";
 import { findUnauthorizedImport } from "./hostAbi.js";
+import { IndexedDbDataStore } from "./indexedDbDataStore.js";
+import { attestStatefulBrowserActivation } from "./statefulBrowserActivation.js";
 import { WasiExit, WasiPipes, createWasiPreview1Imports } from "./wasi.js";
 import type { WasiMemoryRef } from "./wasi.js";
 import { EMBEDDED_TRACE_API_VERSION, embedderError, runtimeStoppedError } from "./types.js";
@@ -64,6 +66,8 @@ interface WasmTarget {
   readonly capabilityVersion: string;
   readonly digest: string;
   readonly module: WebAssembly.Module;
+  /** Optional contract `service_type` from the component manifest (Spec 132). */
+  readonly serviceType: string | null;
 }
 
 interface WorkflowNodeSpec {
@@ -187,6 +191,7 @@ export class BundleEmbedder implements TraverseEmbedderApi, EmbeddedTraceApi {
   private readonly wasmTargets: ReadonlyMap<string, WasmTarget>;
   private readonly workflowTargets: ReadonlyMap<string, WorkflowTarget>;
   private readonly wasmComponentEvidence: readonly JsonValue[];
+  private indexedDbDataStore: IndexedDbDataStore | null = null;
 
   private constructor(
     core: EmbedderCore,
@@ -198,6 +203,15 @@ export class BundleEmbedder implements TraverseEmbedderApi, EmbeddedTraceApi {
     this.wasmTargets = wasmTargets;
     this.workflowTargets = workflowTargets;
     this.wasmComponentEvidence = wasmComponentEvidence;
+  }
+
+  /**
+   * Binds a Spec `085` IndexedDB DataStore for Stateful Browser activation
+   * (Spec `132`). Pass `null` to clear. Attestation inspects this handle —
+   * an honor-system flag is not accepted.
+   */
+  bindIndexedDbDataStore(store: IndexedDbDataStore | null): void {
+    this.indexedDbDataStore = store;
   }
 
   /**
@@ -292,7 +306,12 @@ export class BundleEmbedder implements TraverseEmbedderApi, EmbeddedTraceApi {
         );
       }
 
-      wasmTargets.set(capabilityId, { capabilityVersion, digest: wasmDigest, module });
+      wasmTargets.set(capabilityId, {
+        capabilityVersion,
+        digest: wasmDigest,
+        module,
+        serviceType: optionalString(record, "service_type"),
+      });
       wasmComponentEvidence.push({
         component_id: component.componentId,
         capability_id: capabilityId,
@@ -444,6 +463,38 @@ export class BundleEmbedder implements TraverseEmbedderApi, EmbeddedTraceApi {
       capability_id: targetId,
       capability_version: target.capabilityVersion,
     });
+
+    if (target.serviceType === "stateful") {
+      const attestation = attestStatefulBrowserActivation(this.indexedDbDataStore);
+      if (!attestation.ok) {
+        this.core.recordTrace({
+          executionId,
+          targetId,
+          outcome: "error",
+          phases: [{ code: "error" }],
+          selectedTarget: { targetId, targetVersion: target.capabilityVersion },
+          placement: { target: "browser" },
+          failureCode: attestation.error.code,
+          stateMachineValid: null,
+        });
+        this.core.emit("error", sessionId, {
+          execution_id: executionId,
+          capability_id: targetId,
+          status: "error",
+          error: {
+            code: attestation.error.code,
+            message: "Stateful Browser activation requires an open Spec 085 IndexedDB DataStore",
+            details: {
+              governing_spec: attestation.error.governing_spec,
+              outcome: attestation.error.outcome,
+              reason: attestation.error.reason,
+            },
+          },
+        });
+        return { sessionId, status: "accepted", error: null };
+      }
+    }
+
     const result = executeWasmModule(target, input);
     this.core.recordTrace({
       executionId,
@@ -515,6 +566,24 @@ export class BundleEmbedder implements TraverseEmbedderApi, EmbeddedTraceApi {
         break;
       }
       const nodeInput = buildNodeInput(state, node.fromWorkflowInput);
+      if (target.serviceType === "stateful") {
+        const attestation = attestStatefulBrowserActivation(this.indexedDbDataStore);
+        if (!attestation.ok) {
+          steps.push({
+            stepIndex,
+            nodeId: node.nodeId,
+            capabilityId: node.capabilityId,
+            capabilityVersion: node.capabilityVersion,
+            status: "failed",
+          });
+          failure = {
+            code: attestation.error.code,
+            message:
+              "Stateful Browser activation requires an open Spec 085 IndexedDB DataStore",
+          };
+          break;
+        }
+      }
       const result = executeWasmModule(target, nodeInput);
       if (!result.ok) {
         steps.push({

--- a/packages/web/TraverseEmbedder/src/index.ts
+++ b/packages/web/TraverseEmbedder/src/index.ts
@@ -95,6 +95,17 @@ export type {
 } from "./indexedDbDataStore.js";
 
 export {
+  STATEFUL_BROWSER_STORE_UNAVAILABLE,
+  attestStatefulBrowserActivation,
+} from "./statefulBrowserActivation.js";
+export type {
+  StatefulBrowserActivationDenial,
+  StatefulBrowserActivationEvidence,
+  StatefulBrowserActivationReason,
+  StatefulBrowserActivationResult,
+} from "./statefulBrowserActivation.js";
+
+export {
   HOST_ABI_V1_WHITELIST,
   SUPPORTED_HOST_ABI_VERSION,
   findUnauthorizedImport,

--- a/packages/web/TraverseEmbedder/src/indexedDbDataStore.ts
+++ b/packages/web/TraverseEmbedder/src/indexedDbDataStore.ts
@@ -501,6 +501,26 @@ export class IndexedDbDataStore {
     this.lockRequest = undefined;
   }
 
+  /**
+   * Runtime-verifiable open facts for Spec `132` Stateful Browser activation.
+   * Never includes the database name, payloads, or host-private paths.
+   */
+  openAttestation(): {
+    readonly backend: "indexeddb";
+    readonly closed: boolean;
+    readonly exclusive_lock_held: boolean;
+    readonly public_integrity_available: boolean;
+  } {
+    return {
+      backend: "indexeddb",
+      closed: this.closed,
+      exclusive_lock_held: !this.closed && this.releaseLock !== undefined,
+      // Spec 085 public integrity envelopes are available on every open handle;
+      // private CRUD remains fail-closed until #1294.
+      public_integrity_available: !this.closed,
+    };
+  }
+
   private ensureOpen(operation: "read" | "write" | "delete"): void {
     if (this.closed) {
       throw dataStoreError("backend_failed", operation, "store_closed");

--- a/packages/web/TraverseEmbedder/src/statefulBrowserActivation.ts
+++ b/packages/web/TraverseEmbedder/src/statefulBrowserActivation.ts
@@ -1,0 +1,89 @@
+/**
+ * Spec `132-stateful-browser-placement` activation attestation for Browser
+ * Stateful capabilities. Mirrors `traverse_runtime::stateful_browser`.
+ */
+
+import { IndexedDbDataStore } from "./indexedDbDataStore.js";
+
+/** Stable activation failure code (Spec 132 FR-003). */
+export const STATEFUL_BROWSER_STORE_UNAVAILABLE =
+  "stateful_browser_store_unavailable" as const;
+
+export type StatefulBrowserActivationReason =
+  | "missing_bound_store"
+  | "non_indexeddb_backend"
+  | "exclusive_lock_not_held"
+  | "public_integrity_unavailable"
+  | "store_closed";
+
+/** Secret-free success evidence (Spec 132 FR-005). */
+export interface StatefulBrowserActivationEvidence {
+  readonly governing_spec: "132-stateful-browser-placement";
+  readonly backend: "indexeddb";
+  readonly exclusive_lock_held: true;
+  readonly public_integrity_available: true;
+  readonly outcome: "attested";
+}
+
+/** Fail-closed denial (Spec 132 FR-003/FR-005). */
+export interface StatefulBrowserActivationDenial {
+  readonly code: typeof STATEFUL_BROWSER_STORE_UNAVAILABLE;
+  readonly governing_spec: "132-stateful-browser-placement";
+  readonly outcome: "denied";
+  readonly reason: StatefulBrowserActivationReason;
+}
+
+export type StatefulBrowserActivationResult =
+  | { readonly ok: true; readonly evidence: StatefulBrowserActivationEvidence }
+  | { readonly ok: false; readonly error: StatefulBrowserActivationDenial };
+
+function denial(
+  reason: StatefulBrowserActivationReason,
+): StatefulBrowserActivationResult {
+  return {
+    ok: false,
+    error: {
+      code: STATEFUL_BROWSER_STORE_UNAVAILABLE,
+      governing_spec: "132-stateful-browser-placement",
+      outcome: "denied",
+      reason,
+    },
+  };
+}
+
+/**
+ * Attests Browser activation of a Stateful capability against a bound store.
+ *
+ * The store handle itself is inspected — an honor-system boolean is not enough
+ * (Spec 132 FR-004). Evidence never includes DB names, payloads, or paths.
+ */
+export function attestStatefulBrowserActivation(
+  boundStore: unknown,
+): StatefulBrowserActivationResult {
+  if (boundStore === null || boundStore === undefined) {
+    return denial("missing_bound_store");
+  }
+  if (!(boundStore instanceof IndexedDbDataStore)) {
+    return denial("non_indexeddb_backend");
+  }
+  const facts = boundStore.openAttestation();
+  if (facts.closed) {
+    return denial("store_closed");
+  }
+  if (!facts.exclusive_lock_held) {
+    return denial("exclusive_lock_not_held");
+  }
+  if (!facts.public_integrity_available) {
+    return denial("public_integrity_unavailable");
+  }
+  return {
+    ok: true,
+    evidence: {
+      governing_spec: "132-stateful-browser-placement",
+      backend: "indexeddb",
+      exclusive_lock_held: true,
+      public_integrity_available: true,
+      outcome: "attested",
+    },
+  };
+}

--- a/packages/web/TraverseEmbedder/tests/statefulBrowserActivation.test.mjs
+++ b/packages/web/TraverseEmbedder/tests/statefulBrowserActivation.test.mjs
@@ -1,0 +1,83 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { IDBFactory } from "fake-indexeddb";
+import {
+  IndexedDbDataStore,
+  STATEFUL_BROWSER_STORE_UNAVAILABLE,
+  attestStatefulBrowserActivation,
+} from "../dist/index.js";
+
+class ConformanceLockManager {
+  #held = new Set();
+
+  async request(name, _options, callback) {
+    if (this.#held.has(name)) {
+      return callback(null);
+    }
+    this.#held.add(name);
+    try {
+      return await callback({ name, mode: "exclusive" });
+    } finally {
+      this.#held.delete(name);
+    }
+  }
+}
+
+function config(databaseName) {
+  return {
+    databaseName,
+    classification: "public",
+    indexedDB: new IDBFactory(),
+    locks: new ConformanceLockManager(),
+  };
+}
+
+test("attestStatefulBrowserActivation fails closed without a bound store", () => {
+  const missing = attestStatefulBrowserActivation(null);
+  assert.equal(missing.ok, false);
+  assert.equal(missing.error.code, STATEFUL_BROWSER_STORE_UNAVAILABLE);
+  assert.equal(missing.error.reason, "missing_bound_store");
+  const text = JSON.stringify(missing.error);
+  assert.equal(text.includes("payload"), false);
+  assert.equal(text.includes("databaseName"), false);
+});
+
+test("attestStatefulBrowserActivation fails closed for non-IndexedDB values", () => {
+  const denial = attestStatefulBrowserActivation({ pretend: true });
+  assert.equal(denial.ok, false);
+  assert.equal(denial.error.code, STATEFUL_BROWSER_STORE_UNAVAILABLE);
+  assert.equal(denial.error.reason, "non_indexeddb_backend");
+});
+
+test("attestStatefulBrowserActivation accepts an open IndexedDB store", async () => {
+  const store = await IndexedDbDataStore.open(config("stateful-browser-ok"));
+  const result = attestStatefulBrowserActivation(store);
+  assert.equal(result.ok, true);
+  assert.equal(result.evidence.backend, "indexeddb");
+  assert.equal(result.evidence.outcome, "attested");
+  const text = JSON.stringify(result.evidence);
+  assert.equal(text.includes(store.databaseName), false);
+  store.close();
+});
+
+test("attestStatefulBrowserActivation fails closed after close", async () => {
+  const store = await IndexedDbDataStore.open(config("stateful-browser-closed"));
+  store.close();
+  const denial = attestStatefulBrowserActivation(store);
+  assert.equal(denial.ok, false);
+  assert.equal(denial.error.code, STATEFUL_BROWSER_STORE_UNAVAILABLE);
+  assert.ok(
+    denial.error.reason === "store_closed" ||
+      denial.error.reason === "exclusive_lock_not_held",
+  );
+});
+
+test("IndexedDbDataStore.openAttestation is secret-free", async () => {
+  const store = await IndexedDbDataStore.open(config("stateful-browser-facts"));
+  const facts = store.openAttestation();
+  assert.equal(facts.backend, "indexeddb");
+  assert.equal(facts.exclusive_lock_held, true);
+  assert.equal(facts.public_integrity_available, true);
+  assert.equal(JSON.stringify(facts).includes(store.databaseName), false);
+  store.close();
+});


### PR DESCRIPTION
## Summary
- Implement Spec `132-stateful-browser-placement`: contract validation and placement accept `Stateful` + `Browser`.
- Add runtime + web activation attestation that requires an open Spec `085` IndexedDB DataStore (exclusive lock + public integrity) before guest execution; failures use `stateful_browser_store_unavailable`.
- Evidence stays secret-free (no payloads, DB names, or host-private paths).

## Governing Spec
- `132-stateful-browser-placement`
- `085-datastore-indexeddb`
- `014-service-type-taxonomy`
- `131-stateful-persistence-host-abi`
- `024-placement-constraint-evaluator`
- `002-capability-contracts`
- `068-public-platform-embedder-packages`
- `057-embeddable-runtime-host`
- `518-durable-local-datastore`
- `519-embedder-owned-datastore-integration`
- `016-runtime-placement-router`
- `025-wasm-executor-adapter`
- `006-runtime-request-execution`
- `004-spec-alignment-gate`

## Project Item
- #1289

## Validation
- [x] `cargo test -p traverse-contracts stateful_with_browser`
- [x] `cd packages/web/TraverseEmbedder && npm test` (61 pass, including Spec 132 attestation)
- [ ] `cargo test -p traverse-runtime --lib stateful_browser` (CI)
- [ ] `cargo test -p traverse-runtime --test placement_tests tier2_allows_browser` (CI)
- [ ] CI green on this PR

Tracking #1289. Closes #1289 on merge.
