### PR TITLE
Approve Component Model WIT host-capability profile

### DIFF
--- a/docs/adr/0068-component-model-wit-host-capabilities.md
+++ b/docs/adr/0068-component-model-wit-host-capabilities.md
@@ -1,0 +1,52 @@
+# ADR-0068: Versioned Component Model WIT Host Capabilities
+
+- Status: Accepted
+- Date: 2026-09-10
+- Governing spec: `135-component-model-wit-host-capabilities` (Approved)
+- Related issue: #1340
+- Extends: Decision 6; ADR-0060; ADR-0063
+
+## Context
+
+Traverse Host ABI v1 intentionally validates a fixed core-Wasm/WASI import
+surface. A portable capability that needs a microphone, OS permission,
+foreground lifecycle, secure native storage, or similar target-local authority
+cannot safely express that need through ambient imports, a target-specific
+capability, or an ever-growing ABI v1 whitelist. Callweave proposed a
+`recording-host` WIT import as a concrete need.
+
+## Decision
+
+Introduce `component-wit-v1` as a profile separate from `core-wasm-v1`; do not
+change Host ABI v1. Component imports are validated against exact manifest WIT
+declarations and resolved only through application-activated host bindings. The
+runtime owns validation, selection, target compatibility, error redaction,
+evidence, and conformance policy; hosts own target implementation details.
+
+Traverse standardizes a registry of small `traverse:platform` WIT interfaces.
+The application may select a trusted default or named compatible binding, while
+the component sees only the interface identity. Standard recording is
+foreground-only and lifecycle/reference oriented, never a raw-audio or native
+device API.
+
+## Consequences
+
+Component execution requires new type-metadata validation and host-linking
+support, plus manifest, registry, embedder, trace, and conformance-test work.
+Existing core-Wasm artifacts and the Host ABI v1 whitelist retain their exact
+behavior. Native adapter code remains outside this governing slice.
+
+## Alternatives considered
+
+- Add arbitrary WIT imports to Host ABI v1: rejected because it destroys the
+  fixed-whitelist core-Wasm security/compatibility boundary.
+- One generic `platform`/`device` WIT interface: rejected because it becomes
+  ambient authority and makes auditing/versioning incoherent.
+- Keep `callweave:recording` as an automatic Traverse-standard alias: rejected
+  because package identity and contract governance must be unambiguous.
+- Use WASI for recording: rejected because WASI does not model permission,
+  microphone, device selection, or mobile/browser lifecycle portably.
+- Let components choose targets or hosts at runtime: rejected because guest
+  code must not route itself to more privileged native authority.
+- Auto-activate registry-discovered native hosts: rejected because installation
+  must not silently grant microphone or other native authority.

--- a/docs/decision-log.md
+++ b/docs/decision-log.md
@@ -3462,6 +3462,52 @@ execution:
 3. `#1319` Blocked until `traverse-registry 0.20.0` is on crates.io, then the
    CLI/embedder/runtime upgrade to the batch preparation API proceeds.
 
+## Decision 79: Govern Target-Local Authority Through Versioned Component Model WIT Bindings
+
+- **Date**: 2026-09-10
+- **Status**: Accepted
+- **Related issue**: `#1340`
+- **Governing artifacts**: Spec `135-component-model-wit-host-capabilities`; ADR-0068
+- **Origin**: Owner-directed brainstorm on portable host capabilities and
+  Callweave's proposed recording WIT contract.
+
+### Decision
+
+1. Preserve the fixed `core-wasm-v1` Host ABI v1 behavior. Add a separately
+   versioned `component-wit-v1` Component Model profile rather than broadening
+   the existing import whitelist.
+2. Publish narrowly scoped `traverse:platform` WIT interfaces, not one ambient
+   platform/device interface. Components declare exact mandatory imports;
+   application/embedder code explicitly activates an exact compatible trusted
+   binding for its target. Component code does not choose a target or host.
+3. Standard recording is a host-owned foreground authority. Its portable surface
+   is lifecycle/session/reference based; it excludes raw audio, native device
+   details, codecs, OS permission mechanics, background execution, and implicit
+   cross-capability media access.
+4. Registry metadata may advertise conformance-verified host implementations,
+   but registry installation never activates native authority. Local unverified
+   hosts remain possible only through explicit application activation.
+5. Missing, incompatible, target-mismatched, ambiguous, or untrusted bindings
+   fail before execution with stable redacted diagnostics. WIT operations return
+   typed public domain outcomes; secure host telemetry retains private details.
+
+### Alternatives considered
+
+- **Fold WIT imports into Host ABI v1** — rejected: a fixed core-Wasm import
+  whitelist is an intentional safety and compatibility boundary.
+- **Use WASI for device recording** — rejected: its standardized runtime scope
+  does not model microphone authority, permission, or lifecycle portably.
+- **Use a generic all-purpose WIT platform interface** — rejected: it would
+  recreate ambient authority and impede narrow capability governance.
+- **Keep Callweave's package as an automatic alias** — rejected: package
+  identities and semantic ownership must remain explicit.
+
+### Approval
+
+Approved by Enrico in this owner-directed brainstorm. Spec 135 and ADR-0068
+are accepted and recorded together; their immutable registry entry is the
+implementation gate.
+
 ## Decision 78: Server-Owned Application Availability Lifecycle
 
 - **Date**: 2026-09-09

