### PR TITLE
feat(runtime): hydrate commands and workflows from the persisted index

### DIFF
--- a/crates/traverse-runtime/examples/load_workspace_app_state.rs
+++ b/crates/traverse-runtime/examples/load_workspace_app_state.rs
@@ -1,9 +1,7 @@
 use serde_json::{Value, json};
 use std::env;
 use std::path::Path;
-use traverse_registry::{
-    DiscoveryQuery, LookupScope, ResolvedCapability, WorkspaceAppStateErrorCode,
-};
+use traverse_registry::{ResolvedCapability, WorkspaceAppStateErrorCode};
 use traverse_runtime::{LocalExecutionFailure, LocalExecutionOutput, LocalExecutor, Runtime};
 
 #[derive(Debug)]
@@ -41,21 +39,24 @@ fn main() {
         "downstream-app-conformance",
     ) {
         Ok(runtime) => {
-            let capabilities = runtime
-                .capability_registry()
-                .discover(LookupScope::PreferPrivate, &DiscoveryQuery::default());
-            let workflows = runtime
-                .workflow_registry()
-                .discover(LookupScope::PreferPrivate);
+            let capabilities = runtime.capability_metadata_index().len();
+            let workflows = runtime.indexed_workflows().count();
             println!(
                 "{}",
                 json!({
                     "status": "loaded",
                     "workspace_id": workspace_id,
-                    "capability_count": capabilities.len(),
-                    "workflow_count": workflows.len(),
-                    "capability_ids": capabilities.iter().map(|entry| entry.id.clone()).collect::<Vec<_>>(),
-                    "workflow_ids": workflows.iter().map(|entry| entry.id.clone()).collect::<Vec<_>>()
+                    "capability_count": capabilities,
+                    "workflow_count": workflows,
+                    "capability_ids": runtime
+                        .capability_metadata_index()
+                        .entries()
+                        .map(|entry| entry.capability_id.clone())
+                        .collect::<Vec<_>>(),
+                    "workflow_ids": runtime
+                        .indexed_workflows()
+                        .map(|workflow| workflow.definition.id.clone())
+                        .collect::<Vec<_>>()
                 })
             );
         }

--- a/crates/traverse-runtime/src/capability_metadata.rs
+++ b/crates/traverse-runtime/src/capability_metadata.rs
@@ -46,10 +46,17 @@ pub struct IndexedWorkflowRef {
     pub workflow_digest: Option<String>,
 }
 
+#[derive(Debug, Clone)]
+pub(crate) struct IndexedSource {
+    pub contract: PathBuf,
+    pub artifact: PathBuf,
+    pub manifest: PathBuf,
+}
+
 #[derive(Debug, Clone, Default)]
 pub struct CapabilityMetadataIndex {
     entries: BTreeMap<String, IndexedCapability>,
-    sources: BTreeMap<String, PathBuf>,
+    sources: BTreeMap<String, IndexedSource>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
@@ -151,8 +158,14 @@ impl CapabilityMetadataIndex {
                 },
             );
             if !component.contract_path.is_empty() {
-                self.sources
-                    .insert(lookup_key, PathBuf::from(component.contract_path));
+                self.sources.insert(
+                    lookup_key,
+                    IndexedSource {
+                        contract: PathBuf::from(component.contract_path),
+                        artifact: PathBuf::from(component.artifact_ref),
+                        manifest: PathBuf::from(component.manifest_path),
+                    },
+                );
             }
         }
     }
@@ -178,9 +191,17 @@ impl CapabilityMetadataIndex {
     }
 
     fn source_path(&self, capability_id: &str, capability_version: &str) -> Option<&Path> {
+        self.source(capability_id, capability_version)
+            .map(|source| source.contract.as_path())
+    }
+
+    pub(crate) fn source(
+        &self,
+        capability_id: &str,
+        capability_version: &str,
+    ) -> Option<&IndexedSource> {
         self.sources
             .get(&lookup_key(capability_id, capability_version))
-            .map(PathBuf::as_path)
     }
 }
 
@@ -463,6 +484,10 @@ struct PersistedComponent {
     #[serde(default)]
     contract_path: String,
     #[serde(default)]
+    artifact_ref: String,
+    #[serde(default)]
+    manifest_path: String,
+    #[serde(default)]
     execution_mode: Option<String>,
     #[serde(default)]
     platforms: Vec<String>,
@@ -477,6 +502,9 @@ struct PersistedWorkflow {
     workflow_version: String,
     #[serde(default)]
     workflow_digest: Option<String>,
+    #[serde(default)]
+    #[allow(dead_code)]
+    path: String,
 }
 
 #[must_use]

--- a/crates/traverse-runtime/src/lib.rs
+++ b/crates/traverse-runtime/src/lib.rs
@@ -27,6 +27,7 @@ pub mod security;
 /// Spec `132` Stateful Browser activation attestation.
 pub mod stateful_browser;
 pub mod trace;
+mod workspace_lazy;
 
 use chrono::Utc;
 use events::{
@@ -45,6 +46,7 @@ use security::{
 use semver::Version;
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value, json};
+use std::collections::BTreeMap;
 use std::fmt;
 use std::fs;
 use std::path::Path;
@@ -59,8 +61,7 @@ use traverse_registry::{
     ModelResolutionEvidence, RegistrationOutcome, RegistryFailure, RegistryScope, ResolutionError,
     ResolveTelemetry, ResolvedCapability, WorkflowFailure, WorkflowRegistration,
     WorkflowRegistrationOutcome, WorkflowRegistry, WorkspaceAppStateFailure,
-    WorkspaceApplicationRegistration, load_workspace_application_registries, resolve_dependencies,
-    resolve_version_range,
+    WorkspaceApplicationRegistration, resolve_dependencies, resolve_version_range,
 };
 use uuid::Uuid;
 
@@ -96,6 +97,8 @@ pub struct Runtime<E> {
     usage_telemetry_sink: Arc<dyn UsageTelemetrySink>,
     capability_metadata: CapabilityMetadataIndex,
     contract_hydration: Arc<ContractHydrationCache>,
+    indexed_workflows: BTreeMap<(String, String), traverse_registry::ResolvedWorkflow>,
+    workspace_validator_version: String,
 }
 
 impl<E: Clone> Clone for Runtime<E> {
@@ -113,6 +116,8 @@ impl<E: Clone> Clone for Runtime<E> {
             usage_telemetry_sink: Arc::clone(&self.usage_telemetry_sink),
             capability_metadata: self.capability_metadata.clone(),
             contract_hydration: Arc::clone(&self.contract_hydration),
+            indexed_workflows: self.indexed_workflows.clone(),
+            workspace_validator_version: self.workspace_validator_version.clone(),
         }
     }
 }
@@ -132,6 +137,11 @@ impl<E: fmt::Debug> fmt::Debug for Runtime<E> {
             .field("usage_telemetry_sink", &"Arc<dyn UsageTelemetrySink>")
             .field("capability_metadata_len", &self.capability_metadata.len())
             .field("contract_hydration", &self.contract_hydration)
+            .field("indexed_workflows", &self.indexed_workflows.len())
+            .field(
+                "workspace_validator_version",
+                &self.workspace_validator_version,
+            )
             .finish()
     }
 }
@@ -154,6 +164,8 @@ impl<E> Runtime<E> {
             contract_hydration: Arc::new(ContractHydrationCache::new(
                 DEFAULT_HYDRATION_CACHE_CAPACITY,
             )),
+            indexed_workflows: BTreeMap::new(),
+            workspace_validator_version: String::new(),
         }
     }
 
@@ -186,13 +198,14 @@ impl<E> Runtime<E> {
         validator_version: &str,
     ) -> Result<Self, WorkspaceAppStateFailure> {
         let loaded =
-            load_workspace_application_registries(workspace_root, workspace_id, validator_version)?;
+            workspace_lazy::load_lazy_workspace(workspace_root, workspace_id, validator_version)?;
         let capability_metadata =
             CapabilityMetadataIndex::from_workspace_applications(&loaded.applications);
-        Ok(Self::new(loaded.capability_registry, executor)
-            .with_workflow_registry(loaded.workflow_registry)
+        Ok(Self::new(CapabilityRegistry::new(), executor)
             .with_workspace_applications(loaded.applications)
-            .with_capability_metadata(capability_metadata))
+            .with_capability_metadata(capability_metadata)
+            .with_indexed_workflows(loaded.workflows)
+            .with_workspace_validator_version(validator_version.to_string()))
     }
 
     #[must_use]
@@ -303,6 +316,25 @@ impl<E> Runtime<E> {
     }
 
     #[must_use]
+    pub fn with_indexed_workflows(
+        mut self,
+        workflows: BTreeMap<(String, String), traverse_registry::ResolvedWorkflow>,
+    ) -> Self {
+        self.indexed_workflows = workflows;
+        self
+    }
+
+    #[must_use]
+    pub fn with_workspace_validator_version(mut self, validator_version: String) -> Self {
+        self.workspace_validator_version = validator_version;
+        self
+    }
+
+    pub fn indexed_workflows(&self) -> impl Iterator<Item = &traverse_registry::ResolvedWorkflow> {
+        self.indexed_workflows.values()
+    }
+
+    #[must_use]
     pub fn with_hydration_cache_capacity(mut self, capacity: usize) -> Self {
         self.contract_hydration = Arc::new(ContractHydrationCache::new(capacity));
         self
@@ -329,6 +361,21 @@ impl<E> Runtime<E> {
             capability_id,
             capability_version,
         )
+    }
+
+    pub(crate) fn hydrate_resolved_capability(
+        &self,
+        capability_id: &str,
+        capability_version: &str,
+    ) -> Result<ResolvedCapability, HydrationError> {
+        let contract = self.hydrate_indexed_contract(capability_id, capability_version)?;
+        Ok(workspace_lazy::resolved_from_index(
+            &self.capability_metadata,
+            (*contract).clone(),
+            capability_id,
+            capability_version,
+            &self.workspace_validator_version,
+        ))
     }
 
     /// Returns a mutable reference to the workflow registry.
