### PR TITLE
ci(web): add npm trusted publishing workflow

### DIFF
--- a/.github/workflows/web-embedder-publish.yml
+++ b/.github/workflows/web-embedder-publish.yml
@@ -1,0 +1,51 @@
+name: Publish web embedder
+
+on:
+  push:
+    tags:
+      - "web-v*"
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: packages/web/TraverseEmbedder
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+      - name: Set up Node
+        uses: actions/setup-node@v7
+        with:
+          node-version: 22
+          registry-url: https://registry.npmjs.org
+      - name: Install locked dependencies
+        run: npm ci
+      - name: Verify release tag matches package version
+        shell: bash
+        run: |
+          set -euo pipefail
+          version="$(node -p "require('./package.json').version")"
+          expected="web-v${version}"
+          if [[ "${GITHUB_REF_NAME}" != "${expected}" ]]; then
+            echo "tag ${GITHUB_REF_NAME} does not match package version ${version}" >&2
+            exit 1
+          fi
+      - name: Build
+        run: npm run build
+      - name: Test
+        run: npm test
+      - name: Publish with provenance
+        shell: bash
+        run: |
+          set -euo pipefail
+          version="$(node -p "require('./package.json').version")"
+          if npm view "traverse-embedder-web@${version}" version --registry=https://registry.npmjs.org >/dev/null 2>&1; then
+            echo "traverse-embedder-web@${version} is already published; skipping."
+            exit 0
+          fi
+          npm publish --provenance --access public

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -40,3 +40,11 @@ coverage pass. It runs `bash scripts/ci/publish_crates.sh` with
 crate immediately before publishing it, publishes crates in dependency order,
 and treats an already-uploaded crate version as success so reruns are
 idempotent.
+
+## Web embedder (npm)
+
+The web SDK has an independent release version and tag. From a clean, merged
+checkout, run `cd packages/web/TraverseEmbedder && npm version <version>`;
+this creates `web-v<version>`. Push that tag to trigger the credential-free npm
+Trusted Publishing workflow. See [the web embedder npm publish runbook](web-embedder-npm-publish-runbook.md)
+for setup assumptions and verification.

--- a/docs/web-embedder-npm-publish-runbook.md
+++ b/docs/web-embedder-npm-publish-runbook.md
@@ -1,67 +1,30 @@
-# Publishing `traverse-embedder-web` to npm
+# Web embedder npm publishing
 
-Governed by `068-public-platform-embedder-packages`. Tracks issue `#1097`.
+The `traverse-embedder-web` package is released with npm Trusted Publishing.
+GitHub Actions exchanges its OIDC identity for a short-lived npm credential;
+no `NPM_TOKEN` or `NODE_AUTH_TOKEN` is stored in this repository.
 
-`packages/web/TraverseEmbedder` is a complete, versioned, conformance-tested
-implementation of `embedder-api/1.0.0` — it builds cleanly, all 42 package
-tests pass, and it already satisfies spec 068's package-content requirements
-(FR-006 test double, FR-007 documentation, FR-008 release evidence via
-`releaseEvidence()`, FR-009 conformance corpus — see `npm run build && npm run test`
-and `scripts/ci/embedder_conformance/web_package.sh`). The only remaining gap is
-distribution: it has never been published, so nothing outside this repo can
-`npm install` it.
+## Release
 
-Publishing is an irreversible, externally-visible action against a
-third-party registry. This repo's automation does not perform it — this
-runbook prepares everything up to that point and hands the actual publish
-command to whoever holds npm publish rights for the intended package name.
+1. Merge the package version and lockfile update to `main` after its tests pass.
+2. From the merged commit, run `cd packages/web/TraverseEmbedder && npm version <version>`.
+   The package `.npmrc` creates `web-v<version>` rather than npm's default `v` tag.
+3. Push only that tag: `git push origin web-v<version>`.
+4. The `Publish web embedder` workflow checks out the tagged commit, runs
+   `npm ci`, verifies the tag matches `package.json`, builds, tests, and
+   publishes with provenance.
 
