### PR TITLE
docs: approve app availability lifecycle governance

### DIFF
--- a/docs/adr/0066-server-owned-application-availability.md
+++ b/docs/adr/0066-server-owned-application-availability.md
@@ -1,0 +1,45 @@
+# ADR-0066: Server-Owned Application Availability
+
+- Status: Accepted
+- Date: 2026-09-09
+- Governing spec: `133-app-availability-lifecycle` (Proposed)
+- Related issue: #1324
+
+## Context
+
+Runtime execution state and a manifest's business workflow do not answer
+whether `serve` has materialized a registered app. Reopening an unresolved
+source manifest caused Registry-backed apps to disappear silently despite
+successful registration.
+
+## Decision
+
+Adopt a third, server-owned model with exactly `loading`, `ready`, and
+`failed`. Its only v1 transitions are `loading → ready` and `loading → failed`.
+Retain transition evidence only for the active process; expose it through
+structured diagnostics and a read-only app-status endpoint. Read persisted,
+resolved registration state rather than source manifests. WASM remains
+demand-loaded and per-invocation verified.
+
+## Consequences
+
+The model makes app materialization observable without coupling business
+workflows to server health or making startup compile every declared capability.
+It adds no reload, degradation, durable lifecycle journal, or Registry fetch
+path. A failed registered app is `503 app_unavailable`, never silently 404.
+
+## Alternatives Considered
+
+- Fold availability into runtime lifecycle — rejected: its ownership and scope
+  differ from one execution attempt.
+- Fold it into app workflow — rejected: an app cannot authoritatively report
+  a state machine that failed before it was loaded.
+- Fail all `serve` startup for one app — rejected: unrelated valid apps remain
+  usable.
+- Re-resolve source manifests at startup — rejected: duplicates admission,
+  risks mutable drift, and scales poorly for large apps.
+
+## Approval Evidence
+
+Enrico approved this ADR and Spec `133-app-availability-lifecycle` on
+2026-09-09 in the governing brainstorm for Traverse #1324.

--- a/docs/decision-log.md
+++ b/docs/decision-log.md
@@ -3462,6 +3462,29 @@ execution:
 3. `#1319` Blocked until `traverse-registry 0.20.0` is on crates.io, then the
    CLI/embedder/runtime upgrade to the batch preparation API proceeds.
 
+## Decision 78: Server-Owned Application Availability Lifecycle
+
+- **Date**: 2026-09-09
+- **Status**: Accepted
+- **Related issue**: `#1324`
+- **Governing artifacts**: Spec `133-app-availability-lifecycle`; ADR-0066
+
+### Decision
+
+Keep runtime execution lifecycle, application business workflow, and server-owned
+application availability distinct. The initial availability model is closed:
+`loading → ready` and `loading → failed` are its only transitions. Transition
+evidence is structured and retained only for the active `serve` process.
+
+`ready` is based on persisted, resolved registration state, not source-manifest
+resolution or process-wide WASM preloading. First-use capability failures stay
+command-scoped. A read-only app-status endpoint and structured startup evidence
+make the state observable without a durable lifecycle journal.
+
+### Approval
+
+Approved by Enrico during the #1324 governing brainstorm on 2026-09-09.
+
 ## Decision 77: Final Unblock Path for `#1314` / `#1308` — Config, Then Ops Cuts `web-v0.9.0`
 
 - **Date**: 2026-09-09

