### PR TITLE
feat(web): expose browser-local workflow planner

### DIFF
--- a/packages/web/TraverseEmbedder/package.json
+++ b/packages/web/TraverseEmbedder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "traverse-embedder-web",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Public Traverse platform embedder SDK for Web/TypeScript clients, implementing embedder-api/1.0.0 (spec 068)",
   "license": "Apache-2.0",
   "repository": {
@@ -25,7 +25,7 @@
   "scripts": {
     "build": "tsc",
     "prepublishOnly": "npm run build",
-    "test": "npm run build && node --test tests/embedder.test.mjs tests/bundleEmbedder.test.mjs tests/crossHostFixture.test.mjs tests/registryCache.test.mjs tests/registryCacheCrossHostProjection.test.mjs tests/indexedDbDataStore.test.mjs tests/statefulBrowserActivation.test.mjs tests/verifiedEntrypoint.test.mjs tests/governedProposal.test.mjs"
+    "test": "npm run build && node --test tests/embedder.test.mjs tests/bundleEmbedder.test.mjs tests/browserLocalPlan.test.mjs tests/crossHostFixture.test.mjs tests/registryCache.test.mjs tests/registryCacheCrossHostProjection.test.mjs tests/indexedDbDataStore.test.mjs tests/statefulBrowserActivation.test.mjs tests/verifiedEntrypoint.test.mjs tests/governedProposal.test.mjs"
   },
   "devDependencies": {
     "@types/node": "^22.20.1",

--- a/packages/web/TraverseEmbedder/src/browserLocalPlan.ts
+++ b/packages/web/TraverseEmbedder/src/browserLocalPlan.ts
@@ -1,0 +1,123 @@
+/**
+ * Offline, deterministic proposal construction for Spec 1277.  This module
+ * deliberately has no loader, storage, or fetch dependency: the caller must
+ * supply an already verified registry snapshot and prepared dependencies.
+ */
+import type { JsonValue } from "./types.js";
+import type { SyncedPublicRegistryState, VerifiedRegistryDependency } from "./registryCache.js";
+
+export const BROWSER_WORKFLOW_PROPOSAL_SCHEMA_VERSION = "1.0.0";
+export const SUPPORTED_BROWSER_PLAN_CONTRACT_SCHEMA_VERSION = "1.0.0";
+export const BROWSER_PLAN_MAX_CANDIDATES = 5;
+export const BROWSER_PLAN_MAX_NODES = 8;
+export const BROWSER_PLAN_MAX_FACT_BYTES = 64 * 1024;
+export const BROWSER_PLAN_MAX_DEPENDENCIES = 128;
+
+export interface BrowserPlanTarget {
+  readonly capability_id?: string;
+  readonly capability_version?: string;
+  readonly emits_event?: string;
+}
+
+export interface BrowserSnapshotIdentity {
+  readonly registry_snapshot_digest: string;
+  readonly source_release: string;
+  readonly contract_schema_version: string;
+}
+
+export interface BrowserProposalNode {
+  readonly node_id: string;
+  readonly capability_id: string;
+  readonly capability_version: string;
+  readonly artifact_digest: string;
+}
+
+export interface BrowserProposalMapping {
+  readonly from_node_id: string | null;
+  readonly from_field: string;
+  readonly to_node_id: string;
+  readonly to_field: string;
+  readonly source: "starting_facts" | "capability_output";
+}
+
+export interface BrowserWorkflowProposal {
+  readonly kind: "browser_workflow_proposal";
+  readonly schema_version: string;
+  readonly snapshot_digest: string;
+  readonly source_release: string;
+  readonly mapping_unconfirmed: boolean;
+  readonly proposal: {
+    readonly kind: "workflow_proposal";
+    readonly schema_version: string;
+    readonly proposal_id: string;
+    readonly workspace_id: string;
+    readonly app_manifest: JsonValue;
+    readonly nodes: readonly BrowserProposalNode[];
+    readonly edges: readonly { readonly from_node_id: string; readonly to_node_id: string }[];
+    readonly mappings: readonly BrowserProposalMapping[];
+    readonly initial_input: JsonValue;
+  };
+}
+
+export interface BrowserPlanResponse { readonly proposals: readonly BrowserWorkflowProposal[]; readonly plan_search_truncated: boolean; }
+export type BrowserPlanErrorCode =
+  | "browser_plan_unsupported_contract_schema_version" | "browser_plan_snapshot_digest_mismatch"
+  | "browser_plan_snapshot_empty" | "browser_plan_snapshot_evidence_stale"
+  | "browser_plan_verified_dependency_contract_invalid" | "browser_plan_verified_dependency_not_in_snapshot"
+  | "browser_plan_verified_dependency_digest_mismatch" | "browser_plan_verified_dependency_evidence_mismatch"
+  | "browser_plan_starting_facts_too_large" | "browser_plan_verified_dependency_set_too_large";
+export class BrowserPlanError extends Error { constructor(readonly code: BrowserPlanErrorCode, message: string) { super(message); this.name = "BrowserPlanError"; } }
+
+interface Declared { id: string; version: string; digest: string; inputs: readonly string[]; outputs: readonly string[]; emits: readonly string[]; }
+const record = (value: unknown): Record<string, unknown> | null => typeof value === "object" && value !== null && !Array.isArray(value) ? value as Record<string, unknown> : null;
+const strings = (value: unknown): string[] => Array.isArray(value) ? value.filter((v): v is string => typeof v === "string") : [];
+function required(value: unknown): string[] { const r = record(value); return strings(r?.required); }
+function fields(value: unknown): string[] { const r = record(value); return Object.keys(record(r?.properties) ?? {}).sort(); }
+function stable(value: JsonValue): string { if (Array.isArray(value)) return `[${value.map(stable).join(",")}]`; if (value !== null && typeof value === "object") return `{${Object.keys(value).sort().map(k => `${JSON.stringify(k)}:${stable(value[k] as JsonValue)}`).join(",")}}`; return JSON.stringify(value); }
+async function digest(value: JsonValue): Promise<string> { const bytes = new TextEncoder().encode(stable(value)); const hash = await crypto.subtle.digest("SHA-256", bytes); return `sha256:${[...new Uint8Array(hash)].map(x => x.toString(16).padStart(2, "0")).join("")}`; }
+
+/** Creates only structural candidates; no capability name or natural-language inference is used. */
+export async function browserLocalPlan(identity: BrowserSnapshotIdentity, snapshot: SyncedPublicRegistryState, dependencies: readonly VerifiedRegistryDependency[], target: BrowserPlanTarget, startingFacts: JsonValue, workspaceId: string, appManifest: JsonValue): Promise<BrowserPlanResponse> {
+  if (dependencies.length > BROWSER_PLAN_MAX_DEPENDENCIES) throw new BrowserPlanError("browser_plan_verified_dependency_set_too_large", "prepared dependency set exceeds the fixed bound");
+  if (new TextEncoder().encode(JSON.stringify(startingFacts)).byteLength > BROWSER_PLAN_MAX_FACT_BYTES) throw new BrowserPlanError("browser_plan_starting_facts_too_large", "starting facts exceed the fixed bound");
+  if (identity.contract_schema_version !== SUPPORTED_BROWSER_PLAN_CONTRACT_SCHEMA_VERSION) throw new BrowserPlanError("browser_plan_unsupported_contract_schema_version", "unsupported contract schema version");
+  if (snapshot.capabilities.length === 0) throw new BrowserPlanError("browser_plan_snapshot_empty", "synced registry snapshot contains no capabilities");
+  if (identity.source_release !== snapshot.releaseTag) throw new BrowserPlanError("browser_plan_snapshot_evidence_stale", "snapshot release evidence is stale");
+  if (identity.registry_snapshot_digest !== await digest(snapshot as unknown as JsonValue)) throw new BrowserPlanError("browser_plan_snapshot_digest_mismatch", "snapshot digest does not match supplied snapshot");
+  const declared: Declared[] = dependencies.map(dep => {
+    let contract: Record<string, unknown> | null;
+    try { contract = record(JSON.parse(new TextDecoder().decode(dep.contractBytes))); } catch { contract = null; }
+    if (contract === null) throw new BrowserPlanError("browser_plan_verified_dependency_contract_invalid", "prepared dependency contract is invalid");
+    if (dep.evidence.indexDigest !== identity.registry_snapshot_digest) throw new BrowserPlanError("browser_plan_verified_dependency_evidence_mismatch", "prepared dependency is bound to a different snapshot");
+    const found = snapshot.capabilities.find(c => c.namespace === dep.evidence.namespace && c.id === dep.evidence.id && c.version === dep.evidence.selectedVersion && !c.deprecated);
+    if (found === undefined) throw new BrowserPlanError("browser_plan_verified_dependency_not_in_snapshot", "prepared dependency is not active in snapshot");
+    if (found.digest !== dep.wasmDigest || found.digest !== dep.evidence.artifactDigest) throw new BrowserPlanError("browser_plan_verified_dependency_digest_mismatch", "prepared dependency artifact digest drifted");
+    const inputs = required(record(contract.inputs)?.schema); const outputs = fields(record(contract.outputs)?.schema);
+    const emits = Array.isArray(contract.emits) ? contract.emits.flatMap(v => { const e = record(v); return typeof e?.event_id === "string" ? [e.event_id] : []; }) : [];
+    return { id: found.id, version: found.version, digest: found.digest, inputs, outputs, emits };
+  }).sort((a,b) => a.id.localeCompare(b.id) || a.version.localeCompare(b.version));
+  // Starting facts are values, unlike contract schemas; their own keys form
+  // the initial structural output set.
+  const facts = Object.keys(record(startingFacts) ?? {}).sort();
+  const targets = declared.filter(c => (target.capability_id !== undefined && target.capability_version !== undefined && c.id === target.capability_id && c.version === target.capability_version) || (target.emits_event !== undefined && c.emits.includes(target.emits_event)));
+  const chains: Declared[][] = [];
+  const visit = (node: Declared, chain: Declared[], available: readonly string[]): void => {
+    if (chains.length >= BROWSER_PLAN_MAX_CANDIDATES || chain.length >= BROWSER_PLAN_MAX_NODES) return;
+    if (node.inputs.every(field => available.includes(field))) { chains.push([...chain, node]); return; }
+    for (const predecessor of declared) if (!chain.includes(predecessor) && node.inputs.every(field => available.includes(field) || predecessor.outputs.includes(field))) visit(predecessor, [...chain, node], [...available, ...predecessor.outputs]);
+  };
+  for (const candidate of targets) visit(candidate, [], facts);
+  const proposals = chains.slice(0, BROWSER_PLAN_MAX_CANDIDATES).map((chain, index) => {
+    const ordered = [...chain].reverse(); const nodes = ordered.map((c, n) => ({ node_id: `node-${n + 1}`, capability_id: c.id, capability_version: c.version, artifact_digest: c.digest }));
+    const mappings: BrowserProposalMapping[] = [];
+    for (let n = 0; n < ordered.length; n += 1) {
+      const node = ordered[n]!;
+      for (const field of node.inputs) {
+        const prior = ordered.slice(0, n).map((c, i) => ({ c, i })).reverse().find(({ c }) => c.outputs.includes(field));
+        mappings.push(prior ? { from_node_id: nodes[prior.i]!.node_id, from_field: field, to_node_id: nodes[n]!.node_id, to_field: field, source: "capability_output" } : { from_node_id: null, from_field: field, to_node_id: nodes[n]!.node_id, to_field: field, source: "starting_facts" });
+      }
+    }
+    return { kind: "browser_workflow_proposal" as const, schema_version: BROWSER_WORKFLOW_PROPOSAL_SCHEMA_VERSION, snapshot_digest: identity.registry_snapshot_digest, source_release: identity.source_release, mapping_unconfirmed: true, proposal: { kind: "workflow_proposal" as const, schema_version: "1.0.0", proposal_id: `browser-plan-${index + 1}`, workspace_id: workspaceId, app_manifest: appManifest, nodes, edges: nodes.slice(1).map((node,n) => ({ from_node_id: nodes[n]!.node_id, to_node_id: node.node_id })), mappings, initial_input: startingFacts } };
+  });
+  return { proposals, plan_search_truncated: chains.length >= BROWSER_PLAN_MAX_CANDIDATES };
+}

--- a/packages/web/TraverseEmbedder/src/index.ts
+++ b/packages/web/TraverseEmbedder/src/index.ts
@@ -63,6 +63,26 @@ export type { BundleCompatibility, BundleComponentSummary, BundleWorkflowSummary
 export { BundleEmbedder } from "./bundleEmbedder.js";
 export type { BundleEmbedderConfig } from "./bundleEmbedder.js";
 
+export {
+  BROWSER_PLAN_MAX_CANDIDATES,
+  BROWSER_PLAN_MAX_DEPENDENCIES,
+  BROWSER_PLAN_MAX_FACT_BYTES,
+  BROWSER_PLAN_MAX_NODES,
+  BROWSER_WORKFLOW_PROPOSAL_SCHEMA_VERSION,
+  BrowserPlanError,
+  browserLocalPlan,
+  SUPPORTED_BROWSER_PLAN_CONTRACT_SCHEMA_VERSION,
+} from "./browserLocalPlan.js";
+export type {
+  BrowserPlanErrorCode,
+  BrowserPlanResponse,
+  BrowserPlanTarget,
+  BrowserProposalMapping,
+  BrowserProposalNode,
+  BrowserSnapshotIdentity,
+  BrowserWorkflowProposal,
+} from "./browserLocalPlan.js";
+
 export { FetchBundleLoader, NodeFsBundleLoader } from "./bundleLoader.js";
 export type { BundleLoader } from "./bundleLoader.js";
 

--- a/packages/web/TraverseEmbedder/src/types.ts
+++ b/packages/web/TraverseEmbedder/src/types.ts
@@ -25,7 +25,7 @@ export const SUPPORTED_BUNDLE_SCHEMA_VERSIONS: readonly string[] = ["1.0.0"];
 
 export const EVENT_SCHEMA_VERSION = "1.0.0";
 export const PACKAGE_NAME = "traverse-embedder-web";
-export const PACKAGE_VERSION = "0.7.0";
+export const PACKAGE_VERSION = "0.8.0";
 
 /** Stable embedder-boundary error codes (wire-identical to the Rust SDK). */
 export type EmbedderErrorCode =

--- a/packages/web/TraverseEmbedder/tests/browserLocalPlan.test.mjs
+++ b/packages/web/TraverseEmbedder/tests/browserLocalPlan.test.mjs
@@ -1,0 +1,32 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import test from "node:test";
+import { browserLocalPlan, BrowserPlanError } from "../dist/index.js";
+
+const stable = (value) => Array.isArray(value) ? `[${value.map(stable).join(",")}]` : value && typeof value === "object" ? `{${Object.keys(value).sort().map((key) => `${JSON.stringify(key)}:${stable(value[key])}`).join(",")}}` : JSON.stringify(value);
+const sha = (value) => `sha256:${createHash("sha256").update(stable(value)).digest("hex")}`;
+const digest = (marker) => `sha256:${marker.repeat(64).slice(0, 64)}`;
+const contract = (id, inputs, outputs) => ({ schema_version: "1.0.0", id, inputs: { schema: { required: inputs, properties: Object.fromEntries(inputs.map(key => [key, { type: "string" }])) } }, outputs: { schema: { required: outputs, properties: Object.fromEntries(outputs.map(key => [key, { type: "string" }])) } }, emits: [] });
+
+function inputs() {
+  const snapshot = { releaseTag: "registry-v1", capabilities: [{ namespace: "demo", id: "source", version: "1.0.0", digest: digest("a"), artifactUrl: "", contractDigest: "", contractUrl: "", deprecated: false }, { namespace: "demo", id: "sink", version: "1.0.0", digest: digest("b"), artifactUrl: "", contractDigest: "", contractUrl: "", deprecated: false }] };
+  const identity = { registry_snapshot_digest: sha(snapshot), source_release: snapshot.releaseTag, contract_schema_version: "1.0.0" };
+  const dependency = (id, marker, value) => ({ wasmBytes: new Uint8Array(), contractBytes: new TextEncoder().encode(JSON.stringify(value)), wasmDigest: digest(marker), evidence: { namespace: "demo", id, selectedVersion: "1.0.0", versionRange: "1.0.0", sourceRelease: "registry-v1", indexDigest: identity.registry_snapshot_digest, artifactDigest: digest(marker), verifiedAt: 1, outcome: "prepared" } });
+  return { snapshot, identity, dependencies: [dependency("source", "a", contract("source", ["seed"], ["middle"])), dependency("sink", "b", contract("sink", ["middle"], ["result"]))] };
+}
+
+test("browser planner is deterministic, structural, and leaves mappings unconfirmed", async () => {
+  const { snapshot, identity, dependencies } = inputs();
+  const args = [identity, snapshot, dependencies, { capability_id: "sink", capability_version: "1.0.0" }, { seed: "x" }, "local", { app_id: "demo" }];
+  const first = await browserLocalPlan(...args);
+  const second = await browserLocalPlan(...args);
+  assert.deepEqual(first, second);
+  assert.equal(first.proposals.length, 1);
+  assert.equal(first.proposals[0].mapping_unconfirmed, true);
+  assert.deepEqual(first.proposals[0].proposal.nodes.map(node => node.capability_id), ["source", "sink"]);
+});
+
+test("browser planner fails closed before planning on altered snapshot evidence", async () => {
+  const { snapshot, identity, dependencies } = inputs();
+  await assert.rejects(() => browserLocalPlan({ ...identity, registry_snapshot_digest: digest("z") }, snapshot, dependencies, { capability_id: "sink", capability_version: "1.0.0" }, {}, "local", {}), (error) => error instanceof BrowserPlanError && error.code === "browser_plan_snapshot_digest_mismatch");
+});


### PR DESCRIPTION
## Summary

- Add the public, offline Spec 1277 browser-local planning surface.
- Bind planner inputs to a canonical digest-verified snapshot and prepared dependency evidence.
- Add deterministic structural-planning conformance coverage and prepare the web package 0.8.0 API surface.

## Governing Spec

- `1277-browser-local-workflow-composition`
- `068-public-platform-embedder-packages`

## Project Item

Traverse #1308

## Definition of Done

- [x] No network, storage, or mutation path is introduced by the planner.
- [x] Planning is bounded, deterministic, structural, and returns unconfirmed mappings.
- [x] Snapshot and prepared-dependency evidence failures are fail-closed and redacted.

## Validation

- `cd packages/web/TraverseEmbedder && npm test` (63 passing)
- `BASE_SHA=$(git merge-base HEAD origin/main) && BASE_SHA="$BASE_SHA" bash scripts/ci/spec_alignment_check.sh <pr-body>` (passed)