@@ -1294,7 +1341,9 @@ where
         } else {
             let resolution = self.resolve_candidates(&attempt.request, &mut emitter);
 
-            if resolution.eligible.is_empty() {
+            if let Some(error) = resolution.hydration_failure {
+                hydration_failure_outcome(attempt, emitter, resolution.collection, &error)
+            } else if resolution.eligible.is_empty() {
                 no_eligible_outcome(attempt, emitter, resolution.collection)
             } else if resolution.eligible.len() > 1 {
                 ambiguous_outcome(attempt, emitter, resolution)
@@ -1445,7 +1494,14 @@ where
             CandidateReason::IntentMatch
         };
 
-        let discovered = self.collect_candidates(request, candidate_reason);
+        let mut discovered = self.collect_candidates(request, candidate_reason);
+        let mut hydration_failure = None;
+        if discovered.is_empty() && !self.capability_metadata.is_empty() {
+            match self.collect_indexed_candidates(request) {
+                Ok(indexed) => discovered = indexed,
+                Err(error) => hydration_failure = Some(error),
+            }
+        }
         if !discovered.is_empty() {
             emitter.push(
                 RuntimeState::EvaluatingConstraints,
@@ -1492,7 +1548,82 @@ where
                 rejected_candidates: rejected,
             },
             candidate_reason,
+            hydration_failure,
         }
+    }
+
+    fn collect_indexed_candidates(
+        &self,
+        request: &RuntimeRequest,
+    ) -> Result<Vec<ResolvedCapability>, HydrationError> {
+        if let (Some(id), Some(version)) = (
+            request
+                .intent
+                .capability_id
+                .as_deref()
+                .filter(|value| non_empty(value)),
+            request
+                .intent
+                .capability_version
+                .as_deref()
+                .filter(|value| non_empty(value)),
+        ) {
+            if self.capability_metadata.get(id, version).is_none() {
+                return Ok(Vec::new());
+            }
+            return self
+                .hydrate_resolved_capability(id, version)
+                .map(|cap| vec![cap]);
+        }
+
+        if let (Some(capability_id), Some(range_str)) = (
+            request.intent.capability_id.as_deref(),
+            request.intent.version_range.as_deref(),
+        ) && non_empty(capability_id)
+            && non_empty(range_str)
+        {
+            let Ok(requirement) = semver::VersionReq::parse(range_str) else {
+                return Ok(Vec::new());
+            };
+            let mut matched = self
+                .capability_metadata
+                .entries()
+                .filter(|entry| entry.capability_id == capability_id)
+                .filter_map(|entry| {
+                    Version::parse(&entry.capability_version)
+                        .ok()
+                        .filter(|version| requirement.matches(version))
+                        .map(|version| (version, entry.clone()))
+                })
+                .collect::<Vec<_>>();
+            matched.sort_by(|left, right| left.0.cmp(&right.0));
+            let Some((_, selected)) = matched.pop() else {
+                return Ok(Vec::new());
+            };
+            return self
+                .hydrate_resolved_capability(&selected.capability_id, &selected.capability_version)
+                .map(|cap| vec![cap]);
+        }
+
+        let target = request
+            .intent
+            .capability_id
+            .as_deref()
+            .or(request.intent.intent_key.as_deref())
+            .unwrap_or_default();
+        let matches = self
+            .capability_metadata
+            .entries()
+            .filter(|entry| entry.capability_id == target)
+            .cloned()
+            .collect::<Vec<_>>();
+        let mut resolved = Vec::new();
+        for entry in matches {
+            resolved.push(
+                self.hydrate_resolved_capability(&entry.capability_id, &entry.capability_version)?,
+            );
+        }
+        Ok(resolved)
     }
 
     #[allow(clippy::too_many_lines)]
@@ -2261,6 +2392,75 @@ fn invalid_request_outcome(
         emitted_events: Vec::new(),
         workflow_evidence: None,
     })