--- a/specs/133-app-availability-lifecycle/spec.md
+++ b/specs/133-app-availability-lifecycle/spec.md
@@ -1,0 +1,99 @@
+# Feature Specification: Server-Owned Application Availability Lifecycle
+
+**Status**: Approved
+**Canonical governing ID**: `133-app-availability-lifecycle`
+**Extends**: `046-public-cli-app-registration`, `052-app-state-machine`, `033-http-json-api`
+**Decision evidence**: Traverse #1324, decisions D1–D10
+
+## Purpose
+
+Define the server-owned availability of a registered workspace application. This
+model tells operators and HTTP clients whether `traverse-cli serve` has
+materialized a persisted, resolved app declaration and may accept app commands.
+It is distinct from the fixed runtime execution lifecycle and the app's
+manifest-defined business workflow.
+
+## Scope
+
+This spec governs `traverse-cli serve` startup evidence and a read-only
+workspace app-status endpoint. It introduces no capability, event, network
+fetch, state mutation, reload operation, or durable availability journal.
+
+## State Model
+
+The complete v1 vocabulary is `loading`, `ready`, and `failed`.
+
+| From | To | Stable reason |
+| --- | --- | --- |
+| `loading` | `ready` | `persisted_app_state_loaded` |
+| `loading` | `failed` | a documented app-state materialization reason |
+
+No other transition is valid. `ready` and `failed` are terminal for one
+server-process load attempt. Restarting `serve`, or a future governed reload,
+begins a new attempt at `loading`. Command-time capability failures do not
+alter app availability.
+
+## Functional Requirements
+
+- **FR-001**: `serve` MUST model runtime execution lifecycle, application
+  business workflow, and application availability as distinct owned models.
+- **FR-002**: For every registered workspace app, `serve` MUST create one
+  load attempt and record every permitted availability transition.
+- **FR-003**: `ready` MUST mean that the persisted resolved app declaration
+  and state machine are valid and usable, and that declared components were
+  admitted into verified local workspace state. It MUST NOT require all WASM
+  modules to have been read, compiled, or instantiated in that process.
+- **FR-004**: A missing, malformed, incompatible, or unmaterializable
+  persisted declaration MUST produce `failed`; it MUST NOT silently omit the
+  app or report it as unregistered.
+- **FR-005**: Each transition record MUST contain schema version, workspace
+  id, app id, load-attempt id, prior state, next state, timestamp, and a
+  stable secret-free reason code. Failed evidence MAY contain a redacted
+  message, but MUST NOT expose private paths, Registry URLs, artifact bytes,
+  configuration values, or secrets.
+- **FR-006**: `serve` MUST emit the records as structured startup/server
+  diagnostics and retain their ordered sequence in process memory for the
+  active process lifetime. It MUST NOT persist or restore lifecycle history.
+- **FR-007**: `GET /v1/workspaces/{workspace}/apps/status` MUST return the
+  current availability and ordered transition history for every registered
+  app visible to the caller. Its authorization policy MUST match protected
+  workspace read endpoints; unauthorized callers receive no app evidence.
+- **FR-008**: The endpoint MUST distinguish an absent workspace/app from a
+  registered failed app. A registered failed app remains observable with its
+  failure reason code.
+- **FR-009**: A command addressed to a registered failed app MUST return
+  `503 app_unavailable` with the stable diagnostic; it MUST NOT return
+  `404 app_not_registered`.
+- **FR-010**: `serve` startup and command execution MUST NOT fetch, sync,
+  resolve mutable Registry references, or mutate workspace state to determine
+  availability.
+
+## Compatibility and Non-goals
+
+This is additive to existing runtime and app-state-machine contracts. It does
+not add `degraded`, hot reload, disable/suspend/recover operations, app-defined
+availability values, a durable status journal, lazy Registry resolution, or
+general lazy capability-registry reconstruction. A legacy local registration
+that lacks required persisted resolved state requires explicit re-registration;
+no source-manifest fallback or automatic migration is permitted.
+
+## Acceptance Scenarios
+
+1. A valid persisted app transitions `loading → ready`; the endpoint and
+   startup evidence report the same ordered record.
+2. A malformed persisted declaration transitions `loading → failed`; the app
+   is visible through status and its command returns `503 app_unavailable`.
+3. A missing/tampered capability on first invocation fails only that command
+   with a secret-free capability diagnostic; the app remains `ready`.
+4. A restart creates a new load-attempt id and new in-memory history without
+   restoring the previous attempt's transition records.
+5. Unauthorized callers cannot obtain app availability or transition evidence.
+
+## Quality Gates
+
+- **QG-001**: Unit coverage proves the closed transition table and rejection
+  of every undeclared transition.
+- **QG-002**: HTTP conformance covers ready, failed, `503`, authorization,
+  redaction, ordering, and restart semantics on supported host OSes.
+- **QG-003**: Tests prove startup and command handling make no network call
+  and perform no Registry sync or workspace mutation.

--- a/specs/governance/approved-specs.json
+++ b/specs/governance/approved-specs.json
@@ -1812,6 +1812,18 @@
         "specs/132-stateful-browser-placement/",
         "docs/adr/0065-stateful-browser-placement.md"
       ]
+    },
+    {
+      "id": "133-app-availability-lifecycle",
+      "version": "1.0.0",
+      "status": "approved",
+      "immutable": true,
+      "path": "specs/133-app-availability-lifecycle/spec.md",
+      "governs": [
+        "crates/traverse-cli/src/http_api.rs",
+        "specs/133-app-availability-lifecycle/",
+        "docs/adr/0066-server-owned-application-availability.md"
+      ]
     }
   ]
 }


### PR DESCRIPTION
Closes #1324

## Governing Spec

- `133-app-availability-lifecycle`
- `004-spec-alignment-gate`
- `023-browser-hosted-mcp-consumer-model`

## Project Item

- Traverse Project 1: #1324

## Governing Outcome

Adds approved Spec 133 and ADR-0066 for server-owned application availability,
recording Decisions D1–D10 from #1324.

## Validation

- `jq empty specs/governance/approved-specs.json`
- `git diff --check`

## Approval evidence

Enrico explicitly approved the proposed spec and ADR on 2026-09-09.
