### PR TITLE
fix(ci): upgrade npm to 11.x in web embedder publish for OIDC trusted publishing

### DIFF
--- a/.github/workflows/web-embedder-publish.yml
+++ b/.github/workflows/web-embedder-publish.yml
@@ -23,6 +23,11 @@ jobs:
         with:
           node-version: 22
           registry-url: https://registry.npmjs.org
+      - name: Upgrade npm for OIDC trusted publishing
+        # Node 22 ships npm 10.x; OIDC trusted publishing (credential-less
+        # `npm publish`) requires npm >= 11.5.1. Without this the publish PUT
+        # is unauthenticated and the registry returns a misleading E404.
+        run: npm install -g npm@11
       - name: Install locked dependencies
         run: npm ci
       - name: Verify release tag matches package version


### PR DESCRIPTION
## Summary

One-line CI fix: add `npm install -g npm@11` after **Set up Node** in
`.github/workflows/web-embedder-publish.yml`.

## Why

The `web-v0.9.0` publish run
([34402216405](https://github.com/traverse-framework/traverse/actions/runs/34402216405))
failed at **Publish with provenance**:

```
npm error code E404
npm error 404 Not Found - PUT https://registry.npmjs.org/traverse-embedder-web
npm error 404  'traverse-embedder-web@0.9.0' is not in this registry.
```

`actions/setup-node@v7` + `node-version: 22` provides **npm 10.9.8**. npm's OIDC
trusted-publishing support (credential-less `npm publish`) landed in **npm
11.5.1**. On npm 10 the publish `PUT` is unauthenticated and the registry
answers with a misleading `E404` instead of `401/403`. The provenance statement
was signed and logged fine — that path uses the GitHub Actions OIDC token
directly, not the npm CLI's trusted-publishing exchange.

Every earlier step (`npm ci`, tag/version guard, build, test) passed; the tag
`web-v0.9.0` is on `main@90a9cd4` and `package.json` is already `0.9.0`.

## Governing Spec

- `048-semver-publishing-pipeline`

`048` (approved/immutable, v1.2.0) governs
`.github/workflows/web-embedder-publish.yml`. This change is a bugfix that makes
048 v1.2.0's already-approved "OIDC + provenance" publish scenario executable; it
does not alter what the spec requires, so no amendment.

## Project Item

#1314 (claimed `agent:claude`, In Progress). This unblocks its DoD item
"the `Publish web embedder` workflow run for that tag is green".

## Definition of Done

- [x] `web-embedder-publish.yml` upgrades npm to `>= 11.5.1` before the publish
      step.
- [ ] Re-run of the `web-v0.9.0` job is green and `npm view traverse-embedder-web
      version` → `0.9.0` with a provenance attestation. *(verified post-merge)*

## Validation

- `BASE_SHA=origin/main bash scripts/ci/local_preflight.sh --pr-body <body>`
  → exit 0.
- Post-merge: `gh run rerun 34402216405` (or re-push the tag) → job green →
  npm shows `0.9.0` as `latest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
