### PR TITLE
fix(web): browserLocalPlan forwarding-chain parity with Rust (#1338)

### DIFF
--- a/packages/web/TraverseEmbedder/src/browserLocalPlan.ts
+++ b/packages/web/TraverseEmbedder/src/browserLocalPlan.ts
@@ -97,16 +97,30 @@ export async function browserLocalPlan(identity: BrowserSnapshotIdentity, snapsh
     return { id: found.id, version: found.version, digest: found.digest, inputs, outputs, emits };
   }).sort((a,b) => a.id.localeCompare(b.id) || a.version.localeCompare(b.version));
   // Starting facts are values, unlike contract schemas; their own keys form
-  // the initial structural output set.
+  // the initial structural output set. Chain search MUST match Rust
+  // `build_chains` in `browser_local_plan.rs`: the base case is against
+  // starting facts only, predecessor coverage uses the predecessor's outputs
+  // alone, and starting facts are never accumulated with a node's own outputs
+  // (issue #1338).
   const facts = Object.keys(record(startingFacts) ?? {}).sort();
   const targets = declared.filter(c => (target.capability_id !== undefined && target.capability_version !== undefined && c.id === target.capability_id && c.version === target.capability_version) || (target.emits_event !== undefined && c.emits.includes(target.emits_event)));
   const chains: Declared[][] = [];
