### PR TITLE
docs: land Decision 80 and plan-then-seal authoring pointer

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,6 +277,7 @@ Read the [UMA book](https://www.universalmicroservices.com/) and the
 - [docs/wasm-agent-authoring-guide.md](docs/wasm-agent-authoring-guide.md) — WASM capability authoring
 - [docs/wasm-microservice-authoring-guide.md](docs/wasm-microservice-authoring-guide.md) — WASM microservice authoring
 - [docs/workflow-composition-guide.md](docs/workflow-composition-guide.md) — composing workflows
+- [docs/workflow-authoring-guide.md](docs/workflow-authoring-guide.md) — plan-then-seal default vs adaptive opt-in
 - [docs/capability-publish.md](docs/capability-publish.md) — publishing to the registry
 - [docs/expedition-example-authoring.md](docs/expedition-example-authoring.md) — worked example
 

--- a/docs/decision-log.md
+++ b/docs/decision-log.md
@@ -3608,3 +3608,60 @@ Not in scope of this brainstorm (tracked elsewhere, not blocking
 `#1314`/`#1308`): registry `#412` close-out once `v0.20.0` propagation is
 confirmed; relabeling `specs/1285-capability-state-host-abi/spec.md` from `Draft`
 now that Decision 71 shipped it.
+
+## Decision 80: Dual-Path Workflow Authoring — Plan-Then-Seal Default, Skill Front Door
+
+- **Date**: 2026-09-10
+- **Status**: Accepted
+- **Related artifacts**: Specs `007`, `041`, `108`–`113`, `109`–`112` (planner as untrusted proposer; sealed workflow as execution authority); skill `traverse-app-builder` (last major refresh 2026-07-22)
+- **Related issues**: `#1343` (Decision 80 + thin pointer doc), `#1344` (skill refresh), `#1345` (sealed-default / adaptive opt-in), `#1346` (CLI `workflow plan` / `promote`)
+- **Origin**: Owner `/brainstorm` on evolving the runtime usage model for customer DEVs and coding agents — deterministic sealed workflows plus MCP/planner discovery, with quality as the bar.
+
+### Context
+
+Traverse can already traverse sealed workflows deterministically and can use MCP + the declarative planner at authoring/proposal time to discover capability chains for a structured target. The open product question was how those paths show up as one usage story: what DEVs put in manifests, whether CLI or an agent skill is the front door, and when (if ever) runtime planning is allowed — without sacrificing reproducible, testable apps.
+
+### Decision
+
+1. **Default relationship: plan then seal.** The planner/MCP path helps *author* a workflow (or proposal). What ships and runs by default is a reviewed, pinned, deterministic `workflow.json` referenced from the app/package manifest (`known_compositions` / workflow refs). Runtime planning is not the default production path.
+   - Rejected: *two equal runtime modes forever* — doubles mental model and weakens quality guarantees.
+   - Rejected: *runtime planner primary, sealed as escape hatch* — fights determinism and DEV trust.
+
+2. **Primary authoring UX: evolve `traverse-app-builder` into the plan-then-seal front door.** CLI remains verifier/registrar (`workflow`/`app` validate, register, inspect; execute via existing surfaces). Do not invent a sibling skill or leave only a light patch.
+   - Rejected: *CLI-first plan/promote before proving the ritual* — encode CLI once UX is proven.
+   - Rejected: *manual artifacts + docs only* — underuses the planner and keeps agent DX high-friction.
+   - Note: skill is stale (2026-07-22) relative to planner/promotion governance landed since.
+
+3. **Gap handling: author missing capabilities, then re-plan.** If published capabilities cannot complete the goal, the skill drops into the existing atomic-capability authoring path for gaps, re-runs planning, and seals only a complete, validatable workflow.
+   - Rejected: *stop with gap report only* — incomplete for “build the app” sessions.
+   - Rejected: *seal placeholder/partial workflows* — broken-by-default artifacts and noisy CI.
+
+4. **Human seal gate: always pause for explicit “seal this proposal.”** Before writing `workflow.json` / manifest refs, show the chosen graph (capabilities, versions, edges, any newly authored caps) and wait for confirmation.
+   - Rejected: *auto-seal on a single valid proposal* — a sole bad proposal can still land.
+   - Rejected: *seal and let CLI/PR be the only gate* — review too late for quality.
+
+5. **Session DoD: seal + CLI validate required; register/smoke-execute optional.** Success means artifacts on disk after confirm and validation green (including digest fixes). Register + one smoke execute is an offered follow-on when the workspace/runtime is ready, not required for every authoring session.
+
+6. **Runtime adaptive path: explicit opt-in per app/request.** Sealed workflow remains default. Live goal→plan→propose at execution time is allowed only when the app/request deliberately opts in (e.g. a `composition_mode: adaptive` or equivalent knob) and still obeys governed proposal rules (planner remains untrusted; no silent auto-persist as the app’s sealed workflow).
+   - Rejected: *authoring-only forever* — leaves no governed path for “achieve this goal now.”
+   - Rejected: *adaptive by default unless pinned* — too easy to ship nondeterministic apps by accident.
+
+7. **Delivery sequencing: skill + thin repo pointer + evals first.** Refresh the skill and add a short repo doc that states sealed-default vs adaptive-opt-in and points at the skill + CLI validate path. File separate tickets/spec work for the adaptive runtime/API knob afterward.
+   - Rejected: *spec dual-mode runtime before touching the skill* — leaves the stale skill blocking customer value.
+   - Rejected: *one tranche of spec + runtime + skill* — high stall risk.
+
+8. **Docs model: skill is canonical deep ritual; repo gets a thin pointer guide.** Avoid duplicating the full loop in both places.
+
+### Outcome
+
+Customer DEVs and agents get one story: discover/plan at authoring time (with a brainstorm-style skill that can close capability gaps), confirm seal, validate, then run deterministic workflows. Adaptive runtime composition stays a deliberate, later product mode. Immediate work is skill refresh + evals + thin `docs/` pointer; adaptive opt-in is follow-on governance/implementation.
+
+### Explicitly deferred / ticketed
+
+- Exact API/manifest field name for runtime adaptive opt-in (e.g. `composition_mode`) — implementation choice under approved specs `108`/`109`; tracked in `#1345`
+- CLI `workflow plan` / `promote` — tracked as Ready `#1346` (may land in parallel with skill; skill prefers CLI once merged)
+- Broader distribution of the skill beyond in-repo `.agents/skills/traverse-app-builder/` (tracked via `#1344` landing the in-repo copy first)
+
+### Approval
+
+Approved by Enrico in this owner-directed `/brainstorm` session (2026-09-10).

--- a/docs/workflow-authoring-guide.md
+++ b/docs/workflow-authoring-guide.md
@@ -1,0 +1,60 @@
+# Workflow Authoring Guide
+
+Thin product pointer for how Traverse expects DEVs and coding agents to
+author and run workflows. Deep ritual lives in the skill; this page states
+the defaults and where to go next.
+
+**Decision evidence**: [Decision 80](decision-log.md#decision-80-dual-path-workflow-authoring--plan-then-seal-default-skill-front-door)
+(2026-09-10).
+
+## Defaults
+
+| Mode | When | Authority |
+|---|---|---|
+| **Sealed workflow (default)** | What ships and runs in production | Reviewed, pinned `workflow.json` referenced from the app/package manifest (`known_compositions` / workflow refs). Deterministic traversal. |
+| **Plan-then-seal (authoring)** | Building or changing a workflow | Planner/MCP proposes candidates; human confirms seal; CLI validates before trust. |
+| **Adaptive composition (opt-in)** | Explicit app/request flag only | Live plan at execution time under governed proposal rules. Not the default; never silently persisted as the sealed app workflow. |
+
+Sealed workflows are the production path. Runtime planning is not.
+
+## Plan-then-seal (authoring)
+
+1. Clarify the goal and structured target.
+2. Discover capabilities (registry / MCP).
+3. Ask the declarative planner for candidate graphs (planner remains an
+   untrusted proposer — see ADR-0043 / specs `108`–`113`).
+4. If capabilities are missing, author the gaps, then re-plan.
+5. **Pause for explicit seal confirmation** before writing artifacts.
+6. Write sealed `workflow.json` and manifest workflow refs.
+7. **Required DoD**: CLI validate green (including digest fixes).
+8. Optional follow-on: register and one smoke execute when the workspace is ready.
+
+Do not auto-seal on a single proposal. Do not seal placeholder or partial
+workflows.
+
+## Where to work
+
+| Surface | Role |
+|---|---|
+| [`.agents/skills/traverse-app-builder/`](../.agents/skills/traverse-app-builder/) (landing via [#1344](https://github.com/traverse-framework/traverse/issues/1344)) | Canonical deep authoring ritual (plan → gap-author → confirm seal → validate). Until that path lands in-repo, use the personal skill copy if present. |
+| `traverse-cli` `app validate` / `workflow` validate & register | Verifier and registrar — see [cli-reference.md](cli-reference.md). |
+| Future `workflow plan` / `promote` ([#1346](https://github.com/traverse-framework/traverse/issues/1346)) | CLI wrappers over planner (113) and promotion (112) once shipped; prefer them from the skill when available. |
+| Adaptive runtime opt-in ([#1345](https://github.com/traverse-framework/traverse/issues/1345)) | Explicit sealed-default vs adaptive knob — follow-on implementation. |
+
+Hand-composed workflows remain valid; start from
+[workflow-composition-guide.md](workflow-composition-guide.md) when you already
+know the graph. Prefer the skill when discovery or gap-authoring is part of the
+session.
+
+## Governing specs and ADRs
+
+- Workflow registry / traversal: `007`, `041`
+- Planner as untrusted proposer; sealed workflow as execution authority:
+  `108`–`113`, `109`–`112`
+- [ADR-0043](adr/0043-declarative-workflow-planning-boundary.md) — planning boundary
+- [ADR-0050](adr/0050-governed-runtime-workflow-proposal-authority.md) —
+  proposals as untrusted, manifest-bounded snapshots
+- Proposal lifecycle: [workflow-proposal-lifecycle.md](workflow-proposal-lifecycle.md)
+- Promotion path detail: [governed-workflow-promotion.md](governed-workflow-promotion.md)
+
+This guide intentionally does **not** copy the full skill ritual.

--- a/docs/workflow-composition-guide.md
+++ b/docs/workflow-composition-guide.md
@@ -1,5 +1,9 @@
 # Workflow Composition Guide
 
+For the product defaults (sealed production path, plan-then-seal authoring,
+adaptive opt-in), see [workflow-authoring-guide.md](workflow-authoring-guide.md)
+and [Decision 80](decision-log.md#decision-80-dual-path-workflow-authoring--plan-then-seal-default-skill-front-door).
+
 This guide shows how to chain two capabilities into a governed workflow using the Traverse registry and deterministic traversal model.
 
 After completing it you will be able to:


### PR DESCRIPTION
## Summary

- Land accepted Decision 80 (plan-then-seal default; adaptive opt-in) in `docs/decision-log.md`
- Add thin `docs/workflow-authoring-guide.md` pointer linked from README and the composition guide
- Keep the skill ritual out of the repo guide (skill refresh is #1344)

## Governing Spec

- `108-governed-runtime-workflow-composition`
- `190-readme-rewrite`
- `065-sigstore-bundle-verification`
- `070-runtime-event-sink-boundary`

Issue #1343 is labeled `no-spec-needed`. `108` covers `docs/decision-log.md` (same convention as PRs #1253 / #1320). `190` covers the README index link. `065` / `070` are declared because they govern the touched `docs/workflow-*.md` paths in the approved-specs registry.

## Project Item

- Traverse Project 1: #1343
- Related: #1344, #1345, #1346

## Validation

- `rg -n "Decision 80" docs/decision-log.md`
- `test -f docs/workflow-authoring-guide.md`
- `rg -n "plan-then-seal|sealed|adaptive" docs/workflow-authoring-guide.md`
- `BASE_SHA=origin/main bash scripts/ci/spec_alignment_check.sh /tmp/issue-1343-pr-body.md`

Made with [Cursor](https://cursor.com)