+}
+
+fn hydration_failure_outcome(
+    attempt: AttemptContext,
+    mut emitter: StateEmitter,
+    candidate_collection: CandidateCollectionRecord,
+    error: &HydrationError,
+) -> RuntimeExecutionOutcome {
+    let placement = placement_not_attempted(
+        attempt.request.context.requested_target,
+        PlacementDecisionReason::SelectionNotReached,
+    );
+    let runtime_error = hydration_runtime_error(error);
+    emitter.push(
+        RuntimeState::Error,
+        RuntimeTransitionReasonCode::NoMatch,
+        json!({"code": runtime_error.code, "reason_code": error.code}),
+    );
+    emitter.push(
+        RuntimeState::Ready,
+        RuntimeTransitionReasonCode::ExecutionClosed,
+        json!({"terminal_state": RuntimeState::Error}),
+    );
+    let finished = emitter.finish();
+    let identity = attempt.request.context.identity.clone();
+    terminal_failure(FailureContext {
+        attempt,
+        state_events: finished.events,
+        state_transitions: finished.transitions,
+        state_machine_validation: finished.validation,
+        candidate_collection,
+        selection: SelectionRecord {
+            status: SelectionStatus::NoMatch,
+            selected_capability_id: None,
+            selected_capability_version: None,
+            failure_reason: Some(SelectionFailureReason::NotRunnable),
+            remaining_candidates: Vec::new(),
+        },
+        execution: ExecutionRecord {
+            placement: placement.clone(),
+            placement_target: placement.requested_target,
+            status: ExecutionStatus::NotStarted,
+            artifact_ref: None,
+            started_at: None,
+            completed_at: None,
+            output_digest: None,
+            failure_reason: Some(ExecutionFailureReason::ArtifactNotRunnable),
+            artifact_verification: None,
+            identity,
+        },
+        error: runtime_error,
+        emitted_events: Vec::new(),
+        workflow_evidence: None,
+    })
+}
+
+pub(crate) fn hydration_runtime_error(error: &HydrationError) -> RuntimeError {
+    let code = match error.code {
+        "indexed_capability_missing" => RuntimeErrorCode::CapabilityNotFound,
+        "contract_digest_mismatch" | "contract_parse_failed" | "contract_not_utf8" => {
+            RuntimeErrorCode::ContractViolation
+        }
+        _ => RuntimeErrorCode::ArtifactMissing,
+    };
+    runtime_error(
+        code,
+        "capability contract could not be hydrated",
+        json!({"reason_code": error.code}),
+    )
 }
 
 fn no_eligible_outcome(
@@ -3210,6 +3410,7 @@ struct CandidateResolution {
     eligible: Vec<ResolvedCapability>,
     collection: CandidateCollectionRecord,
     candidate_reason: CandidateReason,
+    hydration_failure: Option<HydrationError>,
 }
 
 struct FailureContext {
@@ -3536,13 +3737,14 @@ mod tests {
     };
     use super::{
         BrowserRuntimeSubscriptionErrorCode, BrowserRuntimeSubscriptionMessage,
-        BrowserRuntimeSubscriptionRequest, CandidateEvaluation, CandidateReason, LocalExecutor,
-        PlacementTarget, RejectedCandidateReason, Runtime, RuntimeContext, RuntimeIntent,
-        RuntimeLookup, RuntimeLookupScope, RuntimeLookupScope::*, RuntimeRequest,
-        RuntimeResultStatus, RuntimeState, RuntimeTransitionReasonCode,
-        browser_subscription_messages, evaluate_candidate, map_implementation_kind, map_lifecycle,
-        map_registry_scope, parse_runtime_request, runtime_candidate, subscription_targets_outcome,
-        validate_browser_subscription_request, validate_payload_against_contract, validate_request,
+        BrowserRuntimeSubscriptionRequest, CandidateEvaluation, CandidateReason, HydrationError,
+        HydrationEvidenceKind, LocalExecutor, PlacementTarget, RejectedCandidateReason, Runtime,
+        RuntimeContext, RuntimeIntent, RuntimeLookup, RuntimeLookupScope, RuntimeLookupScope::*,
+        RuntimeRequest, RuntimeResultStatus, RuntimeState, RuntimeTransitionReasonCode,
+        browser_subscription_messages, capability_metadata, evaluate_candidate,
+        map_implementation_kind, map_lifecycle, map_registry_scope, parse_runtime_request,
+        runtime_candidate, subscription_targets_outcome, validate_browser_subscription_request,
+        validate_payload_against_contract, validate_request,
     };
     use ed25519_dalek::{Signer, SigningKey};
     use serde_json::json;
@@ -4022,7 +4224,7 @@ mod tests {
                     "expedition.planning.validate-team-readiness",
                     "1.0.0"
                 )
-                .is_some()
+                .is_none()
         );
         assert!(
             runtime
@@ -4032,7 +4234,12 @@ mod tests {
                     "expedition.planning.plan-expedition",
                     "1.0.0"
                 )
-                .is_some()
+                .is_none()
+        );
+        assert!(
+            runtime
+                .indexed_workflows()
+                .any(|workflow| workflow.definition.id == "expedition.planning.plan-expedition")
         );
         assert_eq!(
             runtime.workspace_applications()[0].model_dependencies[0].interface_id,
@@ -4067,6 +4274,339 @@ mod tests {
         .expect("reload")
         .with_hydration_cache_capacity(2);
         assert_eq!(sized.capability_metadata_index().len(), 5);
+    }
+
+    #[test]
+    fn workspace_command_hydrates_selected_capability_only() {
+        let workspace_root = unique_workspace_state_dir();
+        write_runtime_workspace_app_state_fixture(&workspace_root, "local");
+        let runtime = Runtime::from_workspace_app_state(
+            &workspace_root,
+            "local",
+            NoopExecutor,
+            "test-runtime",
+        )
+        .expect("workspace app state should load");
+        let mut request = valid_request();
+        request.intent.capability_id =
+            Some("expedition.planning.validate-team-readiness".to_string());
+        request.intent.intent_key = Some("expedition.planning.validate-team-readiness".to_string());
+        request.input = json!({
+            "objective": {"objective_id": "obj-1"},
+            "conditions_summary": {
+                "conditions_summary_id": "cs-1",
+                "objective_id": "obj-1",
+                "overall_rating": "ok",
+                "key_findings": ["clear"],
+                "blocking_concerns": []
+            },
+            "team_profile": {
+                "team_id": "team-1",
+                "member_count": 2,
+                "experience_level": "intermediate",
+                "equipment_ready": true
+            }
+        });
+        let _outcome = runtime.execute(request);
+        let snapshot = runtime.contract_hydration.evidence_snapshot();
+        let leaders = snapshot
+            .iter()
+            .filter(|record| record.kind == HydrationEvidenceKind::HydrationLeader)
+            .map(|record| record.capability_id.as_str())
+            .collect::<Vec<_>>();
+        assert_eq!(leaders, vec!["expedition.planning.validate-team-readiness"]);
+        assert!(!snapshot.iter().any(|record| {
+            record.kind == HydrationEvidenceKind::HydrationLeader
+                && record.capability_id == "expedition.planning.assemble-expedition-plan"
+        }));
+        assert!(capability_metadata::evidence_is_secret_free(&snapshot[0]));
+    }
+
+    fn expedition_request(id: &str, version: Option<&str>, range: Option<&str>) -> RuntimeRequest {
+        let mut request = valid_request();
+        request.intent.capability_id = Some(id.to_string());
+        request.intent.capability_version = version.map(str::to_string);
+        request.intent.version_range = range.map(str::to_string);
+        request.intent.intent_key = Some(id.to_string());
+        request.input = json!({
+            "objective": {"objective_id": "obj-1"},
+            "conditions_summary": {
+                "conditions_summary_id": "cs-1",
+                "objective_id": "obj-1",
+                "overall_rating": "ok",
+                "key_findings": ["clear"],
+                "blocking_concerns": []
+            },
+            "team_profile": {
+                "team_id": "team-1",
+                "member_count": 2,
+                "experience_level": "intermediate",
+                "equipment_ready": true
+            }
+        });
+        request
+    }
+
+    #[test]
+    fn workspace_command_resolves_semver_range_and_intent_from_index() {
+        let workspace_root = unique_workspace_state_dir();
+        write_runtime_workspace_app_state_fixture(&workspace_root, "local");
+        let runtime = Runtime::from_workspace_app_state(
+            &workspace_root,
+            "local",
+            NoopExecutor,
+            "test-runtime",
+        )
+        .expect("workspace app state should load");
+        let _ = runtime.execute(expedition_request(
+            "expedition.planning.validate-team-readiness",
+            None,
+            Some("^1.0"),
+        ));
+        let _ = runtime.execute(expedition_request(
+            "expedition.planning.validate-team-readiness",
+            None,
+            None,
+        ));
+        let leaders = runtime
+            .contract_hydration
+            .evidence_snapshot()
+            .into_iter()
+            .filter(|record| record.kind == HydrationEvidenceKind::HydrationLeader)
+            .count();
+        assert!(leaders >= 1);
+        let _ = runtime.execute(expedition_request(
+            "expedition.planning.validate-team-readiness",
+            None,
+            Some("^99.0"),
+        ));
+        let _ = runtime.execute(expedition_request(
+            "expedition.planning.validate-team-readiness",
+            None,
+            Some("not-a-range"),
+        ));
+    }
+
+    #[test]
+    fn hydration_runtime_error_maps_stable_codes() {
+        assert_eq!(
+            super::hydration_runtime_error(&HydrationError {
+                code: "indexed_capability_missing",
+                message: "x".to_string(),
+            })
+            .code,
+            super::RuntimeErrorCode::CapabilityNotFound
+        );
+        assert_eq!(
+            super::hydration_runtime_error(&HydrationError {
+                code: "contract_parse_failed",
+                message: "x".to_string(),
+            })
+            .code,
+            super::RuntimeErrorCode::ContractViolation
+        );
+        assert_eq!(
+            super::hydration_runtime_error(&HydrationError {
+                code: "contract_unreadable",
+                message: "x".to_string(),
+            })
+            .code,
+            super::RuntimeErrorCode::ArtifactMissing
+        );
+    }
+
+    #[test]
+    fn indexed_workflow_is_hidden_from_public_lookup() {
+        let workspace_root = unique_workspace_state_dir();
+        write_runtime_workspace_app_state_fixture(&workspace_root, "local");
+        let runtime = Runtime::from_workspace_app_state(
+            &workspace_root,
+            "local",
+            NoopExecutor,
+            "test-runtime",
+        )
+        .expect("workspace app state should load");
+        let outcome = runtime.execute_workflow(super::WorkflowExecutionRequest {
+            kind: "workflow_execution_request".to_string(),
+            schema_version: "1.0.0".to_string(),
+            request_id: "wf-public".to_string(),
+            workflow_id: "expedition.planning.plan-expedition".to_string(),
+            workflow_version: "1.0.0".to_string(),
+            scope: super::WorkflowLookupScope::PublicOnly,
+            input: json!({}),
+            governing_spec: "007-workflow-registry-traversal".to_string(),
+        });
+        assert_eq!(outcome.result.status, super::WorkflowTraversalStatus::Error);
+    }
+
+    #[test]
+    fn indexed_workflow_hydration_fault_fails_only_that_step() {
+        let workspace_root = unique_workspace_state_dir();
+        write_runtime_workspace_app_state_fixture(&workspace_root, "local");
+        let corrupt = workspace_root.join("corrupt-contract.json");
+        fs::write(&corrupt, "{not-json").expect("corrupt");
+        let state_path = workspace_root
+            .join(".traverse/workspaces/local/apps/expedition.readiness/1.0.0/registration.json");
+        let mut state: serde_json::Value =
+            serde_json::from_slice(&fs::read(&state_path).expect("state")).expect("json");
+        state["components"][0]["contract_path"] = json!(corrupt.display().to_string());
+        state["components"][0]["contract_digest"] = json!(format!("sha256:{}", "bb".repeat(32)));
+        fs::write(&state_path, serde_json::to_vec(&state).expect("write")).expect("state");
+        let runtime = Runtime::from_workspace_app_state(
+            &workspace_root,
+            "local",
+            NoopExecutor,
+            "test-runtime",
+        )
+        .expect("load");
+        let outcome = runtime.execute_workflow(super::WorkflowExecutionRequest {
+            kind: "workflow_execution_request".to_string(),
+            schema_version: "1.0.0".to_string(),
+            request_id: "wf-hydrate-fail".to_string(),
+            workflow_id: "expedition.planning.plan-expedition".to_string(),
+            workflow_version: "1.0.0".to_string(),
+            scope: super::WorkflowLookupScope::PreferPrivate,
+            input: json!({
+                "destination": "alps",
+                "target_window": {
+                    "start": "2026-06-01T00:00:00Z",
+                    "end": "2026-06-07T00:00:00Z"
+                },
+                "preferences": {
+                    "style": "hut",
+                    "risk_tolerance": "low",
+                    "priority": "safety"
+                },
+                "notes": "none",
+                "planning_intent": "summit",
+                "team_profile": {
+                    "team_id": "team-1",
+                    "member_count": 2,
+                    "experience_level": "intermediate",
+                    "equipment_ready": true
+                }
+            }),
+            governing_spec: "007-workflow-registry-traversal".to_string(),
+        });
+        assert_eq!(
+            outcome.evidence.result.failure_reason,
+            Some(super::WorkflowTraversalFailureReason::StepExecutionFailed)
+        );
+    }
+
+    #[test]
+    fn workspace_workflow_hydrates_reached_steps_only() {
+        let workspace_root = unique_workspace_state_dir();
+        write_runtime_workspace_app_state_fixture(&workspace_root, "local");
+        let runtime = Runtime::from_workspace_app_state(
+            &workspace_root,
+            "local",
+            NoopExecutor,
+            "test-runtime",
+        )
+        .expect("workspace app state should load");
+        let outcome = runtime.execute_workflow(super::WorkflowExecutionRequest {
+            kind: "workflow_execution_request".to_string(),
+            schema_version: "1.0.0".to_string(),
+            request_id: "wf-req-1".to_string(),
+            workflow_id: "expedition.planning.plan-expedition".to_string(),
+            workflow_version: "1.0.0".to_string(),
+            scope: super::WorkflowLookupScope::PreferPrivate,
+            input: json!({
+                "destination": "alps",
+                "target_window": {
+                    "start": "2026-06-01T00:00:00Z",
+                    "end": "2026-06-07T00:00:00Z"
+                },
+                "preferences": {
+                    "style": "hut",
+                    "risk_tolerance": "low",
+                    "priority": "safety"
+                },
+                "notes": "none",
+                "planning_intent": "summit",
+                "team_profile": {
+                    "team_id": "team-1",
+                    "member_count": 2,
+                    "experience_level": "intermediate",
+                    "equipment_ready": true
+                }
+            }),
+            governing_spec: "007-workflow-registry-traversal".to_string(),
+        });
+        assert_eq!(
+            outcome.evidence.visited_nodes[0].capability_id,
+            "expedition.planning.capture-expedition-objective"
+        );
+        let snapshot = runtime.contract_hydration.evidence_snapshot();
+        let leaders = snapshot
+            .iter()
+            .filter(|record| record.kind == HydrationEvidenceKind::HydrationLeader)
+            .map(|record| record.capability_id.clone())
+            .collect::<Vec<_>>();
+        assert_eq!(
+            leaders,
+            vec!["expedition.planning.capture-expedition-objective".to_string()]
+        );
+        assert!(!leaders.contains(&"expedition.planning.assemble-expedition-plan".to_string()));
+        assert!(
+            outcome
+                .evidence
+                .visited_nodes
+                .iter()
+                .any(|step| { step.status == super::WorkflowTraversalStepStatus::Failed })
+        );
+    }
+
+    #[test]
+    fn workspace_hydration_fault_is_secret_free_and_command_scoped() {
+        let workspace_root = unique_workspace_state_dir();
+        write_runtime_workspace_app_state_fixture(&workspace_root, "local");
+        let contract_path = repo_root().join(
+            "contracts/examples/expedition/capabilities/validate-team-readiness/contract.json",
+        );
+        let state_path = workspace_root
+            .join(".traverse/workspaces/local/apps/expedition.readiness/1.0.0/registration.json");
+        let mut state: serde_json::Value =
+            serde_json::from_slice(&fs::read(&state_path).expect("state")).expect("json");
+        let corrupt = workspace_root.join("corrupt-contract.json");
+        fs::write(&corrupt, "{not-json").expect("corrupt contract");
+        state["components"][3]["contract_path"] = json!(corrupt.display().to_string());
+        state["components"][3]["contract_digest"] = json!(format!("sha256:{}", "aa".repeat(32)));
+        fs::write(&state_path, serde_json::to_vec(&state).expect("write")).expect("state");
+        let _ = contract_path;
+        let runtime = Runtime::from_workspace_app_state(
+            &workspace_root,
+            "local",
+            NoopExecutor,
+            "test-runtime",
+        )
+        .expect("index should load without parsing contracts");
+        let mut request = valid_request();
+        request.intent.capability_id =
+            Some("expedition.planning.validate-team-readiness".to_string());
+        request.intent.capability_version = Some("1.0.0".to_string());
+        request.intent.intent_key = Some("expedition.planning.validate-team-readiness".to_string());
+        let outcome = runtime.execute(request);
+        assert_eq!(outcome.result.status, RuntimeResultStatus::Error);
+        let snapshot = runtime.contract_hydration.evidence_snapshot();
+        assert!(snapshot.iter().any(|record| {
+            record.kind == HydrationEvidenceKind::HydrationFailure
+                && record.capability_id == "expedition.planning.validate-team-readiness"
+        }));
+        assert!(
+            snapshot
+                .iter()
+                .all(capability_metadata::evidence_is_secret_free)
+        );
+        runtime
+            .hydrate_indexed_contract("expedition.planning.assemble-expedition-plan", "1.0.0")
+            .expect("unrelated indexed capability remains hydratable");
+        let mut miss = valid_request();
+        miss.intent.capability_id = Some("missing.capability".to_string());
+        miss.intent.capability_version = Some("1.0.0".to_string());
+        let miss_outcome = runtime.execute(miss);
+        assert_eq!(miss_outcome.result.status, RuntimeResultStatus::Error);
     }
 
     #[test]

--- a/crates/traverse-runtime/src/workflows.rs
+++ b/crates/traverse-runtime/src/workflows.rs
@@ -296,11 +296,23 @@ where
         }
 
         let lookup_scope = map_workflow_lookup_scope(request.scope);
-        let Some(workflow) = self.workflow_registry.find_exact(
-            lookup_scope,
-            &request.workflow_id,
-            &request.workflow_version,
-        ) else {
+        let Some(workflow) = self
+            .workflow_registry
+            .find_exact(
+                lookup_scope,
+                &request.workflow_id,
+                &request.workflow_version,
+            )
+            .or_else(|| {
+                crate::workspace_lazy::lookup_indexed_workflow(
+                    &self.indexed_workflows,
+                    lookup_scope,
+                    &request.workflow_id,
+                    &request.workflow_version,
+                )
+                .cloned()
+            })
+        else {
             return workflow_failure(
                 &request,
                 WorkflowTraversalFailureReason::WorkflowNotFound,
@@ -472,11 +484,17 @@ where
             });
 
             let lookup_scope = map_workflow_lookup_scope(request.scope);
-            let Some(capability) = self.registry.find_exact(
+            let capability = if let Some(capability) = self.registry.find_exact(
                 lookup_scope,
                 &node.capability_id,
                 &node.capability_version,
-            ) else {
+            ) {
+                capability
+            } else if self
+                .capability_metadata
+                .get(&node.capability_id, &node.capability_version)
+                .is_none()
+            {
                 return Err(workflow_failure(
                     request,
                     WorkflowTraversalFailureReason::WorkflowInvalid,
@@ -491,6 +509,28 @@ where
                     event_evidence,
                     warnings,
                 ));
+            } else {
+                match self
+                    .hydrate_resolved_capability(&node.capability_id, &node.capability_version)
+                {
+                    Ok(capability) => capability,
+                    Err(error) => {
+                        let mut failed = visited;
+                        if let Some(last) = failed.last_mut() {
+                            last.status = WorkflowTraversalStepStatus::Failed;
+                        }
+                        return Err(workflow_failure(
+                            request,
+                            WorkflowTraversalFailureReason::StepExecutionFailed,
+                            crate::hydration_runtime_error(&error),
+                            failed,
+                            traversed,
+                            emitted,
+                            event_evidence,
+                            warnings,
+                        ));
+                    }
+                }
             };
 
             // Artifact security gate (spec 030-security-identity-model FR-013):

--- a/crates/traverse-runtime/src/workspace_lazy.rs
+++ b/crates/traverse-runtime/src/workspace_lazy.rs
@@ -1,0 +1,1150 @@
+//! Workspace load without parsing component contracts (spec `134`).
+
+use crate::capability_metadata::{CapabilityMetadataIndex, IndexedCapability};
+use serde::Deserialize;
+use serde_json::Value;
+use std::collections::{BTreeMap, BTreeSet};
+use std::fs;
+use std::path::{Path, PathBuf};
+use traverse_contracts::CapabilityContract;
+use traverse_registry::{
+    ApplicationModelDependency, ArtifactDigests, BinaryFormat, BinaryReference,
+    CapabilityArtifactRecord, CapabilityRegistryRecord, ComposabilityMetadata, CompositionKind,
+    CompositionPattern, DiscoveryIndexEntry, ImplementationKind, LookupScope, RegistrationEvidence,
+    RegistrationResult, RegistryProvenance, RegistryScope, ResolvedCapability, ResolvedWorkflow,
+    SourceKind, SourceReference, WorkflowDefinition, WorkflowDiscoveryIndexEntry, WorkflowEdge,
+    WorkflowEdgeTrigger, WorkflowRegistrationEvidence, WorkflowRegistrationResult,
+    WorkflowRegistryRecord, WorkspaceAppStateError, WorkspaceAppStateErrorCode,
+    WorkspaceAppStateFailure, WorkspaceApplicationRegistration,
+};
+
+const WORKSPACE_APP_STATE_SCHEMA_VERSION: &str = "1.0.0";
+const WORKSPACE_APP_STATE_SCOPE: &str = "workspace_persisted";
+const INDEXED_REGISTERED_AT: &str = "1970-01-01T00:00:00Z";
+
+#[derive(Debug, Clone, Default)]
+pub struct LazyWorkspaceLoad {
+    pub applications: Vec<WorkspaceApplicationRegistration>,
+    pub workflows: BTreeMap<(String, String), ResolvedWorkflow>,
+}
+
+/// Loads persisted app registrations and workflow definitions without parsing
+/// component contracts.
+///
+/// # Errors
+///
+/// Returns [`WorkspaceAppStateFailure`] when workspace state is missing,
+/// unreadable, incompatible, or a workflow fails index-backed topology checks.
+pub fn load_lazy_workspace(
+    workspace_root: &Path,
+    workspace_id: &str,
+    validator_version: &str,
+) -> Result<LazyWorkspaceLoad, WorkspaceAppStateFailure> {
+    let state_files = workspace_application_state_files(workspace_root, workspace_id)?;
+    let mut parsed = Vec::new();
+    for state_path in &state_files {
+        parsed.push(read_application(workspace_root, workspace_id, state_path)?);
+    }
+    let applications = parsed
+        .iter()
+        .map(|item| item.registration.clone())
+        .collect::<Vec<_>>();
+    let index = CapabilityMetadataIndex::from_workspace_applications(&applications);
+    let mut workflows = BTreeMap::new();
+    for item in &parsed {
+        for workflow in
+            load_workflows_for_app(workspace_root, &item.workflows, &index, validator_version)?
+        {
+            workflows.insert(
+                (
+                    workflow.definition.id.clone(),
+                    workflow.definition.version.clone(),
+                ),
+                workflow,
+            );
+        }
+    }
+    Ok(LazyWorkspaceLoad {
+        applications,
+        workflows,
+    })
+}
+
+pub(crate) fn lookup_indexed_workflow<'a>(
+    workflows: &'a BTreeMap<(String, String), ResolvedWorkflow>,
+    lookup_scope: LookupScope,
+    workflow_id: &str,
+    workflow_version: &str,
+) -> Option<&'a ResolvedWorkflow> {
+    if lookup_scope == LookupScope::PublicOnly {
+        return None;
+    }
+    workflows.get(&(workflow_id.to_string(), workflow_version.to_string()))
+}
+
+pub(crate) fn resolved_from_index(
+    index: &CapabilityMetadataIndex,
+    contract: CapabilityContract,
+    capability_id: &str,
+    capability_version: &str,
+    validator_version: &str,
+) -> ResolvedCapability {
+    let indexed = index.get(capability_id, capability_version);
+    let source = index.source(capability_id, capability_version);
+    let (indexed, artifact_path, contract_path, manifest_path) =
+        if let (Some(indexed), Some(source)) = (indexed, source) {
+            (
+                indexed.clone(),
+                source.artifact.display().to_string(),
+                source.contract.display().to_string(),
+                source.manifest.display().to_string(),
+            )
+        } else {
+            (
+                IndexedCapability {
+                    app_id: String::new(),
+                    app_version: String::new(),
+                    component_id: contract.id.clone(),
+                    component_version: contract.version.clone(),
+                    capability_id: contract.id.clone(),
+                    capability_version: contract.version.clone(),
+                    contract_digest: String::new(),
+                    artifact_digest: None,
+                    execution_mode: None,
+                    platforms: Vec::new(),
+                    workflow_refs: Vec::new(),
+                },
+                String::new(),
+                String::new(),
+                String::new(),
+            )
+        };
+    let artifact_ref = indexed_artifact_ref(&indexed, artifact_path.is_empty());
+    let provenance = RegistryProvenance {
+        source: format!("workspace_app_state:{}", indexed.app_id),
+        author: indexed.app_id.clone(),
+        created_at: INDEXED_REGISTERED_AT.to_string(),
+    };
+    ResolvedCapability {
+        record: CapabilityRegistryRecord {
+            scope: RegistryScope::Private,
+            id: contract.id.clone(),
+            version: contract.version.clone(),
+            lifecycle: contract.lifecycle.clone(),
+            owner: contract.owner.clone(),
+            contract_path,
+            contract_digest: indexed.contract_digest.clone(),
+            implementation_kind: ImplementationKind::Executable,
+            artifact_ref: artifact_ref.clone(),
+            registered_at: INDEXED_REGISTERED_AT.to_string(),
+            provenance: provenance.clone(),
+            evidence: RegistrationEvidence {
+                evidence_id: format!("idx_{}_{}", contract.id, contract.version),
+                artifact_ref: artifact_ref.clone(),
+                capability_id: contract.id.clone(),
+                capability_version: contract.version.clone(),
+                scope: RegistryScope::Private,
+                governing_spec: "134-lazy-capability-registry-reconstruction".to_string(),
+                validator_version: validator_version.to_string(),
+                produced_at: INDEXED_REGISTERED_AT.to_string(),
+                result: RegistrationResult::Passed,
+            },
+        },
+        artifact: CapabilityArtifactRecord {
+            artifact_ref: artifact_ref.clone(),
+            implementation_kind: ImplementationKind::Executable,
+            source: SourceReference {
+                kind: SourceKind::Local,
+                location: manifest_path,
+            },
+            binary: wasm_binary(&artifact_path),
+            workflow_ref: None,
+            digests: ArtifactDigests {
+                source_digest: indexed.contract_digest.clone(),
+                binary_digest: indexed.artifact_digest.clone(),
+            },
+            provenance,
+        },
+        index_entry: indexed_discovery_entry(&contract, &artifact_ref),
+        contract,
+    }
+}
+
+fn indexed_artifact_ref(indexed: &crate::IndexedCapability, artifact_missing: bool) -> String {
+    if artifact_missing {
+        format!(
+            "app:{}:{}:{}",
+            indexed.app_id, indexed.app_version, indexed.capability_id
+        )
+    } else {
+        format!(
+            "app:{}:{}:component:{}:{}",
+            indexed.app_id, indexed.app_version, indexed.component_id, indexed.component_version
+        )
+    }
+}
+
+fn wasm_binary(artifact_path: &str) -> Option<BinaryReference> {
+    if artifact_path.is_empty() {
+        None
+    } else {
+        Some(BinaryReference {
+            format: BinaryFormat::Wasm,
+            location: artifact_path.to_string(),
+            signature: None,
+        })
+    }
+}
+
+fn indexed_discovery_entry(
+    contract: &CapabilityContract,
+    artifact_ref: &str,
+) -> DiscoveryIndexEntry {
+    DiscoveryIndexEntry {
+        scope: RegistryScope::Private,
+        id: contract.id.clone(),
+        version: contract.version.clone(),
+        lifecycle: contract.lifecycle.clone(),
+        owner: contract.owner.clone(),
+        summary: contract.summary.clone(),
+        tags: Vec::new(),
+        permissions: contract
+            .permissions
+            .iter()
+            .map(|permission| permission.id.clone())
+            .collect(),
+        emits: contract
+            .emits
+            .iter()
+            .map(|event| event.event_id.clone())
+            .collect(),
+        consumes: contract
+            .consumes
+            .iter()
+            .map(|event| event.event_id.clone())
+            .collect(),
+        implementation_kind: ImplementationKind::Executable,
+        composability: ComposabilityMetadata {
+            kind: CompositionKind::Atomic,
+            patterns: vec![CompositionPattern::Validation],
+            provides: Vec::new(),
+            requires: Vec::new(),
+        },
+        artifact_ref: artifact_ref.to_string(),
+        registered_at: INDEXED_REGISTERED_AT.to_string(),
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct PersistedWorkspaceApplicationState {
+    app_id: String,
+    app_version: String,
+    schema_version: String,
+    #[serde(default)]
+    manifest_path: String,
+    #[serde(default)]
+    manifest_digest: String,
+    #[serde(default)]
+    bundle_digest: String,
+    workspace_id: String,
+    state_scope: String,
+    #[serde(default)]
+    components: Vec<Value>,
+    #[serde(default)]
+    workflows: Vec<PersistedWorkspaceWorkflow>,
+    #[serde(default)]
+    model_dependencies: Vec<ApplicationModelDependency>,
+    registration_fingerprint: Value,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+struct PersistedWorkspaceWorkflow {
+    workflow_id: String,
+    workflow_version: String,
+    #[serde(default)]
+    workflow_digest: String,
+    path: String,
+}
+
+fn workspace_application_state_files(
+    workspace_root: &Path,
+    workspace_id: &str,
+) -> Result<Vec<PathBuf>, WorkspaceAppStateFailure> {
+    let apps_dir = workspace_root
+        .join(".traverse")
+        .join("workspaces")
+        .join(workspace_id)
+        .join("apps");
+    if !apps_dir.exists() {
+        return Err(single_error(
+            WorkspaceAppStateErrorCode::MissingWorkspaceState,
+            &apps_dir,
+            format!("workspace {workspace_id} has no durable app registration state"),
+        ));
+    }
+    let mut files = Vec::new();
+    collect_registration_files(&apps_dir, &mut files)?;
+    if files.is_empty() {
+        return Err(single_error(
+            WorkspaceAppStateErrorCode::MissingWorkspaceState,
+            &apps_dir,
+            format!("workspace {workspace_id} has no app registration files"),
+        ));
+    }
+    files.sort();
+    Ok(files)
+}
+
+fn collect_registration_files(
+    root: &Path,
+    files: &mut Vec<PathBuf>,
+) -> Result<(), WorkspaceAppStateFailure> {
+    let entries = fs::read_dir(root).map_err(|error| {
+        single_error(
+            WorkspaceAppStateErrorCode::StateReadFailed,
+            root,
+            format!("failed to read workspace app state directory: {error}"),
+        )
+    })?;
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            collect_registration_files(&path, files)?;
+        } else if path.file_name().and_then(|name| name.to_str()) == Some("registration.json") {
+            files.push(path);
+        }
+    }
+    Ok(())
+}
+
+struct ParsedApplication {
+    registration: WorkspaceApplicationRegistration,
+    workflows: Vec<PersistedWorkspaceWorkflow>,
+}
+
+fn read_application(
+    workspace_root: &Path,
+    workspace_id: &str,
+    state_path: &Path,
+) -> Result<ParsedApplication, WorkspaceAppStateFailure> {
+    let bytes = fs::read(state_path).map_err(|error| {
+        single_error(
+            WorkspaceAppStateErrorCode::StateReadFailed,
+            state_path,
+            format!("failed to read workspace app registration state: {error}"),
+        )
+    })?;
+    let state: PersistedWorkspaceApplicationState =
+        serde_json::from_slice(&bytes).map_err(|error| {
+            single_error(
+                WorkspaceAppStateErrorCode::StateParseFailed,
+                state_path,
+                format!("failed to parse workspace app registration state: {error}"),
+            )
+        })?;
+    if state.schema_version != WORKSPACE_APP_STATE_SCHEMA_VERSION {
+        return Err(single_error(
+            WorkspaceAppStateErrorCode::IncompatibleSchemaVersion,
+            state_path,
+            format!(
+                "workspace app state schema {} is not supported",
+                state.schema_version
+            ),
+        ));
+    }
+    if state.workspace_id != workspace_id || state.state_scope != WORKSPACE_APP_STATE_SCOPE {
+        return Err(single_error(
+            WorkspaceAppStateErrorCode::IncompatibleWorkspaceState,
+            state_path,
+            "workspace app state does not belong to the requested workspace".to_string(),
+        ));
+    }
+    if state.components.is_empty() {
+        return Err(single_error(
+            WorkspaceAppStateErrorCode::CorruptWorkspaceState,
+            state_path,
+            "workspace app state must include at least one component".to_string(),
+        ));
+    }
+    let fingerprint = &state.registration_fingerprint;
+    let matches_identity = fingerprint
+        .get("app_id")
+        .and_then(Value::as_str)
+        .is_some_and(|value| value == state.app_id)
+        && fingerprint
+            .get("app_version")
+            .and_then(Value::as_str)
+            .is_some_and(|value| value == state.app_version)
+        && fingerprint
+            .get("manifest_digest")
+            .and_then(Value::as_str)
+            .is_some_and(|value| value == state.manifest_digest);
+    if !matches_identity {
+        return Err(single_error(
+            WorkspaceAppStateErrorCode::CorruptWorkspaceState,
+            state_path,
+            "workspace app registration fingerprint does not match state identity".to_string(),
+        ));
+    }
+    let _ = workspace_root;
+    Ok(ParsedApplication {
+        registration: WorkspaceApplicationRegistration {
+            app_id: state.app_id,
+            app_version: state.app_version,
+            manifest_path: state.manifest_path,
+            manifest_digest: state.manifest_digest,
+            bundle_digest: state.bundle_digest,
+            model_dependencies: state.model_dependencies,
+            state_path: state_path.to_path_buf(),
+        },
+        workflows: state.workflows,
+    })
+}
+
+fn load_workflows_for_app(
+    workspace_root: &Path,
+    workflows: &[PersistedWorkspaceWorkflow],
+    index: &CapabilityMetadataIndex,
+    validator_version: &str,
+) -> Result<Vec<ResolvedWorkflow>, WorkspaceAppStateFailure> {
+    let mut loaded = Vec::new();
+    for workflow in workflows {
+        let path = resolve_workspace_state_path(workspace_root, &workflow.path);
+        let contents = fs::read_to_string(&path).map_err(|error| {
+            single_error(
+                WorkspaceAppStateErrorCode::StateReadFailed,
+                &path,
+                format!("failed to read registered workflow: {error}"),
+            )
+        })?;
+        let definition: WorkflowDefinition = serde_json::from_str(&contents).map_err(|error| {
+            single_error(
+                WorkspaceAppStateErrorCode::CorruptWorkspaceState,
+                &path,
+                format!("registered workflow is invalid JSON: {error}"),
+            )
+        })?;
+        if definition.id != workflow.workflow_id || definition.version != workflow.workflow_version
+        {
+            return Err(single_error(
+                WorkspaceAppStateErrorCode::CorruptWorkspaceState,
+                &path,
+                "registered workflow identity does not match workspace state".to_string(),
+            ));
+        }
+        validate_workflow_against_index(&definition, index, &path)?;
+        loaded.push(resolved_workflow(
+            definition,
+            path.display().to_string(),
+            workflow.workflow_digest.clone(),
+            validator_version,
+        ));
+    }
+    Ok(loaded)
+}
+
+fn validate_workflow_against_index(
+    definition: &WorkflowDefinition,
+    index: &CapabilityMetadataIndex,
+    path: &Path,
+) -> Result<(), WorkspaceAppStateFailure> {
+    let node_ids: BTreeSet<&str> = definition
+        .nodes
+        .iter()
+        .map(|node| node.node_id.as_str())
+        .collect();
+    if !node_ids.contains(definition.start_node.as_str()) {
+        return Err(single_error(
+            WorkspaceAppStateErrorCode::WorkflowRegistrationFailed,
+            path,
+            "workflow start_node is not present in the definition".to_string(),
+        ));
+    }
+    for terminal in &definition.terminal_nodes {
+        if !node_ids.contains(terminal.as_str()) {
+            return Err(single_error(
+                WorkspaceAppStateErrorCode::WorkflowRegistrationFailed,
+                path,
+                format!("workflow terminal node {terminal} is not present in the definition"),
+            ));
+        }
+    }
+    for node in &definition.nodes {
+        if index
+            .get(&node.capability_id, &node.capability_version)
+            .is_none()
+        {
+            return Err(single_error(
+                WorkspaceAppStateErrorCode::WorkflowRegistrationFailed,
+                path,
+                format!(
+                    "workflow node {} references capability {}@{} missing from the metadata index",
+                    node.node_id, node.capability_id, node.capability_version
+                ),
+            ));
+        }
+    }
+    for edge in &definition.edges {
+        if !node_ids.contains(edge.from.as_str()) || !node_ids.contains(edge.to.as_str()) {
+            return Err(single_error(
+                WorkspaceAppStateErrorCode::WorkflowRegistrationFailed,
+                path,
+                format!("workflow edge {} references a missing node", edge.edge_id),
+            ));
+        }
+    }
+    if workflow_has_cycle(&definition.edges, &node_ids) {
+        return Err(single_error(
+            WorkspaceAppStateErrorCode::WorkflowRegistrationFailed,
+            path,
+            "workflow topology contains a cycle".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+fn workflow_has_cycle(edges: &[WorkflowEdge], node_ids: &BTreeSet<&str>) -> bool {
+    let mut adjacency: BTreeMap<&str, Vec<&str>> = BTreeMap::new();
+    for id in node_ids {
+        adjacency.insert(*id, Vec::new());
+    }
+    for edge in edges {
+        if edge.trigger == WorkflowEdgeTrigger::Direct
+            && let Some(targets) = adjacency.get_mut(edge.from.as_str())
+        {
+            targets.push(edge.to.as_str());
+        }
+    }
+    let mut visiting = BTreeSet::new();
+    let mut visited = BTreeSet::new();
+    node_ids
+        .iter()
+        .any(|node| dfs_cycle(node, &adjacency, &mut visiting, &mut visited))
+}
+
+fn dfs_cycle<'a>(
+    node: &'a str,
+    adjacency: &BTreeMap<&str, Vec<&'a str>>,
+    visiting: &mut BTreeSet<&'a str>,
+    visited: &mut BTreeSet<&'a str>,
+) -> bool {
+    if visited.contains(node) {
+        return false;
+    }
+    if !visiting.insert(node) {
+        return true;
+    }
+    let cyclic = adjacency
+        .get(node)
+        .into_iter()
+        .flatten()
+        .any(|next| dfs_cycle(next, adjacency, visiting, visited));
+    visiting.remove(node);
+    visited.insert(node);
+    cyclic
+}
+
+fn resolved_workflow(
+    definition: WorkflowDefinition,
+    workflow_path: String,
+    workflow_digest: String,
+    validator_version: &str,
+) -> ResolvedWorkflow {
+    let participating_capabilities = definition
+        .nodes
+        .iter()
+        .map(|node| node.capability_id.clone())
+        .collect::<Vec<_>>();
+    let record = WorkflowRegistryRecord {
+        scope: RegistryScope::Private,
+        id: definition.id.clone(),
+        version: definition.version.clone(),
+        lifecycle: definition.lifecycle.clone(),
+        owner: definition.owner.clone(),
+        workflow_path,
+        workflow_digest,
+        registered_at: INDEXED_REGISTERED_AT.to_string(),
+        governing_spec: definition.governing_spec.clone(),
+        validator_version: validator_version.to_string(),
+        evidence: WorkflowRegistrationEvidence {
+            evidence_id: format!("wfidx_{}_{}", definition.id, definition.version),
+            workflow_id: definition.id.clone(),
+            workflow_version: definition.version.clone(),
+            scope: RegistryScope::Private,
+            governing_spec: definition.governing_spec.clone(),
+            validator_version: validator_version.to_string(),
+            produced_at: INDEXED_REGISTERED_AT.to_string(),
+            result: WorkflowRegistrationResult::Passed,
+        },
+    };
+    let index_entry = WorkflowDiscoveryIndexEntry {
+        scope: RegistryScope::Private,
+        id: definition.id.clone(),
+        version: definition.version.clone(),
+        lifecycle: definition.lifecycle.clone(),
+        owner: definition.owner.clone(),
+        summary: definition.summary.clone(),
+        tags: definition.tags.clone(),
+        participating_capabilities,
+        events_used: Vec::new(),
+        start_node: definition.start_node.clone(),
+        terminal_nodes: definition.terminal_nodes.clone(),
+        registered_at: INDEXED_REGISTERED_AT.to_string(),
+    };
+    ResolvedWorkflow {
+        definition,
+        record,
+        index_entry,
+    }
+}
+
+fn resolve_workspace_state_path(workspace_root: &Path, raw: &str) -> PathBuf {
+    let path = PathBuf::from(raw);
+    if path.is_absolute() {
+        path
+    } else {
+        workspace_root.join(path)
+    }
+}
+
+fn single_error(
+    code: WorkspaceAppStateErrorCode,
+    path: &Path,
+    message: String,
+) -> WorkspaceAppStateFailure {
+    WorkspaceAppStateFailure {
+        errors: vec![WorkspaceAppStateError {
+            code,
+            path: path.display().to_string(),
+            message,
+        }],
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::panic)]
+mod tests {
+    use super::*;
+    use serde_json::{Value, json};
+    use std::path::{Path, PathBuf};
+    use std::sync::atomic::{AtomicU64, Ordering};
+    use traverse_contracts::Owner;
+
+    fn unique_dir() -> PathBuf {
+        static NEXT: AtomicU64 = AtomicU64::new(1);
+        let dir = std::env::temp_dir().join(format!(
+            "traverse-runtime-lazy-workspace-{}-{}",
+            std::process::id(),
+            NEXT.fetch_add(1, Ordering::Relaxed)
+        ));
+        fs::create_dir_all(&dir).expect("temp dir");
+        dir
+    }
+
+    #[test]
+    fn missing_workspace_state_is_reported() {
+        let root = unique_dir();
+        let failure = load_lazy_workspace(&root, "local", "test").expect_err("missing");
+        assert_eq!(
+            failure.errors[0].code,
+            WorkspaceAppStateErrorCode::MissingWorkspaceState
+        );
+    }
+
+    #[test]
+    fn apps_path_that_is_a_file_is_a_read_failure() {
+        let root = unique_dir();
+        let apps = root.join(".traverse/workspaces/local/apps");
+        fs::create_dir_all(apps.parent().expect("parent")).expect("parent");
+        fs::write(&apps, b"not-a-dir").expect("file");
+        let failure = load_lazy_workspace(&root, "local", "test").expect_err("file");
+        assert_eq!(
+            failure.errors[0].code,
+            WorkspaceAppStateErrorCode::StateReadFailed
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn unreadable_registration_is_a_read_failure() {
+        use std::os::unix::fs::PermissionsExt;
+        let root = unique_dir();
+        let contract = root.join("c.json");
+        fs::write(&contract, real_contract()).expect("contract");
+        let path = write_state(&root, &base_state(&contract, json!({})));
+        let mut permissions = fs::metadata(&path).expect("meta").permissions();
+        permissions.set_mode(0o000);
+        fs::set_permissions(&path, permissions.clone()).expect("chmod");
+        let failure = load_lazy_workspace(&root, "local", "test");
+        permissions.set_mode(0o644);
+        fs::set_permissions(&path, permissions).expect("restore");
+        assert_eq!(
+            failure.expect_err("unreadable").errors[0].code,
+            WorkspaceAppStateErrorCode::StateReadFailed
+        );
+    }
+
+    #[test]
+    fn empty_apps_directory_is_missing_state() {
+        let root = unique_dir();
+        let apps = root.join(".traverse/workspaces/local/apps");
+        fs::create_dir_all(&apps).expect("apps");
+        let failure = load_lazy_workspace(&root, "local", "test").expect_err("empty");
+        assert_eq!(
+            failure.errors[0].code,
+            WorkspaceAppStateErrorCode::MissingWorkspaceState
+        );
+    }
+
+    #[test]
+    fn lookup_indexed_workflow_hides_private_entries_from_public_scope() {
+        let mut workflows = BTreeMap::new();
+        workflows.insert(
+            ("wf".to_string(), "1.0.0".to_string()),
+            resolved_workflow(
+                WorkflowDefinition {
+                    kind: "workflow_definition".to_string(),
+                    schema_version: "1.0.0".to_string(),
+                    id: "wf".to_string(),
+                    name: "wf".to_string(),
+                    version: "1.0.0".to_string(),
+                    lifecycle: traverse_contracts::Lifecycle::Active,
+                    owner: Owner {
+                        team: "t".to_string(),
+                        contact: "t@example.com".to_string(),
+                    },
+                    summary: "s".to_string(),
+                    inputs: traverse_contracts::SchemaContainer {
+                        schema: serde_json::json!({"type": "object"}),
+                    },
+                    outputs: traverse_contracts::SchemaContainer {
+                        schema: serde_json::json!({"type": "object"}),
+                    },
+                    nodes: Vec::new(),
+                    edges: Vec::new(),
+                    start_node: "start".to_string(),
+                    terminal_nodes: Vec::new(),
+                    output_projection: Vec::new(),
+                    tags: Vec::new(),
+                    governing_spec: "007-workflow-registry-traversal".to_string(),
+                },
+                "wf.json".to_string(),
+                "sha256:x".to_string(),
+                "test",
+            ),
+        );
+        assert!(
+            lookup_indexed_workflow(&workflows, LookupScope::PublicOnly, "wf", "1.0.0").is_none()
+        );
+        assert!(
+            lookup_indexed_workflow(&workflows, LookupScope::PreferPrivate, "wf", "1.0.0")
+                .is_some()
+        );
+    }
+
+    fn write_state(root: &Path, body: &Value) -> PathBuf {
+        let state_path =
+            root.join(".traverse/workspaces/local/apps/demo.app/1.0.0/registration.json");
+        fs::create_dir_all(state_path.parent().expect("parent")).expect("parent");
+        fs::write(&state_path, serde_json::to_vec(body).expect("serialize")).expect("write");
+        state_path
+    }
+
+    fn base_state(contract: &Path, extra: Value) -> Value {
+        let mut body = json!({
+            "app_id": "demo.app",
+            "app_version": "1.0.0",
+            "schema_version": "1.0.0",
+            "manifest_path": "app.manifest.json",
+            "manifest_digest": "sha256:manifest",
+            "bundle_digest": "sha256:bundle",
+            "workspace_id": "local",
+            "state_scope": "workspace_persisted",
+            "components": [{
+                "component_id": "demo.component",
+                "component_version": "1.0.0",
+                "capability_id": "demo.capability",
+                "capability_version": "1.0.0",
+                "contract_path": contract.display().to_string(),
+                "artifact_ref": contract.display().to_string(),
+                "manifest_path": contract.display().to_string()
+            }],
+            "workflows": [],
+            "registration_fingerprint": {
+                "app_id": "demo.app",
+                "app_version": "1.0.0",
+                "manifest_digest": "sha256:manifest"
+            }
+        });
+        if let Value::Object(extra) = extra
+            && let Value::Object(root) = &mut body
+        {
+            root.extend(extra);
+        }
+        body
+    }
+
+    fn real_contract() -> String {
+        let path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(
+            "../../contracts/examples/expedition/capabilities/validate-team-readiness/contract.json",
+        );
+        fs::read_to_string(path).expect("fixture contract")
+    }
+
+    fn workflow_json(
+        id: &str,
+        nodes: &Value,
+        edges: &Value,
+        start: &str,
+        terminals: &Value,
+    ) -> Value {
+        json!({
+            "kind": "workflow_definition",
+            "schema_version": "1.0.0",
+            "id": id,
+            "name": id,
+            "version": "1.0.0",
+            "lifecycle": "active",
+            "owner": {"team": "t", "contact": "t@example.com"},
+            "summary": "s",
+            "inputs": {"schema": {"type": "object"}},
+            "outputs": {"schema": {"type": "object"}},
+            "nodes": nodes,
+            "edges": edges,
+            "start_node": start,
+            "terminal_nodes": terminals,
+            "tags": [],
+            "governing_spec": "007-workflow-registry-traversal"
+        })
+    }
+
+    fn write_workflow_app(root: &Path, definition: &Value, capability_id: &str) {
+        let contract = root.join("c.json");
+        let mut contract_json: Value = serde_json::from_str(&real_contract()).expect("json");
+        contract_json["id"] = json!(capability_id);
+        fs::write(&contract, contract_json.to_string()).expect("contract");
+        let wf = root.join("wf.json");
+        fs::write(&wf, definition.to_string()).expect("workflow");
+        let mut body = base_state(&contract, json!({}));
+        body["components"][0]["capability_id"] = json!(capability_id);
+        body["workflows"] = json!([{
+            "workflow_id": definition["id"],
+            "workflow_version": "1.0.0",
+            "workflow_digest": "sha256:wf",
+            "path": wf.display().to_string()
+        }]);
+        write_state(root, &body);
+    }
+
+    #[test]
+    fn parse_and_schema_failures_are_stable() {
+        let root = unique_dir();
+        write_state(&root, &json!("nope"));
+        let failure = load_lazy_workspace(&root, "local", "test").expect_err("parse");
+        assert_eq!(
+            failure.errors[0].code,
+            WorkspaceAppStateErrorCode::StateParseFailed
+        );
+
+        let root = unique_dir();
+        let contract = root.join("c.json");
+        fs::write(&contract, real_contract()).expect("contract");
+        let mut body = base_state(&contract, json!({}));
+        body["schema_version"] = json!("9.0.0");
+        write_state(&root, &body);
+        let failure = load_lazy_workspace(&root, "local", "test").expect_err("schema");
+        assert_eq!(
+            failure.errors[0].code,
+            WorkspaceAppStateErrorCode::IncompatibleSchemaVersion
+        );
+
+        let root = unique_dir();
+        let contract = root.join("c.json");
+        fs::write(&contract, real_contract()).expect("contract");
+        let mut body = base_state(&contract, json!({}));
+        body["workspace_id"] = json!("other");
+        write_state(&root, &body);
+        let failure = load_lazy_workspace(&root, "local", "test").expect_err("workspace");
+        assert_eq!(
+            failure.errors[0].code,
+            WorkspaceAppStateErrorCode::IncompatibleWorkspaceState
+        );
+
+        let root = unique_dir();
+        let contract = root.join("c.json");
+        fs::write(&contract, real_contract()).expect("contract");
+        let mut body = base_state(&contract, json!({}));
+        body["state_scope"] = json!("other");
+        write_state(&root, &body);
+        let failure = load_lazy_workspace(&root, "local", "test").expect_err("scope");
+        assert_eq!(
+            failure.errors[0].code,
+            WorkspaceAppStateErrorCode::IncompatibleWorkspaceState
+        );
+    }
+
+    #[test]
+    fn corrupt_fingerprint_and_empty_components_fail() {
+        let root = unique_dir();
+        let contract = root.join("c.json");
+        fs::write(&contract, real_contract()).expect("contract");
+        let mut body = base_state(&contract, json!({}));
+        body["components"] = json!([]);
+        write_state(&root, &body);
+        let failure = load_lazy_workspace(&root, "local", "test").expect_err("empty");
+        assert_eq!(
+            failure.errors[0].code,
+            WorkspaceAppStateErrorCode::CorruptWorkspaceState
+        );
+
+        let root = unique_dir();
+        let contract = root.join("c.json");
+        fs::write(&contract, real_contract()).expect("contract");
+        let mut body = base_state(&contract, json!({}));
+        body["registration_fingerprint"]["app_id"] = json!("other");
+        write_state(&root, &body);
+        let failure = load_lazy_workspace(&root, "local", "test").expect_err("fingerprint");
+        assert_eq!(
+            failure.errors[0].code,
+            WorkspaceAppStateErrorCode::CorruptWorkspaceState
+        );
+    }
+
+    #[test]
+    fn workflow_topology_and_identity_failures() {
+        let root = unique_dir();
+        let missing_wf = root.join("missing-wf.json");
+        let contract = root.join("c.json");
+        fs::write(&contract, real_contract()).expect("contract");
+        let mut body = base_state(&contract, json!({}));
+        body["workflows"] = json!([{
+            "workflow_id": "wf",
+            "workflow_version": "1.0.0",
+            "path": missing_wf.display().to_string()
+        }]);
+        write_state(&root, &body);
+        let failure = load_lazy_workspace(&root, "local", "test").expect_err("missing wf");
+        assert_eq!(
+            failure.errors[0].code,
+            WorkspaceAppStateErrorCode::StateReadFailed
+        );
+
+        let root = unique_dir();
+        let wf = root.join("wf.json");
+        fs::write(&wf, "{").expect("bad json");
+        let contract = root.join("c.json");
+        fs::write(&contract, real_contract()).expect("contract");
+        let mut body = base_state(&contract, json!({}));
+        body["workflows"] = json!([{
+            "workflow_id": "wf",
+            "workflow_version": "1.0.0",
+            "path": wf.display().to_string()
+        }]);
+        write_state(&root, &body);
+        let failure = load_lazy_workspace(&root, "local", "test").expect_err("bad json");
+        assert_eq!(
+            failure.errors[0].code,
+            WorkspaceAppStateErrorCode::CorruptWorkspaceState
+        );
+
+        let root = unique_dir();
+        let contract = root.join("c.json");
+        let mut contract_json: Value = serde_json::from_str(&real_contract()).expect("json");
+        contract_json["id"] = json!("demo.capability");
+        fs::write(&contract, contract_json.to_string()).expect("contract");
+        let wf = root.join("wf.json");
+        fs::write(
+            &wf,
+            workflow_json(
+                "other.wf",
+                &json!([{
+                    "node_id": "n1",
+                    "capability_id": "demo.capability",
+                    "capability_version": "1.0.0",
+                    "input": {"from_workflow_input": []},
+                    "output": {"to_workflow_state": []}
+                }]),
+                &json!([]),
+                "n1",
+                &json!(["n1"]),
+            )
+            .to_string(),
+        )
+        .expect("workflow");
+        let mut body = base_state(&contract, json!({}));
+        body["workflows"] = json!([{
+            "workflow_id": "wf",
+            "workflow_version": "1.0.0",
+            "path": wf.display().to_string()
+        }]);
+        write_state(&root, &body);
+        let failure = load_lazy_workspace(&root, "local", "test").expect_err("identity");
+        assert_eq!(
+            failure.errors[0].code,
+            WorkspaceAppStateErrorCode::CorruptWorkspaceState
+        );
+    }
+
+    fn expect_workflow_registration_failure(definition: &Value) {
+        let root = unique_dir();
+        write_workflow_app(root.as_path(), definition, "demo.capability");
+        assert_eq!(
+            load_lazy_workspace(&root, "local", "test")
+                .expect_err("workflow")
+                .errors[0]
+                .code,
+            WorkspaceAppStateErrorCode::WorkflowRegistrationFailed
+        );
+    }
+
+    #[test]
+    fn workflow_index_validation_covers_topology() {
+        let node = |id: &str, cap: &str| {
+            json!({
+                "node_id": id,
+                "capability_id": cap,
+                "capability_version": "1.0.0",
+                "input": {"from_workflow_input": []},
+                "output": {"to_workflow_state": []}
+            })
+        };
+        let edge = |id: &str, from: &str, to: &str| {
+            json!({
+                "edge_id": id,
+                "from": from,
+                "to": to,
+                "trigger": "direct"
+            })
+        };
+        expect_workflow_registration_failure(&workflow_json(
+            "wf",
+            &json!([node("n1", "demo.capability")]),
+            &json!([]),
+            "missing",
+            &json!(["n1"]),
+        ));
+        expect_workflow_registration_failure(&workflow_json(
+            "wf",
+            &json!([node("n1", "demo.capability")]),
+            &json!([]),
+            "n1",
+            &json!(["missing"]),
+        ));
+        expect_workflow_registration_failure(&workflow_json(
+            "wf",
+            &json!([node("n1", "missing.cap")]),
+            &json!([]),
+            "n1",
+            &json!(["n1"]),
+        ));
+        expect_workflow_registration_failure(&workflow_json(
+            "wf",
+            &json!([node("n1", "demo.capability")]),
+            &json!([edge("e1", "n1", "ghost")]),
+            "n1",
+            &json!(["n1"]),
+        ));
+        expect_workflow_registration_failure(&workflow_json(
+            "wf",
+            &json!([node("n1", "demo.capability"), node("n2", "demo.capability")]),
+            &json!([edge("e1", "n1", "n2"), edge("e2", "n2", "n1")]),
+            "n1",
+            &json!(["n2"]),
+        ));
+    }
+
+    #[test]
+    fn successful_workflow_load_and_relative_path() {
+        let root = unique_dir();
+        let contract = root.join("c.json");
+        let mut contract_json: Value = serde_json::from_str(&real_contract()).expect("json");
+        contract_json["id"] = json!("demo.capability");
+        fs::write(&contract, contract_json.to_string()).expect("contract");
+        fs::write(
+            root.join("wf.json"),
+            workflow_json(
+                "wf",
+                &json!([
+                    {
+                        "node_id": "n1",
+                        "capability_id": "demo.capability",
+                        "capability_version": "1.0.0",
+                        "input": {"from_workflow_input": []},
+                        "output": {"to_workflow_state": []}
+                    },
+                    {
+                        "node_id": "n2",
+                        "capability_id": "demo.capability",
+                        "capability_version": "1.0.0",
+                        "input": {"from_workflow_input": []},
+                        "output": {"to_workflow_state": []}
+                    }
+                ]),
+                &json!([
+                    {
+                        "edge_id": "e1",
+                        "from": "n1",
+                        "to": "n2",
+                        "trigger": "direct"
+                    },
+                    {
+                        "edge_id": "e2",
+                        "from": "n1",
+                        "to": "n2",
+                        "trigger": "event",
+                        "event": {"event_id": "demo.event", "version": "1.0.0"}
+                    }
+                ]),
+                "n1",
+                &json!(["n2"]),
+            )
+            .to_string(),
+        )
+        .expect("wf");
+        let mut body = base_state(&contract, json!({}));
+        body["workflows"] = json!([{
+            "workflow_id": "wf",
+            "workflow_version": "1.0.0",
+            "workflow_digest": "sha256:wf",
+            "path": "wf.json"
+        }]);
+        write_state(&root, &body);
+        let loaded = load_lazy_workspace(&root, "local", "test").expect("load");
+        assert_eq!(loaded.workflows.len(), 1);
+        assert!(
+            lookup_indexed_workflow(&loaded.workflows, LookupScope::PreferPrivate, "wf", "1.0.0")
+                .is_some()
+        );
+        let missing = resolved_from_index(
+            &CapabilityMetadataIndex::from_workspace_applications(&loaded.applications),
+            traverse_contracts::parse_contract(&real_contract()).expect("contract"),
+            "missing",
+            "1.0.0",
+            "test",
+        );
+        assert!(missing.artifact.binary.is_none());
+        assert!(missing.record.contract_path.is_empty());
+    }
+
+    #[test]
+    fn empty_artifact_resolves_without_binary() {
+        let root = unique_dir();
+        let contract = root.join("c.json");
+        let mut contract_json: Value = serde_json::from_str(&real_contract()).expect("json");
+        contract_json["id"] = json!("demo.capability");
+        fs::write(&contract, contract_json.to_string()).expect("contract");
+        let mut body = base_state(&contract, json!({}));
+        body["components"][0]["artifact_ref"] = json!("");
+        write_state(&root, &body);
+        let loaded = load_lazy_workspace(&root, "local", "test").expect("load");
+        let index = CapabilityMetadataIndex::from_workspace_applications(&loaded.applications);
+        let resolved = resolved_from_index(
+            &index,
+            traverse_contracts::parse_contract(&contract_json.to_string()).expect("parse"),
+            "demo.capability",
+            "1.0.0",
+            "test",
+        );
+        assert!(resolved.artifact.binary.is_none());
+    }
+}

--- a/docs/releases/next.md
+++ b/docs/releases/next.md
@@ -3,9 +3,11 @@
 ## Lazy capability metadata index
 
 `serve` now builds an immutable persisted capability metadata index at workspace
-load without parsing every component contract. Verified contracts hydrate on
-demand into a host-configured process-local LRU with single-flight coalescing.
-Command and workflow integration remains a follow-up.
+load without parsing every component contract. Command routing and reached
+workflow steps hydrate digest-verified contracts on demand into a host-configured
+process-local LRU with single-flight coalescing. Unreached workflow branches stay
+unparsed. Hydration faults fail only the dependent command or workflow with
+secret-free diagnostics.
 
 ## Server-owned app availability
 


### PR DESCRIPTION
## Summary

- Workspace load now reconstructs command and workflow identity from the persisted metadata index without parsing component contracts.
- Command routing and reached workflow steps hydrate digest-verified contracts just in time; unreached branches stay unparsed.
- Hydration faults fail only that command or workflow, with secret-free diagnostics and ordered trace evidence. Per-invocation artifact verification is unchanged.

Closes #1331

## Governing Spec

- `134-lazy-capability-registry-reconstruction`
- `065-sigstore-bundle-verification`

## Project Item

- https://github.com/traverse-framework/Traverse/issues/1331
- https://github.com/orgs/traverse-framework/projects/1/

## What Changed

- Contracts changed: none.
- Runtime behavior changed: `Runtime::from_workspace_app_state` no longer eagerly builds a `CapabilityRegistry`. Commands collect candidates from the index and hydrate the selected capability; workflow topology is validated from the index and reached steps hydrate on traversal.
- Compatibility impact: additive for in-memory registry construction. Workspace-loaded runtimes expose indexed capabilities through execute/workflow paths rather than `capability_registry().discover`.
- ADR needed or linked: ADR-0067.

## Validation

- [x] Spec alignment checked
- [x] Contract alignment checked
- [x] Tests updated and passing
- [x] Core coverage preserved
- [x] Required validation gates passing

## Notes

No Registry fetch, sync, or mutation at workspace load or execution. HTTP capability listing for workspace-loaded apps remains empty until a follow-up wires discover through the index.

Made with [Cursor](https://cursor.com)