### PR TITLE
fix(cli): serve Registry-backed app commands from persisted state machines

### DIFF
--- a/crates/traverse-cli/src/http_api.rs
+++ b/crates/traverse-cli/src/http_api.rs
@@ -2,9 +2,10 @@ use crate::app_events_websocket::{
     handle_app_events_websocket, is_websocket_upgrade, write_sse_retired_response,
 };
 use crate::app_runtime_events::{
-    APP_EVENT_TYPES, AppEventLogEntry, AppSessionEvent, collect_app_runtime_events,
-    publish_app_runtime_event, runtime_with_app_event_broker,
+    APP_EVENT_TYPES, AppEventLogEntry, AppSessionEvent, build_app_event_broker,
+    collect_app_runtime_events, publish_app_runtime_event, runtime_with_app_event_broker,
 };
+use crate::workspace_app_materialization::{AppLoadFailure, materialize_workspace_apps};
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use sha2::{Digest, Sha256};
@@ -24,13 +25,13 @@ use traverse_mcp::tools::proposals::{
     execute_proposal_via_mcp, submit_proposal, validate_proposal,
 };
 use traverse_registry::{
-    ApplicationStateMachine, ApplicationStateTransition, ApplicationStateTransitionCondition,
-    ApplicationStateTransitionConditionOp, ArtifactDigests, BinaryFormat, BinaryReference,
-    CapabilityArtifactRecord, CapabilityRegistration, CapabilityRegistry, ComposabilityMetadata,
-    CompositionKind, CompositionPattern, DiscoveryQuery, EventRegistration, EventRegistry,
-    ImplementationKind, LookupScope, RegistryProvenance, RegistryScope, SourceKind,
-    SourceReference, WorkflowDefinition, WorkflowRegistration, WorkflowRegistry,
-    WorkspaceAppStateErrorCode, load_application_bundle_manifest,
+    ApplicationBundleManifest, ApplicationStateMachine, ApplicationStateTransition,
+    ApplicationStateTransitionCondition, ApplicationStateTransitionConditionOp, ArtifactDigests,
+    BinaryFormat, BinaryReference, CapabilityArtifactRecord, CapabilityRegistration,
+    CapabilityRegistry, ComposabilityMetadata, CompositionKind, CompositionPattern, DiscoveryQuery,
+    EventRegistration, EventRegistry, ImplementationKind, LookupScope, RegistryProvenance,
+    RegistryScope, SourceKind, SourceReference, WorkflowDefinition, WorkflowRegistration,
+    WorkflowRegistry, WorkspaceAppStateErrorCode,
 };
 use traverse_runtime::proposal::{ApprovalTokenStore, QuotaLimits, QuotaTracker};
 use traverse_runtime::security::RuntimeSecurityConfig;
@@ -215,6 +216,8 @@ pub(crate) struct WorkspaceState<E> {
     pub(crate) app_event_log: Vec<AppEventLogEntry>,
     app_list_context_fields: HashMap<String, Vec<String>>,
     app_state_machines: HashMap<String, ApplicationStateMachine>,
+    app_load_failures: HashMap<String, AppLoadFailure>,
+    app_proposal_manifests: HashMap<String, ApplicationBundleManifest>,
     runtime_grants: Vec<RuntimeGrantRecord>,
 }
 
@@ -280,6 +283,8 @@ fn new_workspace_state<E: LocalExecutor + Clone>(
         app_event_log: Vec::new(),
         app_list_context_fields: HashMap::new(),
         app_state_machines: HashMap::new(),
+        app_load_failures: HashMap::new(),
+        app_proposal_manifests: HashMap::new(),
         runtime_grants: Vec::new(),
     })
 }
@@ -3069,15 +3074,34 @@ fn load_workspace_app_runtime<E: LocalExecutor + Clone>(
         env!("CARGO_PKG_VERSION"),
     ) {
         Ok(runtime) => {
-            let runtime = runtime.with_usage_telemetry_sink(std::sync::Arc::from(
-                crate::telemetry::wire_usage_telemetry_sink(),
-            ));
-            let machines = load_workspace_app_state_machines(workspace_root, &runtime);
-            ws.app_list_context_fields = machines
-                .iter()
-                .map(|(app_id, machine)| (app_id.clone(), machine.list_context_fields.clone()))
-                .collect();
+            let runtime = runtime
+                .with_security_config(runtime_security_for_auth_mode(&state.auth_mode))
+                .with_event_broker(build_app_event_broker()?)
+                .with_usage_telemetry_sink(std::sync::Arc::from(
+                    crate::telemetry::wire_usage_telemetry_sink(),
+                ));
+            let materialized = materialize_workspace_apps(runtime.workspace_applications());
+            let mut machines = HashMap::new();
+            let mut failures = HashMap::new();
+            let mut proposal_manifests = HashMap::new();
+            let mut list_context_fields = HashMap::new();
+            for loaded in materialized {
+                if let Some(machine) = loaded.machine {
+                    list_context_fields
+                        .insert(loaded.app_id.clone(), machine.list_context_fields.clone());
+                    machines.insert(loaded.app_id.clone(), machine);
+                }
+                if let Some(failure) = loaded.failure {
+                    failures.insert(loaded.app_id.clone(), failure);
+                }
+                if let Some(manifest) = loaded.proposal_manifest {
+                    proposal_manifests.insert(loaded.app_id.clone(), manifest);
+                }
+            }
+            ws.app_list_context_fields = list_context_fields;
             ws.app_state_machines = machines;
+            ws.app_load_failures = failures;
+            ws.app_proposal_manifests = proposal_manifests;
             ws.runtime = runtime;
             Ok(())
         }
@@ -3096,27 +3120,41 @@ fn load_workspace_app_runtime<E: LocalExecutor + Clone>(
     }
 }
 