-## Preflight checklist (verified in this PR)
+The one-time manual 0.8.0 exception described in issue #1316 predates Trusted
+Publishing. All later releases use the OIDC workflow.
 
-- [x] `npm run build` compiles cleanly (`tsc`, no errors).
-- [x] `npm test` passes (42/42), including real WASI capability execution and
-      a full checked-in `traverse-starter` bundle run.
-- [x] `npm pack --dry-run` produces the expected tarball: `dist/**`,
-      `README.md`, `LICENSE`, `package.json` (24 → 25 files after adding
-      `LICENSE` to `files` in this PR).
-- [x] `prepublishOnly` now runs `build` automatically so a stale/missing
-      `dist/` can never ship (added in this PR — previously `npm publish`
-      would have shipped whatever `dist/` happened to exist locally).
-- [x] Name availability re-checked live on 2026-08-22:
-      `npm view traverse-embedder-web` → `404 Not Found` (unclaimed, matches
-      the package.json `name` field already committed).
+## Verification and recovery
 
-## What is NOT verified here
+After completion, run `npm view traverse-embedder-web version` and
+`npm view traverse-embedder-web dist-tags --json`; confirm the expected version
+is `latest`. Inspect its npm provenance in the package's npm registry page.
 
-- Whether `traverse-framework` (or whoever publishes) has an npm
-  organization/account with the intended publish identity already set up.
-- Whether `traverse-embedder-web` is the final desired public package name
-  versus a scoped alternative (e.g. `@traverse-framework/embedder-web`) —
-  the unscoped name in `package.json` was already a deliberate prior choice,
-  kept as-is here rather than relitigated.
-- CI-based publish automation (a GitHub Actions workflow gated on a tag or
-  manual dispatch, using an `NPM_TOKEN` secret) — not built in this PR; ask
-  for it explicitly as a follow-up if wanted, since it requires adding a
-  repository secret this session cannot create.
-
-## To actually publish (run this yourself, with your own npm credentials)
-
-```bash
-cd packages/web/TraverseEmbedder
-npm login                 # if not already authenticated for this identity
-npm publish --access public
-```
-
-`--access public` is required the first time for an unscoped package name
-under an account without a default-private setting.
-
-## Verify after publishing
-
-```bash
-npm view traverse-embedder-web
-npm install traverse-embedder-web   # from a scratch directory, outside this repo
-```
-
-Confirm the installed package's `dist/index.js` exports match
-`packages/web/TraverseEmbedder/dist/index.js` from this build, and that
-`releaseEvidence()` reports the expected version/digests.
+If a run is repeated after the same version has been published, it succeeds
+without replacing the artifact. A tag/version mismatch fails before publishing.
+If Trusted Publishing is not configured in npm for this repository and workflow,
+the job fails safely; configure the npm trusted publisher as tracked by #1314,
+then rerun the immutable tag workflow.

--- a/packages/web/TraverseEmbedder/.gitignore
+++ b/packages/web/TraverseEmbedder/.gitignore
@@ -1,3 +1,2 @@
 node_modules/
 dist/
-package-lock.json

--- a/packages/web/TraverseEmbedder/.npmrc
+++ b/packages/web/TraverseEmbedder/.npmrc
@@ -1,0 +1,1 @@
+tag-version-prefix=web-v

