### PR TITLE
docs: record v0.10.1 patch release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## Unreleased
 
+## v0.10.1 — Release candidate
+
+### Fixes
+
+- Runtime: treat WASI preview1 `proc_exit(0)` as successful completion, while
+  retaining fail-closed handling for nonzero exit codes.
+- Web embedder: provide deterministic denied implementations for the approved
+  `emit_event` and `connector_invoke` Host ABI imports so ABI-valid modules
+  load without ambient connector authority.
+- CLI: `app new` now writes the documented `app.manifest.json` filename.
+
 ## v0.10.0 — 2026-09-05
 
 ### Governed runtime workflow composition

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-## v0.10.1 — Release candidate
+## v0.10.1 — 2026-09-09
 
 ### Fixes
 

--- a/README.md
+++ b/README.md
@@ -282,7 +282,7 @@ Read the [UMA book](https://www.universalmicroservices.com/) and the
 
 ### Releases
 
-- [docs/releases/v0.10.0.md](docs/releases/v0.10.0.md) — current release notes
+- [docs/releases/v0.10.1.md](docs/releases/v0.10.1.md) — current release notes
 - [docs/releases/v0.9.1.md](docs/releases/v0.9.1.md) — prior release notes
 - [docs/releases/v0.8.1.md](docs/releases/v0.8.1.md) — prior release notes
 

--- a/docs/releases/v0.10.1.md
+++ b/docs/releases/v0.10.1.md
@@ -1,0 +1,62 @@
+# Traverse v0.10.1
+
+Release candidate for the v0.10 line.
+
+Traverse v0.10.1 is a compatibility-preserving patch release for the public
+runtime, browser embedder, and CLI authoring path.
+
+## Fixes
+
+- The native `WasmExecutor` accepts WASI preview1 `proc_exit(0)` as successful
+  completion and still rejects nonzero process exits. Capabilities that write a
+  JSON result and then exit successfully now return that result as intended.
+- The web embedder supplies deterministic denied shims for the approved
+  `traverse_host.emit_event` and `traverse_host.connector_invoke` imports. This
+  lets ABI-valid modules load while preserving the browser host's no-ambient-
+  connector-authority boundary.
+- `traverse-cli app new` writes `app.manifest.json`, matching the documented
+  application-bundle convention.
+
+## Upgrade notes
+
+The Rust crate APIs and `traverse-cli` binary name are unchanged. Existing
+applications need no migration. Browser capabilities that declare the approved
+connector imports now load deterministically; connector calls remain denied
+until an activated binding adapter is supplied by a host integration.
+
+## Validation
+
+Release preparation must pass these local gates before tagging:
+
+```bash
+cargo build --workspace
+cargo test --workspace
+bash scripts/ci/repository_checks.sh
+bash scripts/ci/spec_alignment_check.sh
+bash scripts/ci/coverage_gate.sh
+TRAVERSE_PUBLISH_DRY_RUN=1 TRAVERSE_PUBLISH_NO_VERIFY=1 bash scripts/ci/publish_crates.sh
+```
+
+The tagged commit must pass the GitHub `version-guard`, `repository-checks`,
+`coverage-gate`, and stress-test jobs before the tag-triggered crates.io
+publish job can run.
+
+## Release steps
+
+Per [the release process](../release-process.md), from this clean release
+candidate after CI is green:
+
+```bash
+bash scripts/ci/bump_version.sh 0.10.1
+git push origin codex/release-v0.10.1:main
+git push origin v0.10.1
+```
+
+The tag push triggers the guarded crates.io publication workflow. The
+publication requires explicit manual approval under the Traverse constitution.
+
+## Traceability
+
+- Governing spec: `048-semver-publishing-pipeline`
+- Fixes: #1255, #1260, #1266
+- Range: `v0.10.0..v0.10.1`

--- a/docs/releases/v0.10.1.md
+++ b/docs/releases/v0.10.1.md
@@ -1,6 +1,6 @@
 # Traverse v0.10.1
 
-Release candidate for the v0.10 line.
+Released 2026-09-09.
 
 Traverse v0.10.1 is a compatibility-preserving patch release for the public
 runtime, browser embedder, and CLI authoring path.


### PR DESCRIPTION
## Summary

Records the published v0.10.1 maintenance release on main: release notes, changelog entry, and README link.

## Governing Spec

- `048-semver-publishing-pipeline`

## Project Item

Published release v0.10.1.

## Definition of Done

- [x] Main documentation links to the published release notes.
- [x] Changelog records the actual release date.

## Validation

- Reviewed the published GitHub release and successful tag workflow.