-fn load_workspace_app_state_machines<E: LocalExecutor>(
-    workspace_root: &Path,
-    runtime: &Runtime<E>,
-) -> HashMap<String, ApplicationStateMachine> {
-    let mut machines = HashMap::new();
-    for app in runtime.workspace_applications() {
-        let manifest_path = PathBuf::from(&app.manifest_path);
-        let manifest_path = if manifest_path.is_absolute() {
-            manifest_path
-        } else {
-            workspace_root.join(manifest_path)
-        };
-        let Ok(manifest) = load_application_bundle_manifest(&manifest_path) else {
-            continue;
-        };
-        let Some(state_machine) = manifest.state_machine else {
-            continue;
-        };
-        machines.insert(app.app_id.clone(), state_machine);
+fn app_command_surface_error<E>(
+    ws: &WorkspaceState<E>,
+    workspace_id: &str,
+    app_id: &str,
+) -> (u16, &'static str, Value) {
+    if let Some(failure) = ws.app_load_failures.get(app_id) {
+        return (
+            failure.status,
+            failure.reason,
+            error_envelope(failure.code, &failure.message),
+        );
     }
-    machines
+    let registered = ws
+        .runtime
+        .workspace_applications()
+        .iter()
+        .any(|app| app.app_id == app_id);
+    if registered {
+        return (
+            503,
+            "Service Unavailable",
+            error_envelope(
+                "app_unavailable",
+                "registered app is unavailable for command dispatch",
+            ),
+        );
+    }
+    (
+        404,
+        "Not Found",
+        error_envelope(
+            "app_not_registered",
+            &format!("app '{app_id}' is not registered in workspace '{workspace_id}'"),
+        ),
+    )
 }
 
 fn render_workspace_app_state_failure(
@@ -5838,37 +5876,31 @@ fn handle_app_proposals<W: Write, E: LocalExecutor + Clone>(
     };
 
     let result = state.with_workspace_mut(workspace_id, |ws| {
-        let Some(app) = ws
+        let Some(state_path) = ws
             .runtime
             .workspace_applications()
             .iter()
             .find(|app| app.app_id == app_id)
+            .map(|app| app.state_path.clone())
         else {
+            return Ok(app_command_surface_error(ws, workspace_id, app_id));
+        };
+        if !ws.app_state_machines.contains_key(app_id) {
+            return Ok(app_command_surface_error(ws, workspace_id, app_id));
+        }
+        let Some(manifest) = ws.app_proposal_manifests.get(app_id).cloned() else {
             return Ok((
-                404,
-                "Not Found",
+                503,
+                "Service Unavailable",
                 error_envelope(
-                    "app_not_registered",
-                    "app is not registered in this workspace",
+                    "app_unavailable",
+                    "persisted application declaration cannot be materialized",
                 ),
             ));
         };
-        let manifest_path = PathBuf::from(&app.manifest_path);
-        let workspace_root = state
-            .registry_root
-            .parent()
-            .and_then(Path::parent)
-            .unwrap_or_else(|| Path::new("."));
-        let manifest_path = if manifest_path.is_absolute() {
-            manifest_path
-        } else {
-            workspace_root.join(manifest_path)
-        };
-        let manifest = load_application_bundle_manifest(&manifest_path)
-            .map_err(|_| "registered application manifest is unavailable".to_string())?;
         let proposal_json = parsed.proposal.to_string();
         let limits = ProposalLimits::default();
-        let snapshots = proposal_snapshots(&manifest_path, ws.runtime.capability_registry());
+        let snapshots = proposal_snapshots(&state_path, ws.runtime.capability_registry());
         let body = match parsed.action.as_str() {
             "validate" => serde_json::to_value(
                 validate_proposal(
@@ -6002,8 +6034,8 @@ fn parse_app_proposal_request(body: &[u8]) -> Result<AppProposalRequest, String>
     })
 }
 
-fn proposal_snapshots(manifest_path: &Path, registry: &CapabilityRegistry) -> SnapshotDigests {
-    let manifest_bytes = std::fs::read(manifest_path).unwrap_or_default();
+fn proposal_snapshots(registration_path: &Path, registry: &CapabilityRegistry) -> SnapshotDigests {
+    let manifest_bytes = std::fs::read(registration_path).unwrap_or_default();
     let digest = |bytes: &[u8]| {
         let digest = Sha256::digest(bytes);
         let mut hex = String::with_capacity(digest.len() * 2);
@@ -6071,17 +6103,7 @@ fn dispatch_app_command<E: LocalExecutor + Clone>(
     request: &AppCommandRequest,
 ) -> Result<(u16, &'static str, Value), String> {
     let Some(machine) = ws.app_state_machines.get(app_id).cloned() else {
-        return Ok((
-            404,
-            "Not Found",
-            error_envelope(
-                "app_not_registered",
-                &format!(
-                    "app '{app_id}' is not registered with a state machine \
-                     in workspace '{workspace_id}'"
-                ),
-            ),
-        ));
+        return Ok(app_command_surface_error(ws, workspace_id, app_id));
     };
 
     let (session_id, current_state) = match &request.session_id {
@@ -10535,6 +10557,114 @@ mod tests {
         body.to_string().into_bytes()
     }
 
+    fn repo_root() -> PathBuf {
+        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..")
+    }
+
+    fn persisted_state_machine(capability_id: &str) -> Value {
+        json!({
+            "initial_state": "idle",
+            "list_context_fields": [],
+            "states": [
+                {
+                    "id": "idle",
+                    "transitions": [{ "on": "submit", "to": "processing" }]
+                },
+                {
+                    "id": "processing",
+                    "invoke": {
+                        "capability_id": capability_id,
+                        "input_from": "command.payload"
+                    },
+                    "transitions": [
+                        { "on": "capability_succeeded", "to": "results" },
+                        { "on": "capability_failed", "to": "error" }
+                    ]
+                },
+                { "id": "results", "transitions": [{ "on": "reset", "to": "idle" }] },
+                { "id": "error", "transitions": [{ "on": "reset", "to": "idle" }] }
+            ]
+        })
+    }
+
+    fn write_registry_backed_registration(
+        workspace_root: &Path,
+        workspace_id: &str,
+        state_machine: Option<Value>,
+    ) -> PathBuf {
+        let repo = repo_root();
+        let component_manifest = repo.join(
+            "examples/applications/expedition-readiness/components/validate-team-readiness/component.manifest.json",
+        );
+        let contract_path = repo.join(
+            "contracts/examples/expedition/capabilities/validate-team-readiness/contract.json",
+        );
+        let artifact_path = repo.join(
+            "examples/capabilities/team-readiness-agent/artifacts/validate-team-readiness-agent.wasm",
+        );
+        let state_path = workspace_root
+            .join(".traverse/workspaces")
+            .join(workspace_id)
+            .join("apps/expedition.readiness/1.0.0/registration.json");
+        std::fs::create_dir_all(state_path.parent().expect("registration parent"))
+            .expect("registration parent must create");
+        let mut body = json!({
+            "status": "registered",
+            "workspace_id": workspace_id,
+            "app_id": "expedition.readiness",
+            "app_version": "1.0.0",
+            "schema_version": "1.0.0",
+            "manifest_path": "/nonexistent/registry-backed/app.manifest.json",
+            "manifest_digest": "sha256:test-manifest",
+            "bundle_digest": "sha256:test-bundle",
+            "components": [{
+                "component_id": "expedition.readiness.validate-team-readiness-component",
+                "component_version": "1.0.0",
+                "capability_id": "expedition.planning.validate-team-readiness",
+                "capability_version": "1.0.0",
+                "wasm_digest": "sha256:5647c39a1d25d8728350f9619025292a62e78a602068a2ad9b6f075751c93d99",
+                "manifest_path": component_manifest.display().to_string(),
+                "contract_path": contract_path.display().to_string(),
+                "artifact_ref": artifact_path.display().to_string()
+            }],
+            "workflows": [],
+            "state_scope": "workspace_persisted",
+            "registration_fingerprint": {
+                "app_id": "expedition.readiness",
+                "app_version": "1.0.0",
+                "manifest_digest": "sha256:test-manifest"
+            }
+        });
+        if let Some(state_machine) = state_machine {
+            body["state_machine"] = state_machine;
+        }
+        std::fs::write(
+            &state_path,
+            serde_json::to_vec_pretty(&body).expect("registration must serialize"),
+        )
+        .expect("registration must write");
+        state_path
+    }
+
+    fn disk_loaded_workspace_state(workspace_root: &Path) -> ApiState<TestExecutor> {
+        let registry_root = workspace_root.join(".traverse/registry");
+        std::fs::create_dir_all(&registry_root).expect("registry root must create");
+        persist_local_test_workspace(&registry_root, "ws-test");
+        ApiState {
+            auth_mode: "dev-loopback".to_string(),
+            allow_unauthenticated: true,
+            allowed_origins: Vec::new(),
+            registry_root,
+            executor: TestExecutor::ok(json!({"result": "ok"})),
+            workspaces: Mutex::new(HashMap::new()),
+            idempotency_records: Mutex::new(HashMap::new()),
+            idempotency_retention_seconds: DEFAULT_IDEMPOTENCY_RETENTION_SECONDS,
+            jwt_verification_key: None,
+            proposal_token_store: ApprovalTokenStore::new(),
+            proposal_quota_tracker: QuotaTracker::new(),
+        }
+    }
+
     #[test]
     fn app_commands_path_parses_workspace_and_app_id() {
         assert_eq!(
@@ -10646,6 +10776,117 @@ mod tests {
         assert_eq!(response_content_type(&out), "application/problem+json");
         let resp = parse_response_body(&out);
         assert_eq!(resp["traverse_code"], "app_not_registered");
+    }
+
+    #[test]
+    fn app_command_dispatches_from_persisted_registration_without_source_manifest() {
+        let workspace_root = test_registry_root();
+        write_registry_backed_registration(
+            &workspace_root,
+            "ws-test",
+            Some(persisted_state_machine(
+                "expedition.planning.validate-team-readiness",
+            )),
+        );
+        assert!(
+            !PathBuf::from("/nonexistent/registry-backed/app.manifest.json").exists(),
+            "source manifest must stay absent so serve cannot reopen it"
+        );
+        let state = disk_loaded_workspace_state(&workspace_root);
+        let req = make_http_request(
+            "POST",
+            "/v1/workspaces/ws-test/apps/expedition.readiness/commands",
+            make_app_command_body("submit", &json!({}), None),
+        );
+
+        let mut out = Vec::new();
+        handle_workspace_operation(&mut out, &req, &state, true)
+            .expect("command dispatch must write a response");
+
+        assert_eq!(response_status(&out), 202, "{}", parse_response_body(&out));
+        let resp = parse_response_body(&out);
+        assert_eq!(resp["status"], "accepted");
+        assert_eq!(resp["app_id"], "expedition.readiness");
+        assert_eq!(resp["state"], "processing");
+    }
+
+    #[test]
+    fn app_command_requires_refresh_when_persisted_state_machine_is_missing() {
+        let workspace_root = test_registry_root();
+        write_registry_backed_registration(&workspace_root, "ws-test", None);
+        let state = disk_loaded_workspace_state(&workspace_root);
+        let req = make_http_request(
+            "POST",
+            "/v1/workspaces/ws-test/apps/expedition.readiness/commands",
+            make_app_command_body("submit", &json!({}), None),
+        );
+
+        let mut out = Vec::new();
+        handle_workspace_operation(&mut out, &req, &state, true)
+            .expect("command dispatch must write a response");
+
+        assert_eq!(response_status(&out), 409);
+        let resp = parse_response_body(&out);
+        assert_eq!(resp["traverse_code"], "app_registration_requires_refresh");
+        let detail = resp["detail"].as_str().unwrap_or_default();
+        assert!(!detail.contains("/nonexistent"));
+        assert!(!detail.contains("registration.json"));
+    }
+
+    #[test]
+    fn app_command_returns_503_when_persisted_state_machine_cannot_materialize() {
+        let workspace_root = test_registry_root();
+        write_registry_backed_registration(
+            &workspace_root,
+            "ws-test",
+            Some(persisted_state_machine("not.a.registered.capability")),
+        );
+        let state = disk_loaded_workspace_state(&workspace_root);
+        let req = make_http_request(
+            "POST",
+            "/v1/workspaces/ws-test/apps/expedition.readiness/commands",
+            make_app_command_body("submit", &json!({}), None),
+        );
+
+        let mut out = Vec::new();
+        handle_workspace_operation(&mut out, &req, &state, true)
+            .expect("command dispatch must write a response");
+
+        assert_eq!(response_status(&out), 503);
+        let resp = parse_response_body(&out);
+        assert_eq!(resp["traverse_code"], "app_unavailable");
+        let detail = resp["detail"].as_str().unwrap_or_default();
+        assert!(!detail.contains("not.a.registered.capability"));
+        assert!(!detail.contains("/nonexistent"));
+    }
+
+    #[test]
+    fn app_proposals_consume_persisted_registration_instead_of_source_manifest() {
+        let workspace_root = test_registry_root();
+        write_registry_backed_registration(
+            &workspace_root,
+            "ws-test",
+            Some(persisted_state_machine(
+                "expedition.planning.validate-team-readiness",
+            )),
+        );
+        let state = disk_loaded_workspace_state(&workspace_root);
+        let req = make_http_request(
+            "POST",
+            "/v1/workspaces/ws-test/apps/expedition.readiness/proposals",
+            br#"{"action":"validate","proposal":{"nodes":[]}}"#.to_vec(),
+        );
+
+        let mut out = Vec::new();
+        handle_workspace_operation(&mut out, &req, &state, true).expect("response");
+
+        let status = response_status(&out);
+        let body = parse_response_body(&out);
+        assert_ne!(body["traverse_code"], "app_not_registered");
+        assert!(
+            status == 200 || status == 400,
+            "proposal path must use durable state, got {status}: {body}"
+        );
     }
 
     #[test]

--- a/crates/traverse-cli/src/main.rs
+++ b/crates/traverse-cli/src/main.rs
@@ -11,6 +11,7 @@ mod http_api;
 mod registry_resolution_diagnostics;
 mod supply_chain;
 mod telemetry;
+mod workspace_app_materialization;
 
 use capability_packages::load_capability_package;
 use ed25519_dalek::{Signature, Verifier, VerifyingKey};
@@ -3390,12 +3391,10 @@ impl SignatureVerifier for CliPreparationHost<'_> {
         else {
             return false;
         };
-        VerifyingKey::from_bytes(&key)
-            .map(|key| {
-                key.verify(bytes, &Signature::from_bytes(&signature))
-                    .is_ok()
-            })
-            .unwrap_or(false)
+        VerifyingKey::from_bytes(&key).is_ok_and(|key| {
+            key.verify(bytes, &Signature::from_bytes(&signature))
+                .is_ok()
+        })
     }
 }
 
@@ -10138,6 +10137,41 @@ mod tests {
             cache_root
                 .join(artifact_digest.trim_start_matches("sha256:"))
                 .exists()
+        );
+
+        assert!(
+            registration_json["state_machine"].is_object(),
+            "register must persist the resolved state machine for serve"
+        );
+        let state_path =
+            app_registration_state_path(&state_root, "local", "expedition.readiness", "1.0.0");
+        let loaded = crate::workspace_app_materialization::materialize_workspace_apps(&[
+            traverse_registry::WorkspaceApplicationRegistration {
+                app_id: "expedition.readiness".to_string(),
+                app_version: "1.0.0".to_string(),
+                manifest_path: "/nonexistent/app.manifest.json".to_string(),
+                manifest_digest: "sha256:test".to_string(),
+                bundle_digest: "sha256:test".to_string(),
+                model_dependencies: Vec::new(),
+                state_path,
+            },
+        ]);
+        assert!(
+            loaded[0].failure.is_none(),
+            "serve must materialize the persisted Registry-backed state machine"
+        );
+        let machine = loaded[0]
+            .machine
+            .as_ref()
+            .expect("persisted state machine must load");
+        assert_eq!(machine.initial_state, "idle");
+        assert_eq!(
+            machine.states[1]
+                .invoke
+                .as_ref()
+                .expect("processing invoke")
+                .capability_id,
+            "expedition.planning.validate-team-readiness"
         );
     }
 

--- a/crates/traverse-cli/src/workspace_app_materialization.rs
+++ b/crates/traverse-cli/src/workspace_app_materialization.rs
@@ -1,0 +1,525 @@
+//! Materialize persisted workspace app registration state for `serve`.
+//!
+//! Command dispatch and proposal handling consume the durable
+//! `registration.json` written by `app register`. They do not reopen or
+//! re-resolve the source application manifest.
+
+use serde::Deserialize;
+use serde_json::Value;
+use std::collections::BTreeSet;
+use std::fs;
+use std::path::{Path, PathBuf};
+use traverse_contracts::{ExecutionTarget, parse_contract};
+use traverse_registry::{
+    ApplicationBundleManifest, ApplicationComponent, ApplicationComponentRef,
+    ApplicationConnectorBinding, ApplicationEffectiveConfig, ApplicationModelDependency,
+    ApplicationState, ApplicationStateInvoke, ApplicationStateMachine, ApplicationStateTransition,
+    ApplicationStateTransitionCondition, ApplicationStateTransitionConditionOp,
+    ApplicationWorkflowRef, ComponentExecutionMode, WasmComponentManifest,
+    WorkspaceApplicationRegistration,
+};
+
+pub(crate) const APP_REGISTRATION_REQUIRES_REFRESH: &str = "app_registration_requires_refresh";
+pub(crate) const APP_UNAVAILABLE: &str = "app_unavailable";
+
+const REFRESH_MESSAGE: &str = "persisted application state machine is missing; re-register the app";
+const UNAVAILABLE_MESSAGE: &str = "persisted application state machine cannot be materialized";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct AppLoadFailure {
+    pub(crate) status: u16,
+    pub(crate) reason: &'static str,
+    pub(crate) code: &'static str,
+    pub(crate) message: String,
+}
+
+impl AppLoadFailure {
+    fn requires_refresh() -> Self {
+        Self {
+            status: 409,
+            reason: "Conflict",
+            code: APP_REGISTRATION_REQUIRES_REFRESH,
+            message: REFRESH_MESSAGE.to_string(),
+        }
+    }
+
+    fn unavailable() -> Self {
+        Self {
+            status: 503,
+            reason: "Service Unavailable",
+            code: APP_UNAVAILABLE,
+            message: UNAVAILABLE_MESSAGE.to_string(),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct MaterializedWorkspaceApp {
+    pub(crate) app_id: String,
+    pub(crate) machine: Option<ApplicationStateMachine>,
+    pub(crate) failure: Option<AppLoadFailure>,
+    pub(crate) proposal_manifest: Option<ApplicationBundleManifest>,
+}
+
+#[derive(Debug, Deserialize)]
+struct PersistedRegistration {
+    #[serde(default)]
+    app_id: String,
+    #[serde(default)]
+    app_version: String,
+    #[serde(default)]
+    schema_version: String,
+    #[serde(default)]
+    components: Vec<PersistedComponent>,
+    #[serde(default)]
+    workflows: Vec<ApplicationWorkflowRef>,
+    #[serde(default)]
+    model_dependencies: Vec<ApplicationModelDependency>,
+    #[serde(default)]
+    connector_bindings: Vec<ApplicationConnectorBinding>,
+    #[serde(default)]
+    public_surfaces: Vec<String>,
+    #[serde(default)]
+    workspace_defaults: Value,
+    #[serde(default)]
+    config_schema: Value,
+    #[serde(default)]
+    default_config: Value,
+    #[serde(default)]
+    placement_policy: Value,
+    #[serde(default)]
+    effective_config: Option<ApplicationEffectiveConfig>,
+    state_machine: Option<Value>,
+}
+
+#[derive(Debug, Deserialize)]
+struct PersistedComponent {
+    component_id: String,
+    #[serde(default)]
+    component_version: String,
+    capability_id: String,
+    #[serde(default)]
+    capability_version: String,
+    #[serde(default)]
+    wasm_digest: Option<String>,
+    #[serde(default)]
+    manifest_path: String,
+    #[serde(default)]
+    contract_path: String,
+    #[serde(default)]
+    artifact_ref: Option<String>,
+    #[serde(default)]
+    execution_mode: Option<String>,
+    #[serde(default)]
+    platforms: Vec<String>,
+    #[serde(default)]
+    wrapper_path: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct PersistedStateMachine {
+    initial_state: String,
+    #[serde(default)]
+    list_context_fields: Vec<String>,
+    states: Vec<PersistedState>,
+}
+
+#[derive(Debug, Deserialize)]
+struct PersistedState {
+    id: String,
+    invoke: Option<PersistedInvoke>,
+    #[serde(default)]
+    transitions: Vec<PersistedTransition>,
+}
+
+#[derive(Debug, Deserialize)]
+struct PersistedInvoke {
+    capability_id: String,
+    input_from: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct PersistedTransition {
+    on: String,
+    to: String,
+    #[serde(default)]
+    condition: Option<PersistedCondition>,
+    #[serde(default)]
+    with_last_payload: bool,
+}
+
+#[derive(Debug, Deserialize)]
+struct PersistedCondition {
+    field: String,
+    op: PersistedConditionOp,
+    #[serde(default)]
+    value: Option<Value>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum PersistedConditionOp {
+    Eq,
+    Neq,
+    Gt,
+    Gte,
+    Lt,
+    Lte,
+    In,
+    Exists,
+}
+
+/// Load every registered workspace app's command surface from durable state.
+pub(crate) fn materialize_workspace_apps(
+    apps: &[WorkspaceApplicationRegistration],
+) -> Vec<MaterializedWorkspaceApp> {
+    apps.iter().map(materialize_workspace_app).collect()
+}
+
+fn materialize_workspace_app(app: &WorkspaceApplicationRegistration) -> MaterializedWorkspaceApp {
+    match read_persisted_registration(&app.state_path) {
+        Ok(registration) => materialize_from_registration(app, &registration),
+        Err(()) => MaterializedWorkspaceApp {
+            app_id: app.app_id.clone(),
+            machine: None,
+            failure: Some(AppLoadFailure::unavailable()),
+            proposal_manifest: None,
+        },
+    }
+}
+
+fn read_persisted_registration(state_path: &Path) -> Result<PersistedRegistration, ()> {
+    let bytes = fs::read(state_path).map_err(|_| ())?;
+    serde_json::from_slice(&bytes).map_err(|_| ())
+}
+
+fn materialize_from_registration(
+    app: &WorkspaceApplicationRegistration,
+    registration: &PersistedRegistration,
+) -> MaterializedWorkspaceApp {
+    let registered_capabilities = registration
+        .components
+        .iter()
+        .map(|component| component.capability_id.clone())
+        .collect::<BTreeSet<_>>();
+    let proposal_manifest = reconstruct_proposal_manifest(registration);
+
+    match registration.state_machine.as_ref() {
+        None | Some(Value::Null) => MaterializedWorkspaceApp {
+            app_id: app.app_id.clone(),
+            machine: None,
+            failure: Some(AppLoadFailure::requires_refresh()),
+            proposal_manifest,
+        },
+        Some(value) => match decode_state_machine(value, &registered_capabilities) {
+            Ok(machine) => MaterializedWorkspaceApp {
+                app_id: app.app_id.clone(),
+                machine: Some(machine),
+                failure: None,
+                proposal_manifest,
+            },
+            Err(()) => MaterializedWorkspaceApp {
+                app_id: app.app_id.clone(),
+                machine: None,
+                failure: Some(AppLoadFailure::unavailable()),
+                proposal_manifest,
+            },
+        },
+    }
+}
+
+fn decode_state_machine(
+    value: &Value,
+    registered_capabilities: &BTreeSet<String>,
+) -> Result<ApplicationStateMachine, ()> {
+    let persisted: PersistedStateMachine = serde_json::from_value(value.clone()).map_err(|_| ())?;
+    if persisted.initial_state.trim().is_empty() || persisted.states.is_empty() {
+        return Err(());
+    }
+    let state_ids = persisted
+        .states
+        .iter()
+        .map(|state| state.id.clone())
+        .collect::<BTreeSet<_>>();
+    if state_ids.len() != persisted.states.len() || !state_ids.contains(&persisted.initial_state) {
+        return Err(());
+    }
+    let mut states = Vec::new();
+    for state in persisted.states {
+        if let Some(invoke) = &state.invoke
+            && !registered_capabilities.contains(&invoke.capability_id)
+        {
+            return Err(());
+        }
+        states.push(ApplicationState {
+            id: state.id,
+            invoke: state.invoke.map(|invoke| ApplicationStateInvoke {
+                capability_id: invoke.capability_id,
+                input_from: invoke.input_from,
+            }),
+            transitions: state
+                .transitions
+                .into_iter()
+                .map(application_state_transition)
+                .collect(),
+        });
+    }
+    Ok(ApplicationStateMachine {
+        initial_state: persisted.initial_state,
+        list_context_fields: persisted.list_context_fields,
+        states,
+    })
+}
+
+fn application_state_transition(transition: PersistedTransition) -> ApplicationStateTransition {
+    ApplicationStateTransition {
+        on: transition.on,
+        to: transition.to,
+        condition: transition
+            .condition
+            .map(|condition| ApplicationStateTransitionCondition {
+                field: condition.field,
+                op: match condition.op {
+                    PersistedConditionOp::Eq => ApplicationStateTransitionConditionOp::Eq,
+                    PersistedConditionOp::Neq => ApplicationStateTransitionConditionOp::Neq,
+                    PersistedConditionOp::Gt => ApplicationStateTransitionConditionOp::Gt,
+                    PersistedConditionOp::Gte => ApplicationStateTransitionConditionOp::Gte,
+                    PersistedConditionOp::Lt => ApplicationStateTransitionConditionOp::Lt,
+                    PersistedConditionOp::Lte => ApplicationStateTransitionConditionOp::Lte,
+                    PersistedConditionOp::In => ApplicationStateTransitionConditionOp::In,
+                    PersistedConditionOp::Exists => ApplicationStateTransitionConditionOp::Exists,
+                },
+                value: condition.value,
+            }),
+        with_last_payload: transition.with_last_payload,
+    }
+}
+
+fn reconstruct_proposal_manifest(
+    registration: &PersistedRegistration,
+) -> Option<ApplicationBundleManifest> {
+    let mut components = Vec::new();
+    for component in &registration.components {
+        let contents = fs::read_to_string(&component.contract_path).ok()?;
+        let contract = parse_contract(&contents).ok()?;
+        let execution_mode = match component.execution_mode.as_deref() {
+            Some("compatible") => ComponentExecutionMode::Compatible,
+            _ => ComponentExecutionMode::Wasm,
+        };
+        components.push(ApplicationComponent {
+            reference: ApplicationComponentRef {
+                component_id: component.component_id.clone(),
+                version: component.component_version.clone(),
+                digest: component.wasm_digest.clone().unwrap_or_default(),
+                manifest_path: component.manifest_path.clone(),
+            },
+            manifest_path: Path::new(&component.manifest_path).to_path_buf(),
+            manifest: WasmComponentManifest {
+                component_id: component.component_id.clone(),
+                version: component.component_version.clone(),
+                schema_version: registration.schema_version.clone(),
+                execution_mode,
+                capability_id: component.capability_id.clone(),
+                capability_version: component.capability_version.clone(),
+                contract_path: Some(component.contract_path.clone()),
+                registry_ref: None,
+                wasm_binary_path: component.artifact_ref.clone(),
+                wasm_digest: component.wasm_digest.clone(),
+                platforms: component.platforms.clone(),
+                wrapper_path: component.wrapper_path.clone(),
+                runtime_constraints: Value::Object(serde_json::Map::new()),
+                permitted_targets: vec![ExecutionTarget::Local],
+                dependencies: Vec::new(),
+                connector_requirements: Vec::new(),
+                validation_evidence: Vec::new(),
+                executable_pin: None,
+            },
+            contract_path: Path::new(&component.contract_path).to_path_buf(),
+            contract,
+            wasm_binary_path: component.artifact_ref.as_ref().map(PathBuf::from),
+            verified_wasm_digest: component.wasm_digest.clone(),
+        });
+    }
+    Some(ApplicationBundleManifest {
+        app_id: registration.app_id.clone(),
+        version: registration.app_version.clone(),
+        schema_version: registration.schema_version.clone(),
+        workspace_defaults: registration.workspace_defaults.clone(),
+        components,
+        workflows: registration.workflows.clone(),
+        connector_bindings: registration.connector_bindings.clone(),
+        model_dependencies: registration.model_dependencies.clone(),
+        config_schema: registration.config_schema.clone(),
+        default_config: registration.default_config.clone(),
+        effective_config: registration.effective_config.clone().unwrap_or(
+            ApplicationEffectiveConfig {
+                values: Value::Object(serde_json::Map::new()),
+                redacted_secret_keys: Vec::new(),
+            },
+        ),
+        placement_policy: registration.placement_policy.clone(),
+        public_surfaces: registration.public_surfaces.clone(),
+        state_machine: None,
+    })
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::panic)]
+mod tests {
+    use super::*;
+    use std::time::{SystemTime, UNIX_EPOCH};
+    use traverse_registry::WorkspaceApplicationRegistration;
+
+    fn unique_dir() -> PathBuf {
+        let suffix = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("time must be valid")
+            .as_nanos();
+        let dir = std::env::temp_dir().join(format!(
+            "traverse-cli-app-materialization-{}-{suffix}",
+            std::process::id()
+        ));
+        fs::create_dir_all(&dir).expect("temp dir must create");
+        dir
+    }
+
+    fn app_for(state_path: &Path) -> WorkspaceApplicationRegistration {
+        WorkspaceApplicationRegistration {
+            app_id: "registry-consumer".to_string(),
+            app_version: "1.0.0".to_string(),
+            manifest_path: "/nonexistent/app.manifest.json".to_string(),
+            manifest_digest: "sha256:test".to_string(),
+            bundle_digest: "sha256:bundle".to_string(),
+            model_dependencies: Vec::new(),
+            state_path: state_path.to_path_buf(),
+        }
+    }
+
+    fn write_registration(state_path: &Path, body: &Value) {
+        if let Some(parent) = state_path.parent() {
+            fs::create_dir_all(parent).expect("registration parent must create");
+        }
+        fs::write(
+            state_path,
+            serde_json::to_vec_pretty(body).expect("registration must serialize"),
+        )
+        .expect("registration must write");
+    }
+
+    fn base_registration(state_machine: Option<Value>) -> Value {
+        let mut body = serde_json::json!({
+            "app_id": "registry-consumer",
+            "app_version": "1.0.0",
+            "schema_version": "1.0.0",
+            "components": [{
+                "component_id": "registry-consumer.process-component",
+                "component_version": "1.0.0",
+                "capability_id": "traverse-starter.process",
+                "capability_version": "1.0.0",
+                "wasm_digest": "sha256:test",
+                "manifest_path": "component.manifest.json",
+                "contract_path": "missing-contract.json",
+                "artifact_ref": "missing.wasm"
+            }]
+        });
+        if let Some(state_machine) = state_machine {
+            body["state_machine"] = state_machine;
+        }
+        body
+    }
+
+    fn valid_machine() -> Value {
+        serde_json::json!({
+            "initial_state": "idle",
+            "states": [
+                {
+                    "id": "idle",
+                    "transitions": [{ "on": "submit", "to": "processing" }]
+                },
+                {
+                    "id": "processing",
+                    "invoke": {
+                        "capability_id": "traverse-starter.process",
+                        "input_from": "command.payload"
+                    },
+                    "transitions": [
+                        { "on": "capability_succeeded", "to": "results" },
+                        { "on": "capability_failed", "to": "error" }
+                    ]
+                },
+                { "id": "results", "transitions": [] },
+                { "id": "error", "transitions": [] }
+            ]
+        })
+    }
+
+    #[test]
+    fn missing_state_machine_requires_refresh_without_leaking_paths() {
+        let dir = unique_dir();
+        let state_path = dir.join("registration.json");
+        write_registration(&state_path, &base_registration(None));
+
+        let loaded = materialize_workspace_app(&app_for(&state_path));
+        let failure = loaded.failure.expect("missing declaration must fail");
+        assert_eq!(failure.code, APP_REGISTRATION_REQUIRES_REFRESH);
+        assert_eq!(failure.status, 409);
+        assert!(loaded.machine.is_none());
+        assert!(
+            !failure
+                .message
+                .contains(state_path.to_string_lossy().as_ref())
+        );
+        assert!(!failure.message.contains("/nonexistent"));
+    }
+
+    #[test]
+    fn undeclared_invoke_capability_is_unavailable() {
+        let dir = unique_dir();
+        let state_path = dir.join("registration.json");
+        let mut machine = valid_machine();
+        machine["states"][1]["invoke"]["capability_id"] = serde_json::json!("not.registered");
+        write_registration(&state_path, &base_registration(Some(machine)));
+
+        let loaded = materialize_workspace_app(&app_for(&state_path));
+        let failure = loaded.failure.expect("invalid declaration must fail");
+        assert_eq!(failure.code, APP_UNAVAILABLE);
+        assert_eq!(failure.status, 503);
+        assert!(loaded.machine.is_none());
+        assert_eq!(failure.message, UNAVAILABLE_MESSAGE);
+    }
+
+    #[test]
+    fn valid_persisted_state_machine_materializes() {
+        let dir = unique_dir();
+        let state_path = dir.join("registration.json");
+        write_registration(&state_path, &base_registration(Some(valid_machine())));
+
+        let loaded = materialize_workspace_app(&app_for(&state_path));
+        assert!(loaded.failure.is_none());
+        let machine = loaded.machine.expect("valid declaration must load");
+        assert_eq!(machine.initial_state, "idle");
+        assert_eq!(
+            machine.states[1]
+                .invoke
+                .as_ref()
+                .expect("processing invoke")
+                .capability_id,
+            "traverse-starter.process"
+        );
+    }
+
+    #[test]
+    fn malformed_state_machine_is_unavailable() {
+        let dir = unique_dir();
+        let state_path = dir.join("registration.json");
+        write_registration(
+            &state_path,
+            &base_registration(Some(serde_json::json!("not-an-object"))),
+        );
+
+        let loaded = materialize_workspace_app(&app_for(&state_path));
+        let failure = loaded.failure.expect("malformed declaration must fail");
+        assert_eq!(failure.code, APP_UNAVAILABLE);
+        assert!(!failure.message.contains("not-an-object"));
+    }
+}

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -132,7 +132,7 @@ cargo run -p traverse-cli-rs -- app register \
 }
 ```
 
-`app register` performs the same validation and writes durable local workspace state under `.traverse/workspaces/<workspace-id>/apps/<app-id>/<version>/registration.json`. A concise success response includes:
+`app register` performs the same validation and writes durable local workspace state under `.traverse/workspaces/<workspace-id>/apps/<app-id>/<version>/registration.json`, including the resolved `state_machine` declaration. `serve` command dispatch consumes that persisted registration; it does not reopen the source app manifest. A concise success response includes:
 
 ```json
 {
@@ -148,6 +148,8 @@ cargo run -p traverse-cli-rs -- app register \
 ```
 
 Re-registering unchanged state is idempotent and returns `status: already_registered` with the same stable app, workspace, and digest evidence.
+
+`serve` loads that persisted `state_machine` for command dispatch. A registration written before this field existed, or one whose persisted declaration cannot be materialized, does not fall back to the source manifest. Re-run `app register` to refresh durable state. Command routes then return `app_registration_requires_refresh` or `503 app_unavailable` instead of a silent `404 app_not_registered`.
 
 `app activate` is the complementary host-only step governed by
 `103-application-connector-binding` and `106-activation-artifact-resolution`.

--- a/docs/releases/next.md
+++ b/docs/releases/next.md
@@ -1,5 +1,14 @@
 # Next Release Notes
 
+## Persist resolved app state machines for `serve`
+
+`traverse-cli serve` now dispatches Registry-backed app commands from the
+persisted `state_machine` in workspace registration state. It does not reopen
+or re-resolve the source application manifest. Legacy registrations without
+that declaration require an explicit `app register` refresh;
+`app_registration_requires_refresh` and `503 app_unavailable` replace silent
+`404 app_not_registered` for registered apps that cannot materialize.
+
 ## Verified Registry application references
 
 The next Traverse release after `v0.10.0` includes the verified Registry

--- a/docs/youaskm3-canonical-app-http-path.md
+++ b/docs/youaskm3-canonical-app-http-path.md
@@ -69,7 +69,7 @@ cargo run -p traverse-cli-rs -- app register \
   --json
 ```
 
-`app validate` emits read-only JSON setup evidence. `app register` writes durable local state at `.traverse/workspaces/<workspace-id>/apps/<app-id>/<version>/registration.json` so Traverse runtime code can load the registered app capability and workflow from workspace state.
+`app validate` emits read-only JSON setup evidence. `app register` writes durable local state at `.traverse/workspaces/<workspace-id>/apps/<app-id>/<version>/registration.json` so Traverse runtime code can load the registered app capability, workflow, and state machine from workspace state. `serve` does not reopen the source manifest for command dispatch. If a command returns `app_registration_requires_refresh`, re-run `app register`; there is no source-manifest fallback.
 
 This slice deliberately does not provide HTTP app registration, runtime-owned downstream UI deployment, deployment orchestration, or a service registry. `youaskm3` owns its browser-hosted UI and deployment. Traverse owns validation, registration evidence, runtime loading, execution, traces, and eventing-oriented contracts used for runtime communication.
 

--- a/examples/applications/registry-consumer/README.md
+++ b/examples/applications/registry-consumer/README.md
@@ -22,3 +22,17 @@ cargo run -p traverse-cli-rs -- app register \
 
 The component versions and digests are pinned to the active `1.1.0` public
 records. Deprecated `1.0.x` records are intentionally excluded.
+
+`traverse-cli serve` dispatches app commands from the persisted
+`registration.json` written by `app register`. It does not reopen the source
+manifest or re-resolve `registry_ref` at startup. After register, prepare, and
+optional activate:
+
+```bash
+cargo run -p traverse-cli-rs -- serve
+```
+
+If a command returns `app_registration_requires_refresh`, the workspace has a
+legacy registration without a persisted state-machine declaration. Re-run
+`app register` against the current manifest. There is no source-manifest
+fallback or automatic migration.

--- a/quickstart.md
+++ b/quickstart.md
@@ -136,6 +136,10 @@ cargo run -p traverse-cli-rs -- app register \
   --json
 ```
 
+`serve` then consumes the persisted registration, including the resolved
+`state_machine`. Re-run `app register` if a command returns
+`app_registration_requires_refresh`; do not expect a source-manifest fallback.
+
 The development/CI HTTP server discovery file remains backward-compatible with the
 `v0.3.0` schema. `cargo run -p traverse-cli-rs -- serve` writes
 `.traverse/server.json` with `schema_version: "1.0.0"`, `base_url`,


### PR DESCRIPTION
## Summary

- `traverse-cli serve` now loads each registered app's `state_machine` from persisted workspace `registration.json` instead of reopening the source manifest.
- Registered apps that cannot materialize return `503 app_unavailable`; legacy records without a persisted declaration return `app_registration_requires_refresh`. There is no source-manifest fallback.
- Registry-backed command dispatch is covered by focused tests from persisted registration state through HTTP command handling.

## Governing Spec

- `046-public-cli-app-registration`
- `052-app-state-machine`
- `133-app-availability-lifecycle`
- `059-http-command-dispatch`
- `033-http-json-api`
- `044-application-bundle-manifest`
- `054-public-scope-registry-ref`
- `065-sigstore-bundle-verification`
- `109-runtime-workflow-proposals`

## Project Item

https://github.com/traverse-framework/traverse/issues/1325

## What Changed

- Contracts changed: none
- Runtime behavior changed: `serve` command dispatch and app-proposal handling consume persisted registration state; they do not re-resolve `registry_ref` or reopen the source app manifest
- Compatibility impact: legacy registrations without a persisted `state_machine` require explicit `app register` refresh
- ADR needed or linked: ADR-0066 / #1324 (D2, D3, D5, D6, D7)

## Validation

- [x] Spec alignment checked
- [x] Contract alignment checked
- [x] Tests updated and passing
- [x] Core coverage preserved
- [x] Required validation gates passing

## Notes

Non-goals preserved: no app-status endpoint, no lazy Registry resolution at serve/startup, no automatic migration shim.

Closes #1325
