### PR TITLE
docs: approve lazy registry reconstruction governance

### DIFF
--- a/docs/adr/0067-lazy-capability-registry-reconstruction.md
+++ b/docs/adr/0067-lazy-capability-registry-reconstruction.md
@@ -1,0 +1,36 @@
+# ADR-0067: Lazy Capability-Registry Reconstruction
+
+- Status: Accepted
+- Date: 2026-09-09
+- Governing spec: `134-lazy-capability-registry-reconstruction` (Proposed)
+- Related issue: #1328
+
+## Context
+
+Workspace startup currently reconstructs all component contract registrations.
+Large applications pay this cost even when most capabilities are unused.
+
+## Decision
+
+Use an immutable persisted metadata index at startup and hydrate verified
+contracts on demand. Cache successful hydration in a bounded process-local LRU
+and coalesce concurrent first use per immutable key. Keep failures
+command/workflow-scoped, workflows just-in-time by reached step, and updates
+restart-only.
+
+## Consequences
+
+Startup cost avoids full contract reconstruction while retaining all routing,
+policy, placement, authorization, and workflow-reference facts eagerly. No
+Registry network operation, automatic reload, or persisted cache is introduced.
+
+## Alternatives Considered
+
+- Eagerly reconstruct every contract — rejected for large-app startup cost.
+- Author-selected eager/lazy modes — rejected as premature readiness policy.
+- Automatic file-watch reload — rejected for snapshot/cache races.
+
+## Approval Evidence
+
+Enrico approved this ADR and Spec 134 on 2026-09-09 during the #1328
+governing brainstorm.

--- a/specs/134-lazy-capability-registry-reconstruction/spec.md
+++ b/specs/134-lazy-capability-registry-reconstruction/spec.md
@@ -1,0 +1,66 @@
+# Feature Specification: Lazy Capability-Registry Reconstruction
+
+**Status**: Approved
+**Canonical governing ID**: `134-lazy-capability-registry-reconstruction`
+**Extends**: `046-public-cli-app-registration`, `133-app-availability-lifecycle`
+**Decision evidence**: Traverse #1328 decisions D1–D7
+
+## Purpose
+
+Make large registered applications responsive at `serve` startup without
+weakening trusted admission, deterministic discovery, workflow validation, or
+per-invocation artifact verification.
+
+## Model
+
+Registration remains the sole Registry-resolution admission point. At startup,
+`serve` loads one immutable workspace snapshot and an eager trusted metadata
+index. The index contains component/app identity and versions, capability id,
+contract/artifact digests and references, workflow references, and every
+immutable routing, placement, policy, and authorization fact needed before
+contract hydration. It excludes contract bodies/schemas and WASM bytes.
+
+## Requirements
+
+- **FR-001**: Startup MUST build the index solely from persisted resolved
+  workspace registration state. It MUST NOT fetch, sync, resolve mutable
+  Registry references, or mutate workspace state.
+- **FR-002**: Discovery, placement, authorization, policy, and workflow
+  topology decisions before hydration MUST use only immutable indexed facts.
+- **FR-003**: A full contract MUST be read, digest-verified, parsed, and
+  registered only when a command or reached workflow step requires it.
+- **FR-004**: Hydrated contracts MUST be stored in a host-configured bounded,
+  process-local LRU keyed by immutable capability identity and contract digest.
+  Only successful verified hydrations enter the cache; eviction is safe and
+  deterministic. The cache is not persisted or app-configurable.
+- **FR-005**: Concurrent hydration for one key MUST be single-flight. Waiters
+  receive the leader outcome. Failures MUST NOT be negatively cached.
+- **FR-006**: Missing, corrupt, or digest-mismatched contract/artifact state
+  discovered while hydrating MUST fail only the dependent command/workflow with
+  a stable secret-free diagnostic. It MUST NOT alter app availability.
+- **FR-007**: Workflows MUST validate topology and capability identities from
+  the index at startup, and hydrate only reached steps. Hydration failure ends
+  that execution with ordered trace evidence.
+- **FR-008**: A running server uses an immutable snapshot. Registration changes
+  take effect only on restart or a future governed reload operation.
+- **FR-009**: Evidence MUST distinguish index lookup, cache hit, hydration
+  leader, coalesced waiter, eviction, and hydration failure; it MUST not expose
+  private paths, secrets, Registry URLs, contract bodies, or artifact bytes.
+
+## Acceptance Scenarios
+
+1. A 100-component app starts by indexing persisted metadata without parsing
+   all contracts or loading WASM; its first selected capability hydrates once.
+2. Concurrent first use of one capability coalesces to one verified hydration.
+3. A corrupt contract fails only its command; unrelated indexed capabilities
+   remain usable.
+4. A branching workflow does not hydrate unreached branches.
+5. Re-registration during a running process has no effect until restart.
+
+## Quality Gates and Non-goals
+
+Conformance MUST cover cache bounds/eviction, concurrency, trace ordering,
+workflow behavior, redaction, restart snapshots, and supported host OSes.
+This spec excludes developer-selected load modes, dynamic dependency injection,
+negative caching, hot reload, durable cache/history, network Registry access,
+and degraded/optional app lifecycle semantics.

--- a/specs/governance/approved-specs.json
+++ b/specs/governance/approved-specs.json
@@ -1824,6 +1824,19 @@
         "specs/133-app-availability-lifecycle/",
         "docs/adr/0066-server-owned-application-availability.md"
       ]
+    },
+    {
+      "id": "134-lazy-capability-registry-reconstruction",
+      "version": "1.0.0",
+      "status": "approved",
+      "immutable": true,
+      "path": "specs/134-lazy-capability-registry-reconstruction/spec.md",
+      "governs": [
+        "crates/traverse-runtime/",
+        "crates/traverse-cli/src/http_api.rs",
+        "specs/134-lazy-capability-registry-reconstruction/",
+        "docs/adr/0067-lazy-capability-registry-reconstruction.md"
+      ]
     }
   ]
 }


### PR DESCRIPTION
Closes #1328

## Governing Spec

- `134-lazy-capability-registry-reconstruction`
- `004-spec-alignment-gate`

## Project Item

- Traverse Project 1: #1328

## Validation

- `jq empty specs/governance/approved-specs.json`
- `git diff --check`

## Approval evidence

Enrico explicitly approved Spec 134 and ADR-0067 on 2026-09-09.