--- a/packages/web/TraverseEmbedder/package-lock.json
+++ b/packages/web/TraverseEmbedder/package-lock.json
@@ -1,0 +1,78 @@
+{
+  "name": "traverse-embedder-web",
+  "version": "0.9.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "traverse-embedder-web",
+      "version": "0.9.0",
+      "license": "Apache-2.0",
+      "devDependencies": {
+        "@types/node": "^22.20.1",
+        "fake-indexeddb": "^6.2.5",
+        "typescript": "^5.6.0",
+        "wabt": "^1.0.39"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "22.20.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
+      "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/fake-indexeddb": {
+      "version": "6.2.5",
+      "resolved": "https://registry.npmjs.org/fake-indexeddb/-/fake-indexeddb-6.2.5.tgz",
+      "integrity": "sha512-CGnyrvbhPlWYMngksqrSSUT1BAVP49dZocrHuK0SvtR0D5TMs5wP0o3j7jexDJW01KSadjBp1M/71o/KR3nD1w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/wabt": {
+      "version": "1.0.39",
+      "resolved": "https://registry.npmjs.org/wabt/-/wabt-1.0.39.tgz",
+      "integrity": "sha512-ba+dRL/75VQQY7RkU/CgriGbkoWAfS8TDyUlJfJhJ8KhtXgMl5dhNvoPNUcQ9IWRhW8u41glMSuZeTvsYq2rRg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "wasm-decompile": "bin/wasm-decompile",
+        "wasm-interp": "bin/wasm-interp",
+        "wasm-objdump": "bin/wasm-objdump",
+        "wasm-stats": "bin/wasm-stats",
+        "wasm-strip": "bin/wasm-strip",
+        "wasm-validate": "bin/wasm-validate",
+        "wasm2c": "bin/wasm2c",
+        "wasm2wat": "bin/wasm2wat",
+        "wat2wasm": "bin/wat2wasm"
+      }
+    }
+  }
+}

--- a/specs/048-semver-publishing-pipeline/spec.md
+++ b/specs/048-semver-publishing-pipeline/spec.md
@@ -2,9 +2,9 @@
 
 **Feature Branch**: `048-semver-publishing-pipeline`
 **Created**: 2026-07-03
-**Amended**: 2026-09-05
+**Amended**: 2026-09-09
 **Status**: Approved
-**Version**: 1.1.0
+**Version**: 1.2.0
 **Input**: Cargo.toml workspace version has drifted from the git tag (0.5.0 in Cargo.toml, v0.7.0 tagged). No crates.io publishing is configured. No automated version bump exists. `repository` field still points to old org URL. This spec closes all three gaps.
 
 ## Purpose
@@ -58,6 +58,23 @@ As a crates.io consumer, I want the `repository` and `homepage` fields in publis
 1. **Given** `Cargo.toml` workspace package, **When** `grep repository Cargo.toml` runs, **Then** it prints `https://github.com/traverse-framework/Traverse`.
 2. **Given** a published crate on crates.io, **When** the metadata is inspected, **Then** `repository` resolves to `https://github.com/traverse-framework/Traverse`.
 
+### User Story 5 — Web embedder publication uses npm Trusted Publishing (Priority: P0)
+
+As a web consumer, I want `traverse-embedder-web` releases published from a
+reviewed `web-v<version>` tag using GitHub OIDC, so that publication is
+reproducible and never depends on a long-lived npm token.
+
+**Acceptance Scenarios**:
+
+1. **Given** `web-v0.9.0` is pushed and the package version is `0.9.0`, **When**
+   the web publish workflow runs, **Then** it publishes exactly `0.9.0` with a
+   provenance attestation.
+2. **Given** a `web-v*` tag whose version differs from `package.json`, **When**
+   the workflow runs, **Then** its version guard fails before any publication.
+3. **Given** the same web tag is rerun after publication, **When** npm reports
+   that version already exists, **Then** the workflow succeeds without replacing
+   the published artifact.
+
 ## Functional Requirements
 
 - **FR-001**: `[workspace.package]` in `Cargo.toml` MUST have `repository = "https://github.com/traverse-framework/Traverse"`.
@@ -70,6 +87,9 @@ As a crates.io consumer, I want the `repository` and `homepage` fields in publis
 - **FR-008**: After `bump_version.sh`, running `cargo build` MUST succeed without manual intervention, and `cargo metadata --locked` (equivalently `cargo build --locked`) MUST succeed with no further change to `Cargo.lock`.
 - **FR-009**: `bump_version.sh` MUST stage `Cargo.toml` and `Cargo.lock` together in the single `chore: bump version to v<version>` commit, so the tree is tag-ready in one step with no follow-up lockfile-sync commit.
 - **FR-010**: CI MUST fail a `Cargo.toml`/`Cargo.lock` version drift before the `publish` job runs. The `version-guard` job MUST run `cargo metadata --locked` on every `push`, `pull_request`, and `v*` tag, and `publish` MUST depend on `version-guard`.
