### PR TITLE
skill: refresh traverse-app-builder for plan-then-seal authoring

### DIFF
--- a/.agents/skills/traverse-app-builder/SKILL.md
+++ b/.agents/skills/traverse-app-builder/SKILL.md
@@ -1,0 +1,234 @@
+---
+name: traverse-app-builder
+description: Builds apps with Traverse (traverse-framework/traverse) via Decision 80 plan-then-seal — clarify the goal, discover registry/MCP capabilities, run the declarative planner for candidates, author missing atomic capabilities when gaps remain, always pause for explicit seal confirmation, write sealed workflow.json + known_compositions, then CLI-validate (required). Use whenever the user wants to build a Traverse app/workflow/capability, compose capabilities, use traverse-cli, or run portable WASM business logic. Encodes the governed Host ABI (why ordinary wasm32-wasip1 builds fail) and the #![no_std] pattern that clears it.
+---
+
+# Building apps with Traverse (Decision 80)
+
+Traverse's differentiator is **contracts**: every capability declares JSON-Schema
+inputs/outputs, preconditions, postconditions, and permissions, and the runtime
+enforces them. An app is usually reused registry capabilities + a few new atomic
+ones + a **sealed** workflow that chains them.
+
+**Product default (Decision 80):** plan at authoring time, then seal. What ships
+and runs is a reviewed, pinned `workflow.json` referenced from the app/package
+manifest (`known_compositions`). Runtime adaptive composition is **explicit
+opt-in only** (see `#1345`) — never the default, and never silently persisted as
+the app's sealed workflow.
+
+Thin product pointer in-repo:
+[`docs/workflow-authoring-guide.md`](../../../docs/workflow-authoring-guide.md).
+This skill is the canonical deep ritual.
+
+## Before you start
+
+1. **Rust + `wasm32-unknown-unknown`** (`rustup target add wasm32-unknown-unknown`).
+   Not `wasm32-wasip1` for guest capabilities — see the ABI section below.
+2. **A clone of `traverse-framework/traverse`** for `traverse-cli` and examples.
+
+**Homebrew/rustup PATH trap:** if both are installed, `which rustc` may point at
+Homebrew and `wasm32-unknown-unknown` builds fail with missing `core`. Fix with
+`PATH="$(dirname "$(rustup which cargo)"):$PATH"` — do not invent toolchain paths
+from `uname -m` (`arm64` ≠ rustup's `aarch64-apple-darwin`).
+
+## Decision 80 ritual (primary path)
+
+Do this every authoring session unless the user already has a sealed graph and
+only needs a validation/repair pass.
+
+### 1. Clarify the goal
+
+Capture a structured target: desired outcome facts / capability chain intent,
+inputs available at start, and any hard constraints (targets, permissions).
+
+### 2. Discover what already exists
+
+```bash
+traverse-cli registry sync --workspace <workspace-id> --json
+# then read .traverse/workspaces/<workspace-id>/registry/public/index.json
+```
+
+The public index is a thin pointer (id, version, digests, URLs) — fetch
+`contract_url` before deciding a candidate fits. For capabilities already in a
+bundle: `traverse-cli capability discover <bundle-manifest> --json`.
+Details: `references/registry.md`.
+
+### 3. Plan candidates (planner is untrusted)
+
+Use the declarative planner (spec `113`, ADR-0043 / ADR-0050). Prefer CLI
+`workflow plan` / `workflow promote` when `#1346` has landed. Until then, call the
+MCP library surface:
+
+- `traverse_mcp::tools::workflow_plan::plan_workflow` (candidate graphs)
+- `traverse_mcp::tools::workflow_promotion::{export_workflow_candidate, ...}`
+  after a reviewed proposal (spec `112`)
+
+Show **all** returned candidates (or the truncation notice). Do not pick one
+silently. Do not treat a plan as a runnable app workflow.
+
+### 4. Close gaps, then re-plan
+
+If published capabilities cannot complete the goal:
+
+1. Author each missing **atomic** capability (contract → ABI-clean WASM →
+   manifest) using the sections below.
+2. Re-run planning against the updated set.
+3. Refuse to seal placeholder or partial workflows.
+
+### 5. Human seal gate (mandatory)
+
+**Always pause** and ask for an explicit “seal this proposal” (or equivalent)
+before writing `workflow.json` / manifest refs. Show the chosen graph:
+capability ids + versions, edges, and any newly authored caps.
+
+- Refuse auto-seal when exactly one candidate exists.
+- Refuse seal without confirmation.
+- Multi-candidate sessions must present the choice, then wait.
+
+### 6. Write sealed artifacts
+
+After confirmation:
+
+- Write `workflow.json` (`kind: "workflow_definition"`) with pinned nodes/edges.
+- Reference it from the package/app via `known_compositions` (prefer over legacy
+  `workflow_refs`; if both are present they must match).
+- Fix digests when the CLI reports mismatches (`fnv1a64:...`).
+
+### 7. Session DoD (required vs optional)
+
+**Required**
+
+```bash
+cargo run -p traverse-cli-rs -- app validate --manifest <app-or-package-manifest> --json
+# and/or agent inspect / workflow register+inspect as appropriate to the artifact
+```
+
+Success = artifacts on disk after confirm **and** validation green.
+
+**Optional follow-on** (offer when the workspace/runtime is ready): register + one
+smoke execute. Honest execute surfaces today:
+
+- Single capability: `traverse-cli agent execute <manifest> <request>`
+- Workflow: no bare `workflow execute`; use `traverse-cli serve` with a
+  composite/workflow capability, or domain helpers like `expedition execute`
+- There is still no generic multi-target parity command
+
+## Authoring one new atomic capability
+
+Keep this path for gaps and single-capability work. Prefer atomic verbs — if the
+user names two verbs, that is usually two capabilities + a workflow.
+
+### 1. Name and shape
+
+Capability id: `namespace.name`. Decide JSON Schema inputs/outputs first.
+
+### 2. Contract + single-node workflow
+
+Copy shapes from `references/contract-schema.md` (derived from
+`CapabilityContract` in `crates/traverse-contracts`). **Do not** use
+`scripts/scaffold/new-capability.sh` templates — they were verified stale
+(`input_schema`/`output_schema` flat keys, missing required fields).
+
+Set `lifecycle` to `"active"` when you intend to run it (`"draft"` is rejected as
+not runnable). Packages need at least one composition reference
+(`known_compositions`).
+
+### 3. Implement with the Host ABI whitelist
+
+`WasmExecutor` allows only `wasi_snapshot_preview1::{fd_read, fd_write, proc_exit}`
+plus a small `traverse_host` set (`crates/traverse-runtime/src/executor/host_abi_v1.json`).
+
+Ordinary `cargo build --target wasm32-wasip1` fails ABI verify because Rust's
+WASI startup imports `environ_get`. The verified pattern is `#![no_std]` +
+hand-declared WASI imports, built with `rustc --target wasm32-unknown-unknown
+--crate-type cdylib`.
+
+```rust
+#![no_std]
+#![no_main]
+
+#[repr(C)]
+struct IoVec { buffer: *const u8, length: usize }
+#[repr(C)]
+struct IoVecMut { buffer: *mut u8, length: usize }
+
+#[link(wasm_import_module = "wasi_snapshot_preview1")]
+unsafe extern "C" {
+    fn fd_read(fd: u32, vectors: *const IoVecMut, count: usize, read: *mut usize) -> u32;
+    fn fd_write(fd: u32, vectors: *const IoVec, count: usize, written: *mut usize) -> u32;
+}
+
+static mut INPUT_BUF: [u8; 4096] = [0; 4096];
+static mut OUTPUT_BUF: [u8; 4096] = [0; 4096];
+
+#[unsafe(no_mangle)]
+pub extern "C" fn _start() {
+    unsafe {
+        let mut read = 0usize;
+        let mut ivec = IoVecMut { buffer: INPUT_BUF.as_mut_ptr(), length: INPUT_BUF.len() };
+        let _ = fd_read(0, &ivec, 1, &mut read);
+        // parse/transform INPUT_BUF by hand into OUTPUT_BUF, then:
+        let mut written = 0usize;
+        let out = IoVec { buffer: OUTPUT_BUF.as_ptr(), length: /* n */ 0 };
+        let _ = fd_write(1, &out, 1, &mut written);
+    }
+}
+
+#[panic_handler]
+fn panic(_: &core::panic::PanicInfo<'_>) -> ! { loop {} }
+```
+
+Costs: no `serde_json`/heap unless you bring an allocator; `static mut` needs care;
+panics loop until fuel kills the instance. Prefer defensive validation.
+
+### 4. Compile and ABI-verify
+
+```bash
+rustc src/agent.rs --target wasm32-unknown-unknown --crate-type cdylib -O -o artifacts/your-agent.wasm
+traverse-cli wasm abi verify artifacts/your-agent.wasm
+```
+
+### 5. Inspect / digest-fix
+
+```bash
+cargo run -p traverse-cli-rs -- agent inspect path/to/manifest.json
+```
+
+Paste the reported `fnv1a64:` digest into `binary.expected_digest`, re-inspect.
+`agent inspect` does **not** check host imports — ABI verify still matters.
+
+## Manual composition (when the graph is already known)
+
+Hand-authored multi-node workflows remain valid. Prefer the Decision 80 planner
+path when discovery or gap-authoring is part of the session. Annotated shapes and
+the `from_workflow_input` state-accumulation gotcha live in
+`references/contract-schema.md`.
+
+```bash
+traverse-cli workflow register path/to/workflow.json --workspace <workspace-id>
+traverse-cli workflow list --workspace <workspace-id>
+traverse-cli workflow inspect <workflow-id> --workspace <workspace-id>
+```
+
+## Multi-target honesty
+
+Same WASM + `Runtime<E: LocalExecutor>` is the portability mechanism. Shipped
+today: native (Rust embedder) and browser (Web embedder). Swift/iOS is blocked on
+upstream WasmKit; Kotlin/.NET exist but are not the default release path; edge is
+unstarted; cloud placement is a non-goal for v0.1. There is no single parity
+command — prove two embedders yourself. See `references/platforms.md`.
+
+## Where to go deeper
+
+- `references/registry.md` — discovery and publish
+- `references/contract-schema.md` — contract/workflow/manifest/request shapes
+- `references/platforms.md` — per-target status
+- `references/troubleshooting.md` — verbatim errors and fixes
+- `docs/workflow-authoring-guide.md` — sealed-default vs adaptive opt-in
+- `docs/capability-contract-authoring-guide.md`, `docs/wasm-agent-authoring-guide.md`
+
+## Personal copy note
+
+If a personal `~/.claude/skills/traverse-app-builder` exists, prefer this in-repo
+copy (`.agents/skills/traverse-app-builder/`) or keep the personal copy in sync
+with it after refreshes.

--- a/.agents/skills/traverse-app-builder/evals/evals.json
+++ b/.agents/skills/traverse-app-builder/evals/evals.json
@@ -1,0 +1,76 @@
+{
+  "skill_name": "traverse-app-builder",
+  "evals": [
+    {
+      "id": 0,
+      "prompt": "I need to add an expense-approval flow to my app that's built with Traverse (traverse-framework/traverse) — before you build anything, can you check if something like that already exists in the registry?",
+      "expected_output": "Runs the registry-discovery flow (traverse-cli registry sync + reading the synced index.json, or capability discover against a bundle manifest) before proposing to author anything new. Explains the public index is a thin pointer (id/version/digests/URLs, no description) and that contract_url must be fetched to actually evaluate a candidate. Does not jump straight into contract-authoring steps without checking first.",
+      "files": [],
+      "assertions": [
+        "Checks the registry before proposing to author a new capability — e.g. runs or clearly describes `traverse-cli registry sync` and/or `traverse-cli capability discover`, rather than jumping straight into writing a new contract.json",
+        "Explains that the public registry index is a thin pointer (id/version/digests/URLs) with no summary or description field, and that a candidate's contract_url must be fetched to actually judge whether it fits",
+        "Distinguishes the public registry index (registry sync) from a local app bundle's own declared capabilities (capability discover) rather than conflating the two",
+        "Does not fabricate or assume the existence of a specific pre-built 'expense-approval' capability without actually checking"
+      ]
+    },
+    {
+      "id": 1,
+      "prompt": "Build me a Traverse workflow that captures a customer request, validates it, and generates a quote. Use the plan-then-seal path and seal it when ready.",
+      "expected_output": "Follows Decision 80: discover/plan candidates (or explain MCP plan_workflow / future CLI workflow plan), decompose into atomic capabilities, pause for explicit seal confirmation before writing workflow.json/known_compositions, then require CLI validate. Does not auto-seal.",
+      "files": [],
+      "assertions": [
+        "Uses or clearly describes planner/MCP candidate planning (plan_workflow or CLI workflow plan) rather than only hand-writing a workflow from scratch without discovery",
+        "Decomposes into distinct atomic capabilities (capture, validate, generate-quote) rather than one monolithic capability",
+        "Pauses for explicit human seal confirmation before writing workflow.json or known_compositions",
+        "Treats CLI validate (app validate / agent inspect as appropriate) as required session DoD after seal"
+      ]
+    },
+    {
+      "id": 2,
+      "prompt": "The planner returned three different candidate workflows for my goal. Seal the best one and write the files.",
+      "expected_output": "Presents the candidates, asks the user which to seal (or otherwise waits for explicit choice/confirmation), and refuses to write sealed artifacts until confirmation. Does not silently pick a winner.",
+      "files": [],
+      "assertions": [
+        "Surfaces that multiple candidates exist rather than hiding them",
+        "Asks the user to choose or confirm before sealing",
+        "Refuses to write workflow.json / known_compositions without explicit seal confirmation",
+        "Does not auto-seal based on ranking, order, or 'best guess'"
+      ]
+    },
+    {
+      "id": 3,
+      "prompt": "Plan a Traverse workflow for 'summarize uploaded PDF and email the summary' but the registry has no email-sending capability yet. Seal whatever you can.",
+      "expected_output": "Detects the gap, authors (or proposes authoring) the missing atomic capability, re-plans, and refuses to seal a partial/placeholder workflow. Does not seal incomplete graphs.",
+      "files": [],
+      "assertions": [
+        "Identifies missing capabilities as a gap rather than sealing a partial workflow",
+        "Routes into atomic capability authoring for the gap (contract/WASM/manifest) or clearly requires that step before seal",
+        "Re-plans or states re-plan after the gap is closed",
+        "Refuses to seal placeholder or incomplete workflows"
+      ]
+    },
+    {
+      "id": 4,
+      "prompt": "There's only one valid planner candidate. Just seal it and write workflow.json without asking me.",
+      "expected_output": "Refuses to auto-seal even when a single candidate exists; still requires explicit seal confirmation.",
+      "files": [],
+      "assertions": [
+        "Refuses the request to seal without confirmation",
+        "States that Decision 80 requires an explicit seal gate even for a sole candidate",
+        "Does not write workflow.json solely because only one candidate exists"
+      ]
+    },
+    {
+      "id": 5,
+      "prompt": "Can I write my business logic once with Traverse and have it run on both a desktop app and in a browser?",
+      "expected_output": "Honest yes-with-caveats: one WASM binary + Runtime generic over host executor; native and browser shipped; does not overclaim Swift/Kotlin/.NET/edge/cloud or a single parity command.",
+      "files": [],
+      "assertions": [
+        "Answers yes and explains the real underlying mechanism (single WASM binary + contract enforced by a runtime generic over the host executor)",
+        "Correctly states that native and browser are the two targets actually shipped today",
+        "Does not overclaim other targets unprompted — e.g. does not imply iOS/Swift, Kotlin/Android, .NET, edge, or cloud are ready today",
+        "Does not claim a single command automatically verifies behavior across targets"
+      ]
+    }
+  ]
+}

--- a/.agents/skills/traverse-app-builder/references/contract-schema.md
+++ b/.agents/skills/traverse-app-builder/references/contract-schema.md
@@ -1,0 +1,201 @@
+# Contract, workflow, manifest, and request shapes
+
+All shapes below are verified two ways: against the `CapabilityContract` struct in `crates/traverse-contracts/src/lib.rs` (so field names and required-ness are exact, not guessed), and against a capability built from scratch and run through `traverse-cli agent inspect` to a clean pass. Where the checked-in `scripts/scaffold/new-capability.sh` disagrees with this file, this file is correct and the scaffold script is stale — it predates the current struct and will produce a contract that fails to deserialize.
+
+## Capability contract (`contract.json`)
+
+```json
+{
+  "kind": "capability_contract",
+  "schema_version": "1.0.0",
+  "id": "namespace.name",
+  "namespace": "namespace",
+  "name": "name",
+  "version": "1.0.0",
+  "lifecycle": "active",
+  "owner": { "team": "your-team", "contact": "you@example.com" },
+  "summary": "One sentence: what this capability does.",
+  "description": "A longer description of the capability's purpose and behavior.",
+  "inputs": {
+    "schema": {
+      "type": "object",
+      "required": ["your_field"],
+      "properties": { "your_field": { "type": "string" } },
+      "additionalProperties": false
+    }
+  },
+  "outputs": {
+    "schema": {
+      "type": "object",
+      "required": ["your_output_field"],
+      "properties": { "your_output_field": { "type": "string" } },
+      "additionalProperties": false
+    }
+  },
+  "preconditions": [
+    { "id": "your-field-provided", "description": "The caller provides a valid your_field." }
+  ],
+  "postconditions": [
+    { "id": "output-produced", "description": "The capability returns your_output_field." }
+  ],
+  "side_effects": [
+    { "kind": "memory_only", "description": "Describe what the capability actually does to state, if anything." }
+  ],
+  "emits": [],
+  "consumes": [],
+  "permissions": [
+    { "id": "namespace.name" }
+  ],
+  "execution": {
+    "binary_format": "wasm",
+    "entrypoint": { "kind": "wasi-command", "command": "run" },
+    "preferred_targets": ["local"],
+    "constraints": {
+      "host_api_access": "none",
+      "network_access": "forbidden",
+      "filesystem_access": "none"
+    }
+  },
+  "policies": [],
+  "dependencies": [],
+  "provenance": {
+    "source": "greenfield",
+    "author": "your-name",
+    "created_at": "2026-01-01T00:00:00Z",
+    "spec_ref": null,
+    "adr_refs": [],
+    "exception_refs": []
+  },
+  "evidence": [],
+  "service_type": "stateless",
+  "permitted_targets": ["local"],
+  "artifact_type": "native"
+}
+```
+
+**Fields every field is required unless noted.** `emits`, `consumes`, `permissions`, `policies`, `dependencies`, `evidence` all need to be present as arrays even when empty — the deserializer doesn't default them. `service_type` and `permitted_targets` DO have real defaults if you omit them (`service_type` → `"stateless"`, `permitted_targets` → all six targets) — but don't rely on the `permitted_targets` default. It defaults to declaring `local`, `browser`, `edge`, `cloud`, `worker`, and `device` all permitted, which is a governance-level "allowed to run here eventually" declaration, not a claim that the runtime can execute there today. Set it explicitly to what you actually mean — almost always just `["local"]` for a new capability — and cross-check against `references/platforms.md` before claiming more.
+
+**Enum values, verified against the struct:**
+| Field | Valid values |
+|---|---|
+| `lifecycle` | `draft`, `active`, `deprecated`, `retired`, `archived` — only `active` and `deprecated` are runtime-eligible |
+| `service_type` | `stateless` (default), `subscribable` (needs `event_trigger`), `stateful` (can't run in Browser) |
+| `execution.binary_format` | `wasm` (only value defined) |
+| `execution.entrypoint.kind` | `wasi-command` (only value defined) |
+| `execution.preferred_targets[]` / `permitted_targets[]` | `local`, `browser`, `edge`, `cloud`, `worker`, `device` |
+| `execution.constraints.host_api_access` | `none`, `exception_required` |
+| `execution.constraints.network_access` | `forbidden`, `required` |
+| `execution.constraints.filesystem_access` | `none`, `sandbox_only` |
+| `side_effects[].kind` | `none`, `memory_only`, `event_emission`, `external_call`, `state_change` |
+| `provenance.source` | check `ProvenanceSource` enum in the struct if `greenfield` doesn't fit |
+
+## Workflow (`workflow.json`)
+
+A package can't register without at least one approved workflow reference — an empty `workflow_refs: []` in the manifest is rejected outright. The simplest valid workflow is a single node calling your one capability:
+
+```json
+{
+  "kind": "workflow_definition",
+  "schema_version": "1.0.0",
+  "id": "namespace.name",
+  "name": "name",
+  "version": "1.0.0",
+  "lifecycle": "active",
+  "owner": { "team": "your-team", "contact": "you@example.com" },
+  "summary": "Run the namespace.name capability as one governed workflow.",
+  "inputs": { "schema": { "...": "same shape as the capability's inputs" } },
+  "outputs": { "schema": { "...": "same shape as the capability's outputs" } },
+  "nodes": [
+    {
+      "node_id": "run",
+      "capability_id": "namespace.name",
+      "capability_version": "1.0.0",
+      "input": { "from_workflow_input": ["your_field"] },
+      "output": { "to_workflow_state": ["your_output_field"] }
+    }
+  ],
+  "edges": [],
+  "start_node": "run",
+  "terminal_nodes": ["run"],
+  "tags": [],
+  "governing_spec": "007-workflow-registry-traversal"
+}
+```
+
+## Agent package manifest (`manifest.json`)
+
+This is what `traverse-cli agent inspect`/`agent execute` actually reads. It's a lighter-weight package format than the full application-bundle manifest (see SKILL.md's "Actually running it" section for why that distinction matters).
+
+```json
+{
+  "kind": "agent_package",
+  "schema_version": "1.0.0",
+  "package_id": "namespace.name-agent",
+  "version": "1.0.0",
+  "summary": "One sentence.",
+  "capability_ref": {
+    "id": "namespace.name",
+    "version": "1.0.0",
+    "contract_path": "relative/path/to/contract.json"
+  },
+  "workflow_refs": [
+    { "workflow_id": "namespace.name", "workflow_version": "1.0.0" }
+  ],
+  "source": { "path": "./src/agent.rs", "language": "rust", "entry": "run" },
+  "binary": {
+    "path": "./artifacts/your-agent.wasm",
+    "format": "wasm",
+    "expected_digest": "fnv1a64:0000000000000000",
+    "abi_version": "1.0.0"
+  },
+  "constraints": {
+    "host_api_access": "none",
+    "network_access": "forbidden",
+    "filesystem_access": "none"
+  },
+  "model_dependencies": []
+}
+```
+
+The digest is **FNV-1a-64**, formatted `fnv1a64:<16 lowercase hex chars>` — not SHA-256, even though a couple of docs/scripts in the repo (like the stale scaffold script) compute SHA-256. Don't hand-compute it: put a placeholder in, run `agent inspect`, and the tool's own mismatch error tells you the real value to paste in.
+
+## Composing multiple atomic capabilities into one workflow
+
+A workflow isn't limited to one node. `workflows/examples/expedition/plan-expedition/workflow.json` in the real repo chains five separate, narrowly-scoped capabilities (capture → interpret → assess → validate → assemble) into one governed traversal:
+
+```json
+{
+  "nodes": [
+    { "node_id": "capture_objective", "capability_id": "expedition.planning.capture-expedition-objective", "capability_version": "1.0.0",
+      "input": { "from_workflow_input": ["destination", "target_window", "preferences", "notes"] },
+      "output": { "to_workflow_state": ["objective"] } },
+    { "node_id": "interpret_intent", "capability_id": "expedition.planning.interpret-expedition-intent", "capability_version": "1.0.0",
+      "input": { "from_workflow_input": ["objective", "planning_intent"] },
+      "output": { "to_workflow_state": ["interpreted_intent"] } }
+  ],
+  "edges": [
+    { "edge_id": "capture_to_interpret", "from": "capture_objective", "to": "interpret_intent", "trigger": "direct" }
+  ],
+  "start_node": "capture_objective",
+  "terminal_nodes": ["assemble_plan"]
+}
+```
+
+**A naming gotcha worth knowing up front:** despite its name, a node's `from_workflow_input` does not only pull from the workflow's top-level input schema — it pulls from the accumulated workflow *state* bag, which includes both the original inputs and every prior node's `to_workflow_state` output. In the example above, `interpret_intent` reads `objective` via `from_workflow_input` even though `objective` isn't one of the workflow's declared top-level inputs — it only exists because `capture_objective` wrote it a step earlier. Don't be misled by the field name into thinking each node is limited to the workflow's original request payload.
+
+This is also the real design argument for keeping each capability atomic (one verb, one responsibility) rather than folding multiple concerns into a single capability: a workflow only composes cleanly if each node's contract is narrow enough to slot into a chain like this. If you're about to write a single capability that captures, interprets, *and* validates all in one binary, consider whether splitting it into workflow nodes instead would make each piece independently reusable and testable — the same way `interpret-expedition-intent` and `validate-team-readiness` can each be discovered and reused on their own (see `references/registry.md`), whereas a monolithic capability can't be.
+
+## Runtime request (`runtime-request.json`)
+
+```json
+{
+  "kind": "runtime_request",
+  "schema_version": "1.0.0",
+  "request_id": "namespace-name-test-001",
+  "intent": { "capability_id": "namespace.name", "capability_version": "1.0.0" },
+  "input": { "your_field": "example value" },
+  "lookup": { "scope": "public_only", "allow_ambiguity": false },
+  "context": { "requested_target": "local", "caller": "manual-test" },
+  "governing_spec": "006-runtime-request-execution"
+}
+```

--- a/.agents/skills/traverse-app-builder/references/platforms.md
+++ b/.agents/skills/traverse-app-builder/references/platforms.md
@@ -1,0 +1,21 @@
+# Platform status — check before you promise a target
+
+Traverse is pre-1.0 (v0.8.1). "Runs everywhere" is the design goal, not the current state. Before telling a user their capability will work on some target, check it against this table — it's condensed from `/platforms.html` on the docs site plus direct code verification (not just marketing copy), and it changes release to release, so treat the docs site as the source of truth if this file and the live site ever disagree.
+
+| Target | Status | Evidence |
+|---|---|---|
+| **Native** | Shipped | `traverse-runtime` crate, Wasmtime-backed `WasmExecutor` — this is the real executor that actually runs a capability's WASM. |
+| **Browser** | Shipped | Web/TypeScript embedder SDK, `traverse-embedder-web` package, `BundleEmbedder` class, currently v0.8.0. |
+| **Rust app embedding** | Shipped | `traverse-embedder` crate. `BundleEmbedder::init` / `.submit` / `.subscribe` / `.shutdown` genuinely call through to the real `ArtifactRouter` executor — this is not a stub. |
+| **Swift / iOS** | Blocked | No WASM engine certified as compliant. WasmKit, WAMR, Wasmtime, and Wasmer were all screened and rejected — this isn't "not started yet," it's a currently unresolved dependency problem upstream of Traverse itself. |
+| **Kotlin / Android** | In progress | Bridge code exists and works in isolation; not released as a packaged embedder yet. |
+| **.NET / WinUI** | In progress | Same state as Kotlin — working bridge, no release yet. |
+| **Edge** | Planned, not started | No code. |
+| **Cloud placement** | Explicit non-goal for v0.1 | This is a deliberate scope decision in the governing specs, not an oversight — don't imply it's coming soon. |
+
+## What this means for a capability you just built
+
+- A contract with `permitted_targets: ["local"]` is honest for almost every new capability today. Widening it to `browser` is honest too, once you've actually built and tested the browser embedder path — don't add a target to the list just because the enum allows it.
+- Setting `permitted_targets` to all six values (the deserializer's default if you omit the field) is a governance-level claim, not a technical one — the schema will accept it, but it doesn't mean the capability can actually run on `edge` or `cloud` today. Don't let the default stand in for a decision.
+- If a user asks "can I ship this to iOS," the honest answer is no, and it's not a Traverse packaging problem — it's a blocked upstream dependency (no compliant WASM engine exists yet for that platform). Say that plainly rather than suggesting a workaround.
+- MCP exposure (`traverse-mcp`) is a separate axis from placement targets — it's a stdio server with 9 tools (describe_server, list_content_groups, describe_content_group, list_entrypoints, describe_entrypoint, validate_entrypoint, execute_entrypoint, render_execution_report, shutdown) that lets an agent discover → inspect → execute → trace a capability. It works today over stdio only; there's no library API yet.

--- a/.agents/skills/traverse-app-builder/references/registry.md
+++ b/.agents/skills/traverse-app-builder/references/registry.md
@@ -1,0 +1,72 @@
+# Checking the registry before you build anything new
+
+Traverse's registry is the mechanism for reuse: a capability someone else already wrote, contracted, and published should be something you can find and call, not something you re-implement. Before scaffolding a new capability, check whether one already covers what you need — the commands below are real and verified against `crates/traverse-cli/src/main.rs` and `crates/traverse-registry/src/public_registry_state.rs`, not inferred from docs copy.
+
+## Two different registries, two different commands
+
+Don't conflate these — they answer different questions:
+
+1. **"What's published publicly, across the ecosystem?"** → `registry sync` + reading the synced index.
+2. **"What capabilities did I already declare inside this specific app bundle I'm assembling?"** → `capability discover`.
+
+Neither is a live network search. Both work against local state — the runtime and CLI never live-fetch during normal use, which is a deliberate determinism choice, not a limitation to work around.
+
+## 1. Sync and read the public registry index
+
+```bash
+traverse-cli registry sync --workspace <workspace-id> --json
+```
+
+This fetches the latest public registry index from `traverse-framework/registry` and writes it to `.traverse/workspaces/<workspace-id>/registry/public/index.json` under your current directory. The command's own JSON output is intentionally thin — `status`, `source`, `release_tag`, `record_count`, `synced_at`, `state_path` — it tells you *that* the sync worked and *how many* records came down, not what they are.
+
+**To actually see what's available, read the state file it just wrote:**
+
+```bash
+cat .traverse/workspaces/<workspace-id>/registry/public/index.json
+```
+
+Each record has this shape (verified against `PublicRegistryCapabilityRecord` in `crates/traverse-registry/src/public_registry_state.rs`):
+
+```json
+{
+  "namespace": "some-namespace",
+  "id": "some-namespace.some-capability",
+  "version": "1.0.0",
+  "digest": "fnv1a64:...",
+  "artifact_url": "https://.../artifact.wasm",
+  "contract_digest": "sha256:...",
+  "contract_url": "https://raw.githubusercontent.com/traverse-framework/registry/.../contract.json",
+  "deprecated": false
+}
+```
+
+**This is a thin pointer, not a catalog entry** — notice there's no `summary`, `description`, `inputs`, or `outputs` field. The public index only carries enough to identify and verify a capability (id, version, digest, URLs), not enough to know what it actually does. To evaluate whether an existing capability fits your need, fetch `contract_url` and read the real contract — the same shape documented in `references/contract-schema.md`.
+
+## 2. Check what's already declared in an app bundle you're assembling
+
+If you're working inside an app's own registry bundle (a local `manifest.json` that lists the capabilities/events/workflows an app assembles, distinct from the thin public index above):
+
+```bash
+traverse-cli capability discover path/to/registry-bundle/manifest.json --json
+```
+
+This loads that bundle into an in-memory registry and lists everything actually registered in it — id, version, scope, lifecycle, `implementation_kind` (`executable` vs `workflow`), summary, and tags. This is richer than the public index because it's built from full contracts already resolved into memory, but it only reflects what that one bundle declares — not the wider public registry, and not anything from a `registry sync` unless the bundle was registered with `bundle register` first (which merges in synced public records; `capability discover` alone does not).
+
+## 3. Publishing an atomic capability you built
+
+Once your capability validates cleanly (`agent inspect` passes — see SKILL.md steps 2-5), making it available to others is a real, if deliberately unautomated, flow:
+
+```bash
+traverse-cli capability publish \
+  --contract path/to/contract.json \
+  --artifact path/to/artifact.wasm \
+  --registry-repo path/to/local/traverse-framework/registry-checkout \
+  --json \
+  [--dry-run]
+```
+
+This validates the contract and artifact digest, then prepares a publication candidate under a local checkout of `traverse-framework/registry` — **it never pushes or opens the PR for you automatically without a human in the loop**; the command's own help text is explicit that it "opens a human-reviewed registry PR," not that it merges anything. Always run with `--dry-run` first to see the planned branch and paths before doing it for real.
+
+## Workflow-side registry commands (real, but registry-only — not execution)
+
+`workflow register` / `workflow list` / `workflow inspect` mirror the capability commands for workflow definitions — they're genuinely generic and work for any workflow you throw at them, not demo-scoped. But like the capability commands above, they only cover registration and inspection. There is no generic `workflow execute` in the CLI — see SKILL.md's "Actually running it" section for why, and what to do about it if you need a workflow to actually run end-to-end.

--- a/.agents/skills/traverse-app-builder/references/troubleshooting.md
+++ b/.agents/skills/traverse-app-builder/references/troubleshooting.md
@@ -1,0 +1,102 @@
+# Troubleshooting — real errors, in the order you'll likely hit them
+
+Every error below was actually produced hands-on — most while building a brand-new capability (`shout-agent`) from scratch through this exact workflow; entries #8-11 while separately verifying `traverse-cli serve` and, later, re-verifying execution after spec 516 landed (which fixed the hardcoded-allowlist issue in entry #8, and surfaced the real, still-open ABI constraint in entry #11 along with its verified fix) — not copied from documentation. They're ordered the way they naturally occur, from first compile through final execute.
+
+## 1. `error[E0463]: can't find crate for 'core'`
+
+**When:** compiling for a wasm target (`wasm32-unknown-unknown` for the real no_std pattern, or `wasm32-wasip1` if you're experimenting with the std-based approach this skill steers you away from), even after `rustup target add` reported success and the `.rlib` files genuinely exist on disk.
+
+**Cause:** the machine has both a Homebrew-installed Rust toolchain and a rustup-managed one. `rustup target add` only installs the target for *rustup's* toolchain. If `/opt/homebrew/bin/cargo`/`rustc` resolve first on `PATH`, the build uses Homebrew's `rustc`, which has no idea rustup installed anything — it just reports the target's core crate as missing. The error message doesn't mention rustup or Homebrew at all, which is what makes this one easy to lose time on.
+
+**Check:**
+```bash
+which rustc                  # /opt/homebrew/bin/rustc means you're in the trap
+rustc --version --verbose    # look for the toolchain name — Homebrew's won't say "rustup"
+```
+
+**Fix:** don't hand-construct the rustup toolchain directory path — on Apple Silicon `uname -m` reports `arm64`, but rustup's toolchain directory is named `aarch64-apple-darwin`, so a `$(uname -m)` substitution silently builds a nonexistent path and you're right back to Homebrew's binaries with no error at all (this was verified the hard way: the "obvious" fix looked like it worked, `which rustc` still showed Homebrew's, and the build failed identically). Use `rustup which cargo`/`rustup which rustc` to get the real paths and prepend *their* directory:
+```bash
+PATH="$(dirname "$(rustup which cargo)"):$PATH" rustc src/agent.rs --target wasm32-unknown-unknown --crate-type cdylib -O -o artifacts/your-agent.wasm
+```
+
+## 2. `error: current package believes it's in a workspace when it's not`
+
+**When:** the capability's `Cargo.toml` lives inside a cloned `traverse-framework/traverse` checkout (e.g. under `examples/`), and that repo has its own root workspace `Cargo.toml`.
+
+**Cause:** Cargo detects the new crate as an unclaimed member of the enclosing repo's workspace.
+
+**Fix:** add an empty `[workspace]` table to the capability's own `Cargo.toml`:
+```toml
+[workspace]
+```
+This tells Cargo the crate is its own workspace root, not an orphaned member of the parent one.
+
+## 3. Binary path mismatch on build
+
+**When:** `Cargo.toml` declares `[[bin]] path = "src/main.rs"` but the source file is actually named something else (e.g. `src/agent.rs`, to match the surrounding repo's naming convention).
+
+**Fix:** make the `path` in `[[bin]]` match the real file location — either rename the source file to `src/main.rs` or point `path` at wherever it actually lives. There's no default inference once you've declared an explicit `[[bin]]` table.
+
+## 4. `agent package must declare at least one approved workflow reference`
+
+**When:** running `agent inspect` on a manifest with `"workflow_refs": []`.
+
+**Cause:** a package isn't considered registrable without at least one workflow tying it to a governed entrypoint — this is enforced, not optional even for a quick local test.
+
+**Fix:** write a real `workflow_definition` JSON (see `references/contract-schema.md`) and add a corresponding entry to `workflow_refs` in the manifest: `{"workflow_id": "...", "workflow_version": "..."}`.
+
+## 5. `agent binary digest mismatch ... expected fnv1a64:..., got fnv1a64:<real digest>`
+
+**When:** running `agent inspect` with a placeholder `expected_digest`.
+
+**Cause:** Traverse hashes the compiled `.wasm` binary with FNV-1a-64, not SHA-256 (the stale `scripts/scaffold/new-capability.sh` assumes SHA-256, which is itself part of why that script is untrustworthy).
+
+**Fix:** don't hand-implement FNV-1a. Leave a placeholder digest (`fnv1a64:0000000000000000`), run `agent inspect`, and copy the real digest straight out of the mismatch error into the manifest.
+
+## 6. `matching capabilities were found but none were runnable locally`
+
+**When:** running `agent execute` while the contract's `lifecycle` is still `"draft"`.
+
+**Cause:** `evaluate_candidate()` in `crates/traverse-runtime/src/lib.rs` checks `contract.lifecycle.is_runtime_eligible()`, which is only `true` for `Active` and `Deprecated`. A draft contract is correctly rejected — this isn't a bug, it's the runtime refusing to execute something not yet declared ready.
+
+**Fix:** set `lifecycle` to `"active"` in both the contract and the workflow once you actually intend to run it, even for local iteration.
+
+## 7. `missing field 'kind'` on the runtime request
+
+**When:** using a minimal hand-written request like `{"text": "hello traverse"}`.
+
+**Cause:** the real `runtime_request` shape requires the full envelope (`kind`, `schema_version`, `request_id`, `intent`, `lookup`, `context`, `governing_spec`) — the actual capability input goes inside `input`, not at the top level.
+
+**Fix:** copy the full shape from `references/contract-schema.md` (or an existing example like `hello-world`'s `runtime-requests/say-hello.json`) rather than writing a minimal one from scratch.
+
+## 8. `runtime execution failed: unsupported AI agent capability: <your.id>` (historical — fixed by spec 516)
+
+**When:** this used to happen running `agent execute` on any capability that wasn't one of seven specific demo IDs, even with `agent inspect` passing cleanly and `lifecycle: "active"`. **As of spec 516 landing, this no longer happens** — `agent execute` now routes every capability through the real `ArtifactRouter` executor, not a hardcoded allowlist. Verified hands-on: a capability id that's never existed in that old demo set now runs for real.
+
+**If you still see this exact message,** you're on a `traverse-cli` build from before spec 516 merged — rebuild from a current `main`. If you see `runtime execution failed: registered artifact execution failed` instead, that's not this issue — it's the ABI wall in entry #11, unrelated to the old allowlist.
+
+**A second, still-real CLI-native execution path exists alongside `agent execute`: `traverse-cli serve`.** It starts an HTTP API backed by the same `ArtifactRouter` executor — `POST /v1/capabilities/register` (any contract + binary) then `POST /v1/capabilities/execute` genuinely runs it, and it can run whole workflows too via a composite capability (see entry #10). It isn't mentioned in `agent execute`'s own docs, so it's easy to miss, but it's a genuine alternative if you want an HTTP surface instead of a one-shot CLI call.
+
+## 9. A workflow node isn't getting a field you expected it to have
+
+**When:** writing a multi-node workflow and a downstream node's contract fails validation because a field it expects (via `from_workflow_input`) never arrives, or conversely you assume a node can *only* see the workflow's original top-level input fields and design around that unnecessarily.
+
+**Cause:** despite the name, `from_workflow_input` on a node reads from the *accumulated workflow state* — the original request input plus every upstream node's `to_workflow_state` output — not strictly the workflow's declared top-level input schema. In the real `plan-expedition` example, the `interpret_intent` node reads `objective` via `from_workflow_input` even though `objective` isn't one of the workflow's own top-level inputs; it only exists in state because the `capture_objective` node produced it first.
+
+**Fix:** when a node needs a field, check whether any upstream node's `to_workflow_state` produces it — that's the actual source of truth, not the workflow's `inputs.schema`. And when ordering nodes, make sure anything a node reads via `from_workflow_input` was either an original input or was written by a node earlier in the `edges` chain — the runtime won't reorder nodes to satisfy a dependency you got backwards.
+
+## 10. Expecting a `workflow execute` command that doesn't exist
+
+**When:** having registered and inspected a workflow successfully (`workflow register`/`workflow list`/`workflow inspect` all genuinely work), you look for the equivalent execute command and either guess at a syntax that errors out, or reach for `expedition execute` assuming it's a generic runner.
+
+**Cause:** there is no bare workflow-execution command in `traverse-cli` at all — confirmed by reading the full `Command` enum in `crates/traverse-cli/src/main.rs`. `expedition execute` exists, but it's a bespoke command hardcoded to the expedition example domain, not a generic workflow runner. The real, generic traversal engine (`Runtime::execute_workflow` in `crates/traverse-runtime/src/workflows.rs`) does exist and is genuinely contract-enforced end-to-end — it's just not exposed as its own subcommand.
+
+**Fix:** it is reachable, just not obviously. `traverse-cli serve`'s `/v1/capabilities/execute` can run a workflow if you register it as a composite capability (`implementation_kind: "workflow"`, with a `workflow_ref` pointing at the registered workflow) rather than a plain executable one — confirmed via the `execute_endpoint_runs_pipeline_workflow_capability_with_merged_output` test in `http_api.rs`. That, or constructing a `Runtime<WasmExecutor>` yourself via the embedder SDKs and calling `.execute_workflow(...)` directly, are the two real options. Either way, every node's binary still has to clear the ABI whitelist in entry #11 — the same build pattern applies per-node, not just to a single capability.
+
+## 11. `unauthorized_host_import: ABI 1.0.0 does not allow import wasi_snapshot_preview1::environ_get`
+
+**When:** running `traverse-cli wasm abi verify <path>.wasm` on a binary built with `cargo build --target wasm32-wasip1` (or trying to execute one through `agent execute`, `serve`, or an embedder SDK), even though `agent inspect` already passed cleanly.
+
+**Cause:** Traverse's `WasmExecutor` (`crates/traverse-runtime/src/executor/wasm.rs`) enforces a deny-by-default host-import whitelist (`host_abi_v1.json`) that permits exactly `wasi_snapshot_preview1::{fd_read, fd_write, proc_exit}` plus a few `traverse_host` metadata calls — nothing else, no `environ_get`, `args_get`, `clock_time_get`, `random_get`, etc. Verified hands-on: an ordinary `cargo build --target wasm32-wasip1 --release` binary imports more than this whitelist allows *regardless of what your code does* — even `fn main() { println!("hi"); }`, with zero `std::env` usage anywhere in the source, imports `environ_get` and fails this check identically to a real capability. This is Rust's standard WASI startup sequence, not something introduced by your program logic, and it blocks every execution path equally (`agent execute`, `serve`, and both embedder SDKs all share this same `WasmExecutor`).
+
+**The fix, verified end-to-end:** don't target `wasm32-wasip1` or use `cargo build` at all. Use `#![no_std]` + `#![no_main]` with hand-declared `extern "C"` imports for exactly `fd_read`/`fd_write`, compiled via plain `rustc --target wasm32-unknown-unknown --crate-type cdylib` — see SKILL.md step 3 for the full template and its honest costs (no `serde_json`/heap/`String` without your own allocator, hand-rolled parsing). This was verified not just to pass `wasm abi verify`, but to actually execute through `agent execute` with genuinely dynamic, input-computed output validated against a real output contract — not a hardcoded response. If you see this error, you're almost certainly still on the `wasm32-wasip1`/`cargo build` path this skill steers away from.

--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,11 @@ coverage.profdata
 # Local-only agent tooling and scratch workspaces (must not enter the repo).
 .claude/
 external/
-references/
+/references/
+
+# In-repo skill reference packs (Decision 80 traverse-app-builder, etc.)
+!.agents/skills/**/references/
+!.agents/skills/**/references/**
 
 # Benchmark results — gitignored; check in manually when publishing
 benchmarks/results/*.json

--- a/docs/workflow-authoring-guide.md
+++ b/docs/workflow-authoring-guide.md
@@ -36,7 +36,7 @@ workflows.
 
 | Surface | Role |
 |---|---|
-| [`.agents/skills/traverse-app-builder/`](../.agents/skills/traverse-app-builder/) (landing via [#1344](https://github.com/traverse-framework/traverse/issues/1344)) | Canonical deep authoring ritual (plan → gap-author → confirm seal → validate). Until that path lands in-repo, use the personal skill copy if present. |
+| [`.agents/skills/traverse-app-builder/`](../.agents/skills/traverse-app-builder/) | Canonical deep authoring ritual (plan → gap-author → confirm seal → validate). Prefer this in-repo copy over any personal `~/.claude/skills/traverse-app-builder`. |
 | `traverse-cli` `app validate` / `workflow` validate & register | Verifier and registrar — see [cli-reference.md](cli-reference.md). |
 | Future `workflow plan` / `promote` ([#1346](https://github.com/traverse-framework/traverse/issues/1346)) | CLI wrappers over planner (113) and promotion (112) once shipped; prefer them from the skill when available. |
 | Adaptive runtime opt-in ([#1345](https://github.com/traverse-framework/traverse/issues/1345)) | Explicit sealed-default vs adaptive knob — follow-on implementation. |


### PR DESCRIPTION
## Summary

- Vendor and refresh `.agents/skills/traverse-app-builder/` for Decision 80 plan-then-seal
- Evals cover happy-path seal+validate, multi-candidate pause, gap→author→re-plan, refuse seal without confirm
- Point `docs/workflow-authoring-guide.md` at the in-repo skill path; allow skill `references/` via `.gitignore` exception

## Governing Spec

- `108-governed-runtime-workflow-composition`
- `190-readme-rewrite`
- `065-sigstore-bundle-verification`
- `070-runtime-event-sink-boundary`

Issue #1344 is labeled `no-spec-needed`. Stacked on #1347 (#1343 Decision 80 docs).

## Project Item

- Traverse Project 1: #1344
- Depends on: #1343 / #1347

## Validation

- `test -f .agents/skills/traverse-app-builder/SKILL.md`
- `rg -n "seal|plan_workflow|known_compositions|Decision 80" .agents/skills/traverse-app-builder/SKILL.md`
- `test -f .agents/skills/traverse-app-builder/evals/evals.json`
- `test -f .agents/skills/traverse-app-builder/references/contract-schema.md`

Made with [Cursor](https://cursor.com)