--- a/specs/135-component-model-wit-host-capabilities/spec.md
+++ b/specs/135-component-model-wit-host-capabilities/spec.md
@@ -1,0 +1,170 @@
+# Feature Specification: Component Model WIT Host Capabilities
+
+**Status**: Approved (2026-09-10)
+**Canonical governing ID**: `135-component-model-wit-host-capabilities`
+**Version**: 0.1.0
+**Extends**: `038-wasi-host-insulation`, `100-capability-package-authoring`,
+`103-application-connector-binding`, `104-mediated-connector-invocation`, and
+`1259-portable-authority-contracts`.
+**Decision evidence**: Traverse #1340; Decision 79; ADR-0068.
+
+## Purpose and boundary
+
+Define a governed Component Model execution profile through which a portable
+Wasm Component may import a narrowly scoped, versioned WIT interface implemented
+by an explicitly activated target-local host. This is a composition and
+authorization boundary, not a target API or a native adapter implementation.
+
+The existing `core-wasm-v1` Host ABI v1 path remains unchanged. It continues to
+validate its fixed WASI/`traverse_host` import whitelist. `component-wit-v1` is
+a distinct profile; it does not broaden that whitelist or permit ambient core
+Wasm imports.
+
+Portable business logic uses neither interface where possible. Governed WASI is
+for standardized sandbox runtime services. WIT is reserved for an unavoidable
+host authority such as hardware, OS permission/lifecycle, secure identity or
+storage, notifications, or similar target-local services. It MUST NOT be used
+as a general-purpose plug-in, filesystem, provider, or application-workflow
+escape hatch.
+
+## Model
+
+Traverse publishes a registry of narrow standard interfaces under
+`traverse:platform`; it MUST NOT publish one ambient, catch-all `platform` or
+`device` interface. An application selects an activated binding; a component
+knows only its declared interface identity, never a host implementation,
+operating system, provider, device identity, path, credential, or permission
+mechanism.
+
+The initial standard interface candidate is
+`traverse:platform/recording-host@0.1.0`. Callweave's
+`callweave:recording/recording-host@0.1.0` is input to this standardization, not
+an automatically equivalent runtime alias. A migration adapter, if ever needed,
+MUST be explicit and MUST NOT make package identities interchangeable.
+
+## Requirements
+
+- **FR-001 — Profiles**: The runtime MUST expose `core-wasm-v1` and
+  `component-wit-v1` as separately versioned execution profiles. A profile
+  mismatch MUST fail before execution with a stable, secret-free error.
+- **FR-002 — Component metadata**: For `component-wit-v1`, Traverse MUST read
+  the Component Model type metadata and enumerate every imported WIT package,
+  interface, version, and exported operation shape. It MUST reject malformed
+  metadata and imports not declared by the package manifest.
+- **FR-003 — Manifest declaration**: A component package MUST declare each
+  required WIT import by package namespace/name, interface name, and exact
+  interface version. The declaration set and component import set MUST match
+  exactly. Required imports are mandatory; no optional privileged import exists
+  in v0.1.0.
+- **FR-004 — Pinned compatibility**: Activation MUST require exact package,
+  interface, version, and WIT operation-shape compatibility. Semver ranges,
+  package aliases, and name-only matching are forbidden in v0.1.0.
+- **FR-005 — Registration**: A host implementation registration MUST include a
+  stable binding ID, WIT package/interface/version, supported precise target
+  families, provenance/trust state, and conformance-evidence reference. A
+  registry entry MAY publish registration metadata but MUST NOT activate native
+  code or host authority automatically.
+- **FR-006 — Activation and target ownership**: Only the application/embedder
+  may activate a trusted local implementation and map it to an interface. The
+  application owns logical placement (for example local execution); the host
+  claims precise governed target families. The component MUST NOT choose a
+  target, binding, OS, provider, or device at execution time.
+- **FR-007 — Deterministic selection**: Multiple compatible registrations MAY
+  exist, but the application MUST select an explicit binding for a capability
+  profile/workflow. Missing, incompatible, target-mismatched, untrusted, or
+  ambiguous bindings MUST fail before guest execution.
+- **FR-008 — Errors and redaction**: Activation failures MUST use stable public
+  codes: `component_model_profile_unsupported`, `wit_import_undeclared`,
+  `wit_import_unfulfilled`, `wit_import_version_incompatible`,
+  `wit_host_target_mismatch`, `wit_host_binding_ambiguous`, and
+  `wit_host_activation_failed`. Host calls MUST return only WIT-defined public
+  domain outcomes. Neither output nor diagnostics may contain raw audio, device
+  identities, paths, endpoints, credentials, native error strings, entitlement
+  names, or private configuration.
+- **FR-009 — Evidence**: Traverse MUST record the profile, declared import
+  identities, selected binding ID, abstract target family, compatibility result,
+  and stable outcome code. Evidence MUST omit host-private implementation data.
+- **FR-010 — Conformance**: Every registry-published implementation MUST carry
+  shared WIT contract-test evidence. Official Traverse implementations also
+  require target-specific integration evidence. Application-local hosts MAY be
+  marked unverified but MUST be explicitly activated and never represented as a
+  verified portable default.
+
+## `traverse:platform/recording-host@0.1.0`
+
+The first standard host capability is foreground recording only. Its initial
+interface has `status`, `start`, `stop`, and `events`; `discard` is a required
+follow-up before publishing a durable-reference contract unless the adopted WIT
+already provides equivalent cancellation semantics.
+
+- `status` is advisory and exposes only portable states.
+- `start` is authoritative and may prompt only when the app-authenticated
+  execution context is both user-initiated and foregrounded. Otherwise it
+  returns `permission-required` without prompting.
+- A host supports at most one active recording session per host context and
+  returns `recording-busy` for another start.
+- `events` is a bounded lifecycle stream only (`started`, `stopped`,
+  `interrupted`, and public failures); it carries no audio/content bytes.
+- `stop` succeeds only when its opaque recording reference is ready for its
+  documented next host-authorized use.
+- The host chooses microphone/device and audio format. The component receives
+  no device ID, codec negotiation surface, path, URL, provider, or raw bytes.
+- Recording references are host-managed, scoped, expiring opaque values. They
+  are not transferable by default; cross-capability use requires an explicit
+  application/workflow-mediated grant.
+- `background-unsupported`, `permission-required`, `recording-busy`, and
+  `unavailable` are portable domain outcomes. Background recording, raw audio
+  streaming, codec profiles, multiple concurrent tracks, and direct reference
+  transfer are out of scope.
+
+## Manifest examples
+
+```json
+{
+  "execution_profile": "component-wit-v1",
+  "required_wit_imports": [{
+    "package": "traverse:platform",
+    "interface": "recording-host",
+    "version": "0.1.0"
+  }]
+}
+```
+
+```json
+{
+  "wit_bindings": {
+    "traverse:platform/recording-host@0.1.0": "default-local-recording"
+  }
+}
+```
+
+## Acceptance scenarios
+
+1. A Component importing the declared `recording-host@0.1.0` validates,
+   activates, and invokes `status`, `start`, `stop`, and lifecycle `events`
+   through a compatible explicit fake local host.
+2. A missing declaration, host, compatible version, matching target, or
+   unambiguous explicit binding fails deterministically before guest execution.
+3. A fake host returns `permission-required` and `background-unsupported` as
+   public typed outcomes, while its private diagnostics never appear in guest
+   output or trace evidence.
+4. A second active session returns `recording-busy`; event queues are bounded
+   and terminal lifecycle behavior is deterministic.
+5. Existing `core-wasm-v1`/WASI Host ABI v1 fixtures pass unchanged.
+6. A registry-declared host cannot become active without application activation;
+   an application-local unverified fake is clearly distinguishable from an
+   official conformance-verified host.
+
+## Compatibility and non-goals
+
+This is additive and does not modify Host ABI v1, existing core-Wasm artifacts,
+the connector contracts in spec `1259`, or target-specific host implementations.
+It does not implement macOS, iOS, Android, browser, filesystem, storage,
+permission, microphone, audio byte, or provider APIs. It does not make WIT a
+replacement for WASI or a general module-composition mechanism.
+
+Migration: existing capabilities retain `core-wasm-v1`. A recording-dependent
+capability is repackaged as a Component, declares the exact standard WIT import,
+and runs only where an application activates a compatible host. Callweave may
+keep its current package during transition, but it is not a Traverse-standard
+default until an explicit adapter or republished interface is approved.