-  const visit = (node: Declared, chain: Declared[], available: readonly string[]): void => {
+  const visit = (node: Declared, chain: Declared[]): void => {
     if (chains.length >= BROWSER_PLAN_MAX_CANDIDATES || chain.length >= BROWSER_PLAN_MAX_NODES) return;
-    if (node.inputs.every(field => available.includes(field))) { chains.push([...chain, node]); return; }
-    for (const predecessor of declared) if (!chain.includes(predecessor) && node.inputs.every(field => available.includes(field) || predecessor.outputs.includes(field))) visit(predecessor, [...chain, node], [...available, ...predecessor.outputs]);
+    // Base case: covered by starting facts only — never by this node's outputs.
+    if (node.inputs.every(field => facts.includes(field))) {
+      chains.push([...chain, node]);
+    }
+    // Empty required inputs never gain predecessors (vacuous cover would invent edges).
+    if (node.inputs.length === 0) return;
+    for (const predecessor of declared) {
+      if (predecessor === node || chain.includes(predecessor)) continue;
+      // Predecessor outputs alone must cover this node's required inputs.
+      if (!node.inputs.every(field => predecessor.outputs.includes(field))) continue;
+      visit(predecessor, [...chain, node]);
+    }
   };
-  for (const candidate of targets) visit(candidate, [], facts);
+  for (const candidate of targets) visit(candidate, []);
   const proposals = chains.slice(0, BROWSER_PLAN_MAX_CANDIDATES).map((chain, index) => {
     const ordered = [...chain].reverse(); const nodes = ordered.map((c, n) => ({ node_id: `node-${n + 1}`, capability_id: c.id, capability_version: c.version, artifact_digest: c.digest }));
     const mappings: BrowserProposalMapping[] = [];

--- a/packages/web/TraverseEmbedder/tests/browserLocalPlan.test.mjs
+++ b/packages/web/TraverseEmbedder/tests/browserLocalPlan.test.mjs
@@ -26,6 +26,76 @@ test("browser planner is deterministic, structural, and leaves mappings unconfir
   assert.deepEqual(first.proposals[0].proposal.nodes.map(node => node.capability_id), ["source", "sink"]);
 });
 
+test("browser planner keeps forwarding intermediate nodes in end-to-end chains", async () => {
+  // Regression for #1338 / registry#441: an intermediate node that both
+  // consumes and forwards a field (inputs ∩ outputs ≠ ∅) must remain on the
+  // planned path. The old TS visit() folded predecessor outputs into
+  // `available`, so the intermediate looked like a valid chain head and the
+  // upstream edge was dropped.
+  const nodes = [
+    { id: "collect", inputs: ["fragments"], outputs: ["fragments", "structured_facts"] },
+    { id: "enrich", inputs: ["fragments", "structured_facts"], outputs: ["fragments", "structured_facts", "insights"] },
+    { id: "summarize", inputs: ["structured_facts", "insights"], outputs: ["structured_facts", "summary"] },
+    { id: "format", inputs: ["summary"], outputs: ["report"] },
+  ];
+  const snapshot = {
+    releaseTag: "registry-v1",
+    capabilities: nodes.map((node, index) => ({
+      namespace: "report",
+      id: node.id,
+      version: "1.0.0",
+      digest: digest(String.fromCharCode(97 + index)),
+      artifactUrl: "",
+      contractDigest: "",
+      contractUrl: "",
+      deprecated: false,
+    })),
+  };
+  const identity = {
+    registry_snapshot_digest: sha(snapshot),
+    source_release: snapshot.releaseTag,
+    contract_schema_version: "1.0.0",
+  };
+  const dependencies = nodes.map((node, index) => ({
+    wasmBytes: new Uint8Array(),
+    contractBytes: new TextEncoder().encode(JSON.stringify(contract(node.id, node.inputs, node.outputs))),
+    wasmDigest: digest(String.fromCharCode(97 + index)),
+    evidence: {
+      namespace: "report",
+      id: node.id,
+      selectedVersion: "1.0.0",
+      versionRange: "1.0.0",
+      sourceRelease: "registry-v1",
+      indexDigest: identity.registry_snapshot_digest,
+      artifactDigest: digest(String.fromCharCode(97 + index)),
+      verifiedAt: 1,
+      outcome: "prepared",
+    },
+  }));
+  const result = await browserLocalPlan(
+    identity,
+    snapshot,
+    dependencies,
+    { capability_id: "format", capability_version: "1.0.0" },
+    { fragments: "[]" },
+    "local",
+    { app_id: "report" },
+  );
+  const paths = result.proposals.map((proposal) =>
+    proposal.proposal.nodes.map((node) => node.capability_id),
+  );
+  assert.ok(
+    paths.some((path) =>
+      path.length === 4
+      && path[0] === "collect"
+      && path[1] === "enrich"
+      && path[2] === "summarize"
+      && path[3] === "format",
+    ),
+    `expected collect→enrich→summarize→format among proposals, got ${JSON.stringify(paths)}`,
+  );
+});
+
 test("browser planner fails closed before planning on altered snapshot evidence", async () => {
   const { snapshot, identity, dependencies } = inputs();
   await assert.rejects(() => browserLocalPlan({ ...identity, registry_snapshot_digest: digest("z") }, snapshot, dependencies, { capability_id: "sink", capability_version: "1.0.0" }, {}, "local", {}), (error) => error instanceof BrowserPlanError && error.code === "browser_plan_snapshot_digest_mismatch");


### PR DESCRIPTION
## Summary

- Align `browserLocalPlan.ts` chain search with Rust `build_chains`: base case against starting facts only; predecessor coverage from predecessor outputs alone; never fold a node's outputs into the set it is evaluated against.
- Add a regression covering a 4-node forwarding pipe (`collect → enrich → summarize → format`) matching the `report.*` / registry#441 shape.

Closes #1338

## Governing Spec

- `068-public-platform-embedder-packages`
- `1277-browser-local-workflow-composition`
- `113-declarative-workflow-planning`

## Project Item

- https://github.com/traverse-framework/Traverse/issues/1338
- https://github.com/orgs/traverse-framework/projects/1/

## What Changed

- Contracts changed: none.
- Runtime behavior changed: TypeScript browser-local planner now plans chains where intermediate nodes forward consumed fields (inputs ∩ outputs ≠ ∅), matching the Rust embedder planner.
- Compatibility impact: fixes under-planning; may surface additional valid proposals that were previously dropped.
- ADR needed or linked: none.

## Validation

- [x] Spec alignment checked
- [x] Contract alignment checked
- [x] Tests updated and passing (`npm test` in `packages/web/TraverseEmbedder`)
- [x] Core coverage preserved
- [x] Required validation gates passing

## Notes

Unblocks `traverse-framework/registry#441` and website `/discover` French-report goal. No FR change — TS port was out of conformance with the Rust twin.