+- **FR-011**: A dedicated workflow MUST trigger only for `web-v*` tags and publish `packages/web/TraverseEmbedder` through npm Trusted Publishing with `id-token: write` and `contents: read`; it MUST NOT reference `NPM_TOKEN` or `NODE_AUTH_TOKEN`.
+- **FR-012**: The web workflow MUST use a committed npm lockfile, run `npm ci`, validate that `web-v<version>` exactly matches `package.json`, build, test, and publish with `npm publish --provenance --access public`.
+- **FR-013**: Web publication reruns MUST be idempotent: an already-published exact version is a successful no-op. The release runbook MUST document the OIDC model, `web-v<version>` tag creation, and post-publish verification.
 
 ## Non-Functional Requirements
 
@@ -86,7 +106,10 @@ As a crates.io consumer, I want the `repository` and `homepage` fields in publis
   independently of the release pipeline)
 - `scripts/ci/bump_version.sh` (new)
 - `.github/workflows/ci.yml` (version-guard job, publish job)
-- `docs/release-process.md` (new — documents the full release sequence)
+- `.github/workflows/web-embedder-publish.yml` (web tag publication)
+- `packages/web/TraverseEmbedder/package.json` and `package-lock.json` (web release identity and locked dependencies)
+- `packages/web/TraverseEmbedder/.npmrc` (web tag prefix)
+- `docs/release-process.md` and `docs/web-embedder-npm-publish-runbook.md` (release documentation)
 
 ## Amendment History
 
@@ -106,3 +129,14 @@ files) and FR-010 (`version-guard` runs `cargo metadata --locked` on every
 push, PR, and tag; `publish` depends on it). `Cargo.lock` documented under
 Files Governed but deliberately left out of the `governs` prefix list. No
 change to the publish flow, crate list, or version-bump interface.
+
+### 1.2.0 — 2026-09-09
+
+**Owner**: Traverse maintainers (issue #1316). **Rationale**: the public web
+embedder needs a governed release path that does not rely on an expiring
+personal npm credential.
+
+**Changes**: adds npm Trusted Publishing as a second, independent publication
+target. `web-v<version>` tags bind an exact package version, a committed lockfile
+makes installation reproducible, and provenance is attached by npm. This is
+additive: the crate publishing interface and `v<version>` tags are unchanged.

--- a/specs/governance/approved-specs.json
+++ b/specs/governance/approved-specs.json
@@ -342,7 +342,7 @@
     },
     {
       "id": "033-http-json-api",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "status": "approved",
       "immutable": true,
       "path": "specs/033-http-json-api/spec.md",
@@ -540,7 +540,10 @@
         "scripts/ci/bump_version.sh",
         "scripts/ci/publish_crates.sh",
         ".github/workflows/ci.yml",
-        "docs/release-process.md"
+        ".github/workflows/web-embedder-publish.yml",
+        "packages/web/TraverseEmbedder/",
+        "docs/release-process.md",
+        "docs/web-embedder-npm-publish-runbook.md"
       ]
     },
     {


### PR DESCRIPTION
## Summary

Adds governed npm Trusted Publishing for `traverse-embedder-web`, including the `web-v<version>` release-tag guard, OIDC provenance publishing, reproducible locked installs, and release documentation.

## Governing Spec

Spec `048-semver-publishing-pipeline` v1.2.0 (amended by this PR); Decision 72 and issue #1316.

## Project Item

Traverse Project 1 issue #1316, In Progress.

## Definition of Done

- [x] Spec 048 and approved-spec registry record the npm Trusted Publishing surface.
- [x] `web-v*` workflow validates package/tag identity and publishes with OIDC provenance without npm secrets.
- [x] A committed web package lockfile supports `npm ci`.
- [x] Runbooks document the release, verification, and #1314 configuration dependency.

## Validation

- `cd packages/web/TraverseEmbedder && npm ci && npm test` (65 passing)
- matching and mismatched `web-v<version>` guard conditions checked locally
- workflow YAML parses successfully
- `bash scripts/ci/spec_alignment_check.sh /private/tmp/traverse-1316-pr-body.md`
