### PR TITLE
fix(runtime): require adaptive composition opt-in for proposals

### DIFF
--- a/crates/traverse-cli/src/http_api.rs
+++ b/crates/traverse-cli/src/http_api.rs
@@ -6132,8 +6132,9 @@ fn parse_app_proposal_request(body: &[u8]) -> Result<AppProposalRequest, String>
     };
     let composition_mode = match object.get("composition_mode") {
         None | Some(Value::Null) => CompositionMode::Sealed,
-        Some(Value::String(raw)) => CompositionMode::parse(Some(raw.as_str()))
-            .map_err(|message| message.to_string())?,
+        Some(Value::String(raw)) => {
+            CompositionMode::parse(Some(raw.as_str())).map_err(|message| message.to_string())?
+        }
         Some(_) => {
             return Err("composition_mode must be a string when present".to_string());
         }
@@ -10879,10 +10880,7 @@ mod tests {
         handle_workspace_operation(&mut out, &req, &state, true).expect("response");
         assert_eq!(response_status(&out), 403);
         let body = parse_response_body(&out);
-        assert_eq!(
-            body["traverse_code"],
-            ADAPTIVE_COMPOSITION_OPT_IN_REQUIRED
-        );
+        assert_eq!(body["traverse_code"], ADAPTIVE_COMPOSITION_OPT_IN_REQUIRED);
         assert!(
             body["detail"]
                 .as_str()
@@ -11326,7 +11324,8 @@ mod tests {
         let req = make_http_request(
             "POST",
             "/v1/workspaces/ws-test/apps/expedition.readiness/proposals",
-            br#"{"action":"validate","proposal":{"nodes":[]},"composition_mode":"adaptive"}"#.to_vec(),
+            br#"{"action":"validate","proposal":{"nodes":[]},"composition_mode":"adaptive"}"#
+                .to_vec(),
         );
 
         let mut out = Vec::new();

--- a/crates/traverse-cli/src/http_api.rs
+++ b/crates/traverse-cli/src/http_api.rs
@@ -6132,7 +6132,7 @@ fn parse_app_proposal_request(body: &[u8]) -> Result<AppProposalRequest, String>
     let composition_mode = match object.get("composition_mode") {
         None | Some(Value::Null) => CompositionMode::Sealed,
         Some(Value::String(raw)) => {
-            CompositionMode::parse(Some(raw.as_str())).map_err(|message| message.to_string())?
+            CompositionMode::parse(Some(raw.as_str())).map_err(str::to_string)?
         }
         Some(_) => {
             return Err("composition_mode must be a string when present".to_string());

--- a/crates/traverse-cli/src/http_api.rs
+++ b/crates/traverse-cli/src/http_api.rs
@@ -26,8 +26,7 @@ use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use traverse_contracts::{CapabilityContract, EventContract, parse_contract, parse_event_contract};
 use traverse_contracts::{ProposalLimits, SnapshotDigests};
 use traverse_mcp::tools::proposals::{
-    ADAPTIVE_COMPOSITION_OPT_IN_REQUIRED, CompositionMode, ProposalExecutionRequest,
-    ProposalExecutionResponse, adaptive_composition_opt_in_message, authorization_state,
+    CompositionMode, ProposalExecutionRequest, ProposalExecutionResponse, authorization_state,
     deny_unless_adaptive, execute_proposal_via_mcp, submit_proposal, validate_proposal,
 };
 use traverse_registry::{
@@ -10870,6 +10869,7 @@ mod tests {
 
     #[test]
     fn app_proposals_require_adaptive_composition_opt_in() {
+        use traverse_mcp::tools::proposals::ADAPTIVE_COMPOSITION_OPT_IN_REQUIRED;
         let state = empty_state();
         let req = make_http_request(
             "POST",
@@ -10888,7 +10888,6 @@ mod tests {
                 .contains("sealed workflows are the default"),
             "denial must point callers at sealed workflows: {body}"
         );
-        let _ = adaptive_composition_opt_in_message();
     }
 
     #[test]

--- a/crates/traverse-cli/src/http_api.rs
+++ b/crates/traverse-cli/src/http_api.rs
@@ -26,8 +26,9 @@ use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use traverse_contracts::{CapabilityContract, EventContract, parse_contract, parse_event_contract};
 use traverse_contracts::{ProposalLimits, SnapshotDigests};
 use traverse_mcp::tools::proposals::{
-    ProposalExecutionRequest, ProposalExecutionResponse, authorization_state,
-    execute_proposal_via_mcp, submit_proposal, validate_proposal,
+    ADAPTIVE_COMPOSITION_OPT_IN_REQUIRED, CompositionMode, ProposalExecutionRequest,
+    ProposalExecutionResponse, adaptive_composition_opt_in_message, authorization_state,
+    deny_unless_adaptive, execute_proposal_via_mcp, submit_proposal, validate_proposal,
 };
 use traverse_registry::{
     ApplicationBundleManifest, ApplicationStateMachine, ApplicationStateTransition,
@@ -5967,6 +5968,14 @@ fn handle_app_proposals<W: Write, E: LocalExecutor + Clone>(
             );
         }
     };
+    if let Some(denial) = deny_unless_adaptive(parsed.composition_mode) {
+        return write_json(
+            w,
+            403,
+            "Forbidden",
+            &error_envelope(&denial.code, &denial.message),
+        );
+    }
 
     let result = state.with_workspace_mut(workspace_id, |ws| {
         let Some(state_path) = ws
@@ -6085,6 +6094,7 @@ struct AppProposalRequest {
     action: String,
     proposal: Value,
     approval_token: Option<String>,
+    composition_mode: CompositionMode,
 }
 
 fn parse_app_proposal_request(body: &[u8]) -> Result<AppProposalRequest, String> {
@@ -6120,10 +6130,19 @@ fn parse_app_proposal_request(body: &[u8]) -> Result<AppProposalRequest, String>
         Some(Value::String(token)) if !token.trim().is_empty() => Some(token.clone()),
         _ => return Err("'approval_token' must be a non-empty string when present".to_string()),
     };
+    let composition_mode = match object.get("composition_mode") {
+        None | Some(Value::Null) => CompositionMode::Sealed,
+        Some(Value::String(raw)) => CompositionMode::parse(Some(raw.as_str()))
+            .map_err(|message| message.to_string())?,
+        Some(_) => {
+            return Err("composition_mode must be a string when present".to_string());
+        }
+    };
     Ok(AppProposalRequest {
         action,
         proposal,
         approval_token,
+        composition_mode,
     })
 }
 
@@ -10849,12 +10868,55 @@ mod tests {
     }
 
     #[test]
+    fn app_proposals_require_adaptive_composition_opt_in() {
+        let state = empty_state();
+        let req = make_http_request(
+            "POST",
+            "/v1/workspaces/ws-test/apps/missing/proposals",
+            br#"{"action":"validate","proposal":{}}"#.to_vec(),
+        );
+        let mut out = Vec::new();
+        handle_workspace_operation(&mut out, &req, &state, true).expect("response");
+        assert_eq!(response_status(&out), 403);
+        let body = parse_response_body(&out);
+        assert_eq!(
+            body["traverse_code"],
+            ADAPTIVE_COMPOSITION_OPT_IN_REQUIRED
+        );
+        assert!(
+            body["detail"]
+                .as_str()
+                .unwrap_or_default()
+                .contains("sealed workflows are the default"),
+            "denial must point callers at sealed workflows: {body}"
+        );
+        let _ = adaptive_composition_opt_in_message();
+    }
+
+    #[test]
+    fn app_proposals_accept_explicit_adaptive_opt_in_past_the_gate() {
+        let state = empty_state();
+        let req = make_http_request(
+            "POST",
+            "/v1/workspaces/ws-test/apps/missing/proposals",
+            br#"{"action":"validate","proposal":{},"composition_mode":"adaptive"}"#.to_vec(),
+        );
+        let mut out = Vec::new();
+        handle_workspace_operation(&mut out, &req, &state, true).expect("response");
+        assert_eq!(response_status(&out), 404);
+        assert_eq!(
+            parse_response_body(&out)["traverse_code"],
+            "app_not_registered"
+        );
+    }
+
+    #[test]
     fn app_proposals_reject_invalid_browser_request_before_runtime_access() {
         let state = empty_state();
         let req = make_http_request(
             "POST",
             "/v1/workspaces/ws-test/apps/missing/proposals",
-            br#"{"action":"validate","proposal":{},"credentials":"secret"}"#.to_vec(),
+            br#"{"action":"validate","proposal":{},"credentials":"secret","composition_mode":"adaptive"}"#.to_vec(),
         );
         let mut out = Vec::new();
         handle_workspace_operation(&mut out, &req, &state, true).expect("response");
@@ -10871,7 +10933,7 @@ mod tests {
         let req = make_http_request(
             "POST",
             "/v1/workspaces/ws-test/apps/missing/proposals",
-            br#"{"action":"validate","proposal":{}}"#.to_vec(),
+            br#"{"action":"validate","proposal":{},"composition_mode":"adaptive"}"#.to_vec(),
         );
         let mut out = Vec::new();
         handle_workspace_operation(&mut out, &req, &state, true).expect("response");
@@ -11264,7 +11326,7 @@ mod tests {
         let req = make_http_request(
             "POST",
             "/v1/workspaces/ws-test/apps/expedition.readiness/proposals",
-            br#"{"action":"validate","proposal":{"nodes":[]}}"#.to_vec(),
+            br#"{"action":"validate","proposal":{"nodes":[]},"composition_mode":"adaptive"}"#.to_vec(),
         );
 
         let mut out = Vec::new();

--- a/crates/traverse-mcp/src/tools/proposals.rs
+++ b/crates/traverse-mcp/src/tools/proposals.rs
@@ -43,7 +43,7 @@ impl CompositionMode {
     /// `sealed` or `adaptive`.
     pub fn parse(raw: Option<&str>) -> Result<Self, &'static str> {
         match raw.map(str::trim) {
-            None | Some("") | Some("sealed") => Ok(Self::Sealed),
+            None | Some("" | "sealed") => Ok(Self::Sealed),
             Some("adaptive") => Ok(Self::Adaptive),
             Some(_) => Err("composition_mode must be sealed or adaptive when present"),
         }
@@ -553,8 +553,12 @@ mod composition_mode_tests {
             CompositionMode::parse(Some("sealed")).ok(),
             Some(CompositionMode::Sealed)
         );
-        let denial = deny_unless_adaptive(CompositionMode::Sealed).expect("sealed denies");
-        assert_eq!(denial.code, ADAPTIVE_COMPOSITION_OPT_IN_REQUIRED);
+        assert_eq!(
+            deny_unless_adaptive(CompositionMode::Sealed)
+                .as_ref()
+                .map(|denial| denial.code.as_str()),
+            Some(ADAPTIVE_COMPOSITION_OPT_IN_REQUIRED)
+        );
     }
 
     #[test]

--- a/crates/traverse-mcp/src/tools/proposals.rs
+++ b/crates/traverse-mcp/src/tools/proposals.rs
@@ -541,13 +541,14 @@ fn debug_enum_to_snake_case(value: &str) -> String {
 
 #[cfg(test)]
 mod composition_mode_tests {
-    use super::{
-        ADAPTIVE_COMPOSITION_OPT_IN_REQUIRED, CompositionMode, deny_unless_adaptive,
-    };
+    use super::{ADAPTIVE_COMPOSITION_OPT_IN_REQUIRED, CompositionMode, deny_unless_adaptive};
 
     #[test]
     fn missing_or_sealed_denies_proposal_surfaces() {
-        assert_eq!(CompositionMode::parse(None).ok(), Some(CompositionMode::Sealed));
+        assert_eq!(
+            CompositionMode::parse(None).ok(),
+            Some(CompositionMode::Sealed)
+        );
         assert_eq!(
             CompositionMode::parse(Some("sealed")).ok(),
             Some(CompositionMode::Sealed)

--- a/crates/traverse-mcp/src/tools/proposals.rs
+++ b/crates/traverse-mcp/src/tools/proposals.rs
@@ -25,6 +25,58 @@ use traverse_runtime::{LocalExecutor, Runtime};
 
 use crate::{McpError, McpErrorCode};
 
+/// Decision 80 dual-path: sealed workflows are the default production path;
+/// live proposal validate/submit/execute requires explicit `adaptive` opt-in.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum CompositionMode {
+    #[default]
+    Sealed,
+    Adaptive,
+}
+
+impl CompositionMode {
+    /// Parses an optional request/app field. Missing or empty means sealed.
+    ///
+    /// # Errors
+    ///
+    /// Returns a stable secret-free message when the value is present but not
+    /// `sealed` or `adaptive`.
+    pub fn parse(raw: Option<&str>) -> Result<Self, &'static str> {
+        match raw.map(str::trim) {
+            None | Some("") | Some("sealed") => Ok(Self::Sealed),
+            Some("adaptive") => Ok(Self::Adaptive),
+            Some(_) => Err("composition_mode must be sealed or adaptive when present"),
+        }
+    }
+
+    #[must_use]
+    pub const fn allows_proposal_surfaces(self) -> bool {
+        matches!(self, Self::Adaptive)
+    }
+}
+
+/// Stable denial when adaptive proposal surfaces are used without opt-in.
+pub const ADAPTIVE_COMPOSITION_OPT_IN_REQUIRED: &str = "adaptive_composition_opt_in_required";
+
+#[must_use]
+pub fn adaptive_composition_opt_in_message() -> &'static str {
+    "adaptive composition requires explicit composition_mode=adaptive; sealed workflows are the default — author and validate a pinned workflow instead"
+}
+
+/// Fail-closed gate for proposal validate/submit/execute (Decision 80 §6).
+#[must_use]
+pub fn deny_unless_adaptive(mode: CompositionMode) -> Option<ProposalDenial> {
+    if mode.allows_proposal_surfaces() {
+        None
+    } else {
+        Some(ProposalDenial {
+            code: ADAPTIVE_COMPOSITION_OPT_IN_REQUIRED.to_string(),
+            path: "/composition_mode".to_string(),
+            message: adaptive_composition_opt_in_message().to_string(),
+        })
+    }
+}
+
 /// One stable, machine-readable, secret-free denial (spec 109 FR-010).
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct ProposalDenial {
@@ -485,4 +537,36 @@ fn debug_enum_to_snake_case(value: &str) -> String {
         }
     }
     output
+}
+
+#[cfg(test)]
+mod composition_mode_tests {
+    use super::{
+        ADAPTIVE_COMPOSITION_OPT_IN_REQUIRED, CompositionMode, deny_unless_adaptive,
+    };
+
+    #[test]
+    fn missing_or_sealed_denies_proposal_surfaces() {
+        assert_eq!(CompositionMode::parse(None).ok(), Some(CompositionMode::Sealed));
+        assert_eq!(
+            CompositionMode::parse(Some("sealed")).ok(),
+            Some(CompositionMode::Sealed)
+        );
+        let denial = deny_unless_adaptive(CompositionMode::Sealed).expect("sealed denies");
+        assert_eq!(denial.code, ADAPTIVE_COMPOSITION_OPT_IN_REQUIRED);
+    }
+
+    #[test]
+    fn adaptive_allows_proposal_surfaces() {
+        assert_eq!(
+            CompositionMode::parse(Some("adaptive")).ok(),
+            Some(CompositionMode::Adaptive)
+        );
+        assert!(deny_unless_adaptive(CompositionMode::Adaptive).is_none());
+    }
+
+    #[test]
+    fn rejects_unknown_composition_mode_values() {
+        assert!(CompositionMode::parse(Some("auto")).is_err());
+    }
 }

--- a/docs/workflow-authoring-guide.md
+++ b/docs/workflow-authoring-guide.md
@@ -13,7 +13,7 @@ the defaults and where to go next.
 |---|---|---|
 | **Sealed workflow (default)** | What ships and runs in production | Reviewed, pinned `workflow.json` referenced from the app/package manifest (`known_compositions` / workflow refs). Deterministic traversal. |
 | **Plan-then-seal (authoring)** | Building or changing a workflow | Planner/MCP proposes candidates; human confirms seal; CLI validates before trust. |
-| **Adaptive composition (opt-in)** | Explicit app/request flag only | Live plan at execution time under governed proposal rules. Not the default; never silently persisted as the sealed app workflow. |
+| **Adaptive composition (opt-in)** | Explicit app/request `composition_mode: "adaptive"` only | Live plan at execution time under governed proposal rules. Not the default; never silently persisted as the sealed app workflow. Missing or `"sealed"` fails closed on proposal validate/submit/execute with `adaptive_composition_opt_in_required`. |
 
 Sealed workflows are the production path. Runtime planning is not.
 


### PR DESCRIPTION
## Summary

- Fail closed on HTTP `…/proposals` validate/submit/execute unless the request sets `composition_mode: "adaptive"`
- Stable denial code `adaptive_composition_opt_in_required` points callers at sealed workflows
- Document the field name in `docs/workflow-authoring-guide.md` (matches Decision 80 illustration)

## Governing Spec

- `108-governed-runtime-workflow-composition`
- `109-runtime-workflow-proposals`
- `113-declarative-workflow-planning`
- `065-sigstore-bundle-verification`
- `070-runtime-event-sink-boundary`

Decision 80 §6. Sealed `/commands` path is unchanged. Promotion catalog mutation invariants unchanged.

## Project Item

- Traverse Project 1: #1345

## Validation

- `cargo test -p traverse-mcp --lib composition_mode`
- `cargo test -p traverse-cli-rs app_proposals_`

Made with [Cursor](https://cursor.com)