--- a/specs/governance/approved-specs.json
+++ b/specs/governance/approved-specs.json
@@ -1837,6 +1837,23 @@
         "specs/134-lazy-capability-registry-reconstruction/",
         "docs/adr/0067-lazy-capability-registry-reconstruction.md"
       ]
+    },
+    {
+      "id": "135-component-model-wit-host-capabilities",
+      "version": "0.1.0",
+      "status": "approved",
+      "immutable": true,
+      "path": "specs/135-component-model-wit-host-capabilities/spec.md",
+      "governs": [
+        "crates/traverse-runtime/",
+        "crates/traverse-cli/src/capability_packages.rs",
+        "crates/traverse-contracts/",
+        "crates/traverse-registry/",
+        "crates/traverse-embedder/",
+        "packages/",
+        "specs/135-component-model-wit-host-capabilities/",
+        "docs/adr/0068-component-model-wit-host-capabilities.md"
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary

Approves the governed Component Model/WIT host-capability profile, including the
portable recording-host boundary, while preserving core-Wasm Host ABI v1.

## Governing Spec

- `135-component-model-wit-host-capabilities`
- `100-capability-package-authoring`
- `004-spec-alignment-gate`

## Project Item

- Traverse Project 1: governing specification issue #1340

## Validation

- `jq empty specs/governance/approved-specs.json`
- `bash scripts/ci/spec_alignment_check.sh /private/tmp/issue-1340-pr-body.md`
