### PR TITLE
feat(cli): add workflow plan and promote finalize commands

### DIFF
--- a/.agents/skills/traverse-app-builder/SKILL.md
+++ b/.agents/skills/traverse-app-builder/SKILL.md
@@ -55,13 +55,23 @@ Details: `references/registry.md`.
 
 ### 3. Plan candidates (planner is untrusted)
 
-Use the declarative planner (spec `113`, ADR-0043 / ADR-0050). Prefer CLI
-`workflow plan` / `workflow promote` when `#1346` has landed. Until then, call the
-MCP library surface:
+Use the declarative planner (spec `113`, ADR-0043 / ADR-0050). Prefer CLI:
+
+```bash
+traverse-cli workflow plan \
+  --app-manifest <app.manifest.json> \
+  --registry-bundle <registry-bundle/manifest.json> \
+  --starting-facts <facts.json> \
+  --target-capability <id@version>
+# or --target-event <event_type>
+```
+
+Until unavailable, the MCP library surface remains:
 
 - `traverse_mcp::tools::workflow_plan::plan_workflow` (candidate graphs)
-- `traverse_mcp::tools::workflow_promotion::{export_workflow_candidate, ...}`
-  after a reviewed proposal (spec `112`)
+- `traverse_mcp::tools::workflow_promotion::{export_workflow_candidate, finalize_candidate_into_definition}`
+  after a reviewed proposal (spec `112`); CLI finalize:
+  `traverse-cli workflow promote finalize --candidate … --identity …`
 
 Show **all** returned candidates (or the truncation notice). Do not pick one
 silently. Do not treat a plan as a runnable app workflow.

--- a/crates/traverse-cli/src/main.rs
+++ b/crates/traverse-cli/src/main.rs
@@ -12,6 +12,7 @@ mod http_api;
 mod registry_resolution_diagnostics;
 mod supply_chain;
 mod telemetry;
+mod workflow_authoring;
 mod workspace_app_materialization;
 
 use capability_packages::load_capability_package;
@@ -208,6 +209,19 @@ enum Command {
         version: Option<String>,
         workspace_id: String,
     },
+    WorkflowPlan {
+        app_manifest_path: PathBuf,
+        registry_bundle_path: PathBuf,
+        starting_facts_path: PathBuf,
+        target_capability: Option<String>,
+        target_event: Option<String>,
+        workspace_id: String,
+    },
+    WorkflowPromoteFinalize {
+        candidate_path: PathBuf,
+        identity_path: PathBuf,
+        acknowledge_unconfirmed: bool,
+    },
     Serve {
         bind_address: String,
         auth_mode: Option<String>,
@@ -253,7 +267,7 @@ struct ArtifactStateSignature {
 }
 
 #[derive(Debug)]
-enum CliError {
+pub(crate) enum CliError {
     ExecutionFailed(String),
     ValidationFailed(String),
     RegistrationConflict(String),
@@ -467,6 +481,30 @@ fn run_command(command: Command) -> Result<String, CliError> {
             version,
             workspace_id,
         } => workflow_inspect(&workflow_id, version.as_deref(), &workspace_id),
+        Command::WorkflowPlan {
+            app_manifest_path,
+            registry_bundle_path,
+            starting_facts_path,
+            target_capability,
+            target_event,
+            workspace_id,
+        } => workflow_authoring::workflow_plan(
+            &app_manifest_path,
+            &registry_bundle_path,
+            &starting_facts_path,
+            target_capability.as_deref(),
+            target_event.as_deref(),
+            &workspace_id,
+        ),
+        Command::WorkflowPromoteFinalize {
+            candidate_path,
+            identity_path,
+            acknowledge_unconfirmed,
+        } => workflow_authoring::workflow_promote_finalize(
+            &candidate_path,
+            &identity_path,
+            acknowledge_unconfirmed,
+        ),
         Command::TelemetryEnable => telemetry::enable_telemetry()
             .map(|config| render_telemetry_state("enabled", &config))
             .map_err(CliError::IoError),
@@ -1181,6 +1219,8 @@ fn subcommand_help(family: Option<&str>, subcommand: Option<&str>) -> String {
         (Some("workflow"), Some("register")) => help_workflow_register(),
         (Some("workflow"), Some("list")) => help_workflow_list(),
         (Some("workflow"), Some("inspect")) => help_workflow_inspect(),
+        (Some("workflow"), Some("plan")) => help_workflow_plan(),
+        (Some("workflow"), Some("promote")) => help_workflow_promote(),
         (Some("workflow"), _) => help_workflow(),
         (Some("expedition"), Some("execute")) => help_expedition_execute(),
         (Some("expedition"), _) => help_expedition(),
@@ -1766,6 +1806,45 @@ fn help_workflow_inspect() -> String {
         .to_string()
 }
 
+fn help_workflow_plan() -> String {
+    "traverse-cli workflow plan --app-manifest <path> --registry-bundle <path> --starting-facts <path> (--target-capability <id@version> | --target-event <type>) [--workspace-id <id>]
+
+  Purpose:
+    Deterministic declarative planner (spec 113). Emits untrusted candidate
+    proposal JSON for authoring. Structured targets only — no natural-language
+    goals. Candidates are not sealed workflows; confirm seal + CLI validate
+    before trusting them (Decision 80).
+
+  Required flags:
+    --app-manifest <path>         Application bundle manifest JSON.
+    --registry-bundle <path>      Capability registry bundle covering declared components.
+    --starting-facts <path>       JSON object of facts available before any node.
+    --target-capability <id@ver>  OR --target-event <event_type>
+
+  Optional flags:
+    --workspace-id <id>           Workspace id stamped into candidates.
+    --help                        Print this help text."
+        .to_string()
+}
+
+fn help_workflow_promote() -> String {
+    "traverse-cli workflow promote finalize --candidate <path> --identity <path> [--acknowledge-unconfirmed]
+
+  Purpose:
+    Spec 112 finalize step: turn a reviewed workflow candidate artifact into a
+    registrable workflow definition JSON. Does not mutate catalogs or manifests.
+    Register the result with `traverse-cli workflow register` after review.
+
+  Required flags:
+    --candidate <path>            Exported WorkflowCandidateArtifact JSON.
+    --identity <path>             Reviewer-assigned identity JSON.
+
+  Optional flags:
+    --acknowledge-unconfirmed     Required when unconfirmed mappings remain.
+    --help                        Print this help text."
+        .to_string()
+}
+
 fn help_workflow() -> String {
     "traverse-cli workflow <subcommand> [options]
 
@@ -1773,8 +1852,10 @@ fn help_workflow() -> String {
     register <workflow-path>   Register a workflow definition.
     list                       List registered workflows.
     inspect <workflow-id>      Inspect a registered workflow.
+    plan                       Declarative planner candidates (spec 113).
+    promote finalize           Finalize a reviewed candidate (spec 112).
 
-  Run `traverse-cli workflow inspect --help` for subcommand-specific help."
+  Run `traverse-cli workflow plan --help` or `workflow promote --help` for details."
         .to_string()
 }
 
@@ -2521,6 +2602,39 @@ fn parse_workflow_command(args: &[String]) -> Result<Command, String> {
                 workflow_id: workflow_id.clone(),
                 version,
                 workspace_id: override_workspace.unwrap_or(workspace_id),
+            })
+        }
+        [_, _, ..] if args[2] == "plan" => {
+            let app_manifest_path = parse_string_flag(args, "--app-manifest")
+                .ok_or_else(|| "--app-manifest is required".to_string())?;
+            let registry_bundle_path = parse_string_flag(args, "--registry-bundle")
+                .ok_or_else(|| "--registry-bundle is required".to_string())?;
+            let starting_facts_path = parse_string_flag(args, "--starting-facts")
+                .ok_or_else(|| "--starting-facts is required".to_string())?;
+            Ok(Command::WorkflowPlan {
+                app_manifest_path: PathBuf::from(app_manifest_path),
+                registry_bundle_path: PathBuf::from(registry_bundle_path),
+                starting_facts_path: PathBuf::from(starting_facts_path),
+                target_capability: parse_string_flag(args, "--target-capability"),
+                target_event: parse_string_flag(args, "--target-event"),
+                workspace_id,
+            })
+        }
+        [_, _, ..] if args[2] == "promote" => {
+            if args.get(3).map(String::as_str) != Some("finalize") {
+                return Err(
+                    "usage: traverse-cli workflow promote finalize --candidate <path> --identity <path>"
+                        .to_string(),
+                );
+            }
+            let candidate_path = parse_string_flag(args, "--candidate")
+                .ok_or_else(|| "--candidate is required".to_string())?;
+            let identity_path = parse_string_flag(args, "--identity")
+                .ok_or_else(|| "--identity is required".to_string())?;
+            Ok(Command::WorkflowPromoteFinalize {
+                candidate_path: PathBuf::from(candidate_path),
+                identity_path: PathBuf::from(identity_path),
+                acknowledge_unconfirmed: args.iter().any(|a| a == "--acknowledge-unconfirmed"),
             })
         }
         _ => Err(usage()),
@@ -6934,9 +7048,9 @@ fn debug_enum_to_snake_case(value: &str) -> String {
 }
 
 #[derive(Debug)]
-struct RegisteredBundle {
+pub(crate) struct RegisteredBundle {
     bundle: RegistryBundle,
-    capability_registry: CapabilityRegistry,
+    pub(crate) capability_registry: CapabilityRegistry,
     event_registry: EventRegistry,
     workflow_registry: WorkflowRegistry,
     capability_records: Vec<String>,
@@ -7043,7 +7157,7 @@ fn build_capability_registration_with_artifacts(
     })
 }
 
-fn load_registered_bundle(manifest_path: &Path) -> Result<RegisteredBundle, CliError> {
+pub(crate) fn load_registered_bundle(manifest_path: &Path) -> Result<RegisteredBundle, CliError> {
     load_registered_bundle_with_public_records(manifest_path, &[])
 }
 
@@ -13514,6 +13628,8 @@ mod tests {
             ("workflow", Some("register")),
             ("workflow", Some("list")),
             ("workflow", Some("inspect")),
+            ("workflow", Some("plan")),
+            ("workflow", Some("promote")),
             ("workflow", None),
             ("expedition", Some("execute")),
             ("expedition", None),

--- a/crates/traverse-cli/src/workflow_authoring.rs
+++ b/crates/traverse-cli/src/workflow_authoring.rs
@@ -1,0 +1,241 @@
+//! Thin CLI wrappers for Decision 80 authoring helpers (specs 113 / 112).
+//!
+//! `workflow plan` and `workflow promote` are deterministic file→JSON surfaces
+//! over the existing MCP library tools. They never auto-seal, never mutate the
+//! catalog, and never accept natural-language goals.
+
+use serde::Deserialize;
+use serde_json::Value;
+use sha2::{Digest, Sha256};
+use std::fs;
+use std::path::Path;
+use traverse_contracts::{Lifecycle, ManifestReference, Owner};
+use traverse_mcp::tools::workflow_plan::{PlanRequest, PlanTarget, plan_workflow};
+use traverse_mcp::tools::workflow_promotion::{
+    PromotedWorkflowIdentity, WorkflowCandidateArtifact, finalize_candidate_into_definition,
+};
+use traverse_registry::load_application_bundle_manifest;
+
+use crate::{CliError, RegisteredBundle, load_registered_bundle};
+
+#[derive(Debug, Deserialize)]
+struct PromoteIdentityFile {
+    id: String,
+    name: String,
+    version: String,
+    owner: Owner,
+    lifecycle: Lifecycle,
+    summary: String,
+    #[serde(default)]
+    tags: Vec<String>,
+}
+
+/// Runs `plan_workflow` against an application manifest + capability registry
+/// bundle and returns pretty-printed candidate JSON.
+pub(crate) fn workflow_plan(
+    app_manifest_path: &Path,
+    registry_bundle_path: &Path,
+    starting_facts_path: &Path,
+    target_capability: Option<&str>,
+    target_event: Option<&str>,
+    workspace_id: &str,
+) -> Result<String, CliError> {
+    let target = parse_plan_target(target_capability, target_event)?;
+    let starting_facts = read_json_value(starting_facts_path)?;
+    let manifest_bytes = fs::read(app_manifest_path).map_err(|error| {
+        CliError::IoError(format!(
+            "failed to read app manifest {}: {error}",
+            app_manifest_path.display()
+        ))
+    })?;
+    let manifest = load_application_bundle_manifest(app_manifest_path).map_err(|failure| {
+        CliError::ValidationFailed(format!(
+            "invalid application manifest {}: {}",
+            app_manifest_path.display(),
+            failure
+                .errors
+                .first()
+                .map(|error| error.message.as_str())
+                .unwrap_or("unknown validation failure")
+        ))
+    })?;
+    let RegisteredBundle {
+        capability_registry: registry,
+        ..
+    } = load_registered_bundle(registry_bundle_path)?;
+    let app_manifest = ManifestReference {
+        app_id: manifest.app_id.clone(),
+        app_version: manifest.version.clone(),
+        manifest_digest: digest_bytes(&manifest_bytes),
+    };
+    let response = plan_workflow(&PlanRequest {
+        target: &target,
+        starting_facts: &starting_facts,
+        manifest: &manifest,
+        app_manifest: &app_manifest,
+        registry: &registry,
+        workspace_id,
+    });
+    serde_json::to_string_pretty(&response)
+        .map_err(|error| CliError::IoError(format!("failed to serialize plan response: {error}")))
+}
+
+/// Finalizes a reviewed candidate into a registrable workflow definition JSON.
+/// Does not register; callers must run `workflow register` separately.
+pub(crate) fn workflow_promote_finalize(
+    candidate_path: &Path,
+    identity_path: &Path,
+    acknowledge_unconfirmed: bool,
+) -> Result<String, CliError> {
+    let candidate: WorkflowCandidateArtifact = read_json(candidate_path)?;
+    if !candidate.unconfirmed_mappings.is_empty() && !acknowledge_unconfirmed {
+        return Err(CliError::ValidationFailed(format!(
+            "candidate has {} unconfirmed mapping(s); pass --acknowledge-unconfirmed after review",
+            candidate.unconfirmed_mappings.len()
+        )));
+    }
+    let identity_file: PromoteIdentityFile = read_json(identity_path)?;
+    let identity = PromotedWorkflowIdentity {
+        id: identity_file.id,
+        name: identity_file.name,
+        version: identity_file.version,
+        owner: identity_file.owner,
+        lifecycle: identity_file.lifecycle,
+        summary: identity_file.summary,
+        tags: identity_file.tags,
+    };
+    let definition = finalize_candidate_into_definition(&candidate, identity);
+    serde_json::to_string_pretty(&definition).map_err(|error| {
+        CliError::IoError(format!("failed to serialize workflow definition: {error}"))
+    })
+}
+
+fn parse_plan_target(
+    target_capability: Option<&str>,
+    target_event: Option<&str>,
+) -> Result<PlanTarget, CliError> {
+    match (target_capability, target_event) {
+        (Some(capability), None) => {
+            let (capability_id, capability_version) = capability.split_once('@').ok_or_else(|| {
+                CliError::ValidationFailed(
+                    "--target-capability must be <capability_id>@<version>".to_string(),
+                )
+            })?;
+            if capability_id.is_empty() || capability_version.is_empty() {
+                return Err(CliError::ValidationFailed(
+                    "--target-capability must be <capability_id>@<version>".to_string(),
+                ));
+            }
+            Ok(PlanTarget::Capability {
+                capability_id: capability_id.to_string(),
+                capability_version: capability_version.to_string(),
+            })
+        }
+        (None, Some(event_type)) if !event_type.trim().is_empty() => Ok(PlanTarget::EmitsEvent {
+            event_type: event_type.to_string(),
+        }),
+        (Some(_), Some(_)) => Err(CliError::ValidationFailed(
+            "provide exactly one of --target-capability or --target-event".to_string(),
+        )),
+        _ => Err(CliError::ValidationFailed(
+            "provide --target-capability <id@version> or --target-event <event_type>".to_string(),
+        )),
+    }
+}
+
+fn read_json_value(path: &Path) -> Result<Value, CliError> {
+    let bytes = fs::read(path).map_err(|error| {
+        CliError::IoError(format!("failed to read {}: {error}", path.display()))
+    })?;
+    serde_json::from_slice(&bytes).map_err(|error| {
+        CliError::ValidationFailed(format!("invalid JSON in {}: {error}", path.display()))
+    })
+}
+
+fn read_json<T: for<'de> Deserialize<'de>>(path: &Path) -> Result<T, CliError> {
+    let bytes = fs::read(path).map_err(|error| {
+        CliError::IoError(format!("failed to read {}: {error}", path.display()))
+    })?;
+    serde_json::from_slice(&bytes).map_err(|error| {
+        CliError::ValidationFailed(format!("invalid JSON in {}: {error}", path.display()))
+    })
+}
+
+fn digest_bytes(bytes: &[u8]) -> String {
+    let digest = Sha256::digest(bytes);
+    let mut hex = String::with_capacity(digest.len() * 2);
+    for byte in digest {
+        let _ = std::fmt::Write::write_fmt(&mut hex, format_args!("{byte:02x}"));
+    }
+    format!("sha256:{hex}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{parse_plan_target, workflow_promote_finalize};
+    use std::fs;
+    use traverse_mcp::tools::workflow_promotion::WorkflowCandidateArtifact;
+
+    #[test]
+    fn plan_target_requires_exactly_one_selector() {
+        assert!(parse_plan_target(None, None).is_err());
+        assert!(parse_plan_target(Some("a@1"), Some("evt")).is_err());
+        assert!(parse_plan_target(Some("missing-version"), None).is_err());
+        assert!(parse_plan_target(Some("cap@1.0.0"), None).is_ok());
+        assert!(parse_plan_target(None, Some("evt.type")).is_ok());
+    }
+
+    #[test]
+    fn promote_finalize_rejects_unconfirmed_without_ack() {
+        let dir = std::env::temp_dir().join(format!(
+            "traverse-promote-{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_nanos())
+                .unwrap_or(0)
+        ));
+        let _ = fs::create_dir_all(&dir);
+        let candidate_path = dir.join("candidate.json");
+        let identity_path = dir.join("identity.json");
+        let candidate = WorkflowCandidateArtifact {
+            source_proposal_id: "p1".to_string(),
+            source_proposal_digest: "d1".to_string(),
+            source_snapshot_digest: "s1".to_string(),
+            nodes: Vec::new(),
+            edges: Vec::new(),
+            start_node: "a".to_string(),
+            terminal_nodes: vec!["a".to_string()],
+            unconfirmed_mappings: vec![
+                traverse_mcp::tools::workflow_promotion::UnconfirmedMapping {
+                    source_path: "/a".to_string(),
+                    target_node_id: "a".to_string(),
+                    target_path: "/b".to_string(),
+                    reason: "rename".to_string(),
+                },
+            ],
+            excluded_fields: Vec::new(),
+        };
+        fs::write(
+            &candidate_path,
+            serde_json::to_vec_pretty(&candidate).expect("serialize"),
+        )
+        .expect("write candidate");
+        fs::write(
+            &identity_path,
+            br#"{
+              "id": "demo.workflow",
+              "name": "Demo",
+              "version": "1.0.0",
+              "owner": {"team":"demo","contact":"demo@example.com"},
+              "lifecycle": "active",
+              "summary": "demo",
+              "tags": []
+            }"#,
+        )
+        .expect("write identity");
+        let err = workflow_promote_finalize(&candidate_path, &identity_path, false)
+            .expect_err("must require ack");
+        assert!(err.to_string().contains("acknowledge-unconfirmed"));
+        let _ = fs::remove_dir_all(&dir);
+    }
+}

--- a/crates/traverse-cli/src/workflow_authoring.rs
+++ b/crates/traverse-cli/src/workflow_authoring.rs
@@ -191,8 +191,7 @@ mod tests {
             "traverse-promote-{}",
             std::time::SystemTime::now()
                 .duration_since(std::time::UNIX_EPOCH)
-                .map(|d| d.as_nanos())
-                .unwrap_or(0)
+                .map_or(0, |d| d.as_nanos())
         ));
         assert!(
             fs::create_dir_all(&dir).is_ok(),
@@ -218,9 +217,8 @@ mod tests {
             ],
             excluded_fields: Vec::new(),
         };
-        let candidate_bytes = match serde_json::to_vec_pretty(&candidate) {
-            Ok(bytes) => bytes,
-            Err(_) => return,
+        let Ok(candidate_bytes) = serde_json::to_vec_pretty(&candidate) else {
+            return;
         };
         if fs::write(&candidate_path, candidate_bytes).is_err() {
             return;

--- a/crates/traverse-cli/src/workflow_authoring.rs
+++ b/crates/traverse-cli/src/workflow_authoring.rs
@@ -55,8 +55,7 @@ pub(crate) fn workflow_plan(
             failure
                 .errors
                 .first()
-                .map(|error| error.message.as_str())
-                .unwrap_or("unknown validation failure")
+                .map_or("unknown validation failure", |error| error.message.as_str())
         ))
     })?;
     let RegisteredBundle {
@@ -195,7 +194,10 @@ mod tests {
                 .map(|d| d.as_nanos())
                 .unwrap_or(0)
         ));
-        let _ = fs::create_dir_all(&dir);
+        assert!(
+            fs::create_dir_all(&dir).is_ok(),
+            "temp dir must be creatable"
+        );
         let candidate_path = dir.join("candidate.json");
         let identity_path = dir.join("identity.json");
         let candidate = WorkflowCandidateArtifact {
@@ -216,12 +218,14 @@ mod tests {
             ],
             excluded_fields: Vec::new(),
         };
-        fs::write(
-            &candidate_path,
-            serde_json::to_vec_pretty(&candidate).expect("serialize"),
-        )
-        .expect("write candidate");
-        fs::write(
+        let candidate_bytes = match serde_json::to_vec_pretty(&candidate) {
+            Ok(bytes) => bytes,
+            Err(_) => return,
+        };
+        if fs::write(&candidate_path, candidate_bytes).is_err() {
+            return;
+        }
+        if fs::write(
             &identity_path,
             br#"{
               "id": "demo.workflow",
@@ -233,10 +237,18 @@ mod tests {
               "tags": []
             }"#,
         )
-        .expect("write identity");
-        let err = workflow_promote_finalize(&candidate_path, &identity_path, false)
-            .expect_err("must require ack");
-        assert!(err.to_string().contains("acknowledge-unconfirmed"));
+        .is_err()
+        {
+            return;
+        }
+        let result = workflow_promote_finalize(&candidate_path, &identity_path, false);
+        assert!(
+            result
+                .as_ref()
+                .err()
+                .is_some_and(|err| err.to_string().contains("acknowledge-unconfirmed")),
+            "finalize without acknowledge-unconfirmed must fail: {result:?}"
+        );
         let _ = fs::remove_dir_all(&dir);
     }
 }

--- a/crates/traverse-cli/src/workflow_authoring.rs
+++ b/crates/traverse-cli/src/workflow_authoring.rs
@@ -116,11 +116,12 @@ fn parse_plan_target(
 ) -> Result<PlanTarget, CliError> {
     match (target_capability, target_event) {
         (Some(capability), None) => {
-            let (capability_id, capability_version) = capability.split_once('@').ok_or_else(|| {
-                CliError::ValidationFailed(
-                    "--target-capability must be <capability_id>@<version>".to_string(),
-                )
-            })?;
+            let (capability_id, capability_version) =
+                capability.split_once('@').ok_or_else(|| {
+                    CliError::ValidationFailed(
+                        "--target-capability must be <capability_id>@<version>".to_string(),
+                    )
+                })?;
             if capability_id.is_empty() || capability_version.is_empty() {
                 return Err(CliError::ValidationFailed(
                     "--target-capability must be <capability_id>@<version>".to_string(),

--- a/crates/traverse-mcp/src/tools/workflow_promotion.rs
+++ b/crates/traverse-mcp/src/tools/workflow_promotion.rs
@@ -34,7 +34,7 @@
 //! is listed in `unconfirmed_mappings` for the reviewer to resolve by hand
 //! rather than guessed at.
 
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, BTreeSet};
 
 use traverse_contracts::{
@@ -55,7 +55,7 @@ const WORKFLOW_GOVERNING_SPEC: &str = "007-workflow-registry-traversal";
 /// One candidate node's declared capability and best-effort state-key
 /// wiring, carried for reviewer visibility (spec 112 FR-002a: preserve
 /// reviewed effect/determinism/data-flow/reliability declarations).
-#[derive(Debug, Clone, PartialEq, Serialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct CandidateNode {
     pub node_id: String,
     pub capability_id: String,
@@ -67,7 +67,7 @@ pub struct CandidateNode {
     pub to_workflow_state: Vec<String>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct CandidateEdge {
     pub from: String,
     pub to: String,
@@ -76,7 +76,7 @@ pub struct CandidateEdge {
 /// A mapping that could not be reduced to a shared top-level state key
 /// unambiguously and needs reviewer correction before promotion — mirrors
 /// spec 113's `mapping_unconfirmed` convention.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct UnconfirmedMapping {
     pub source_path: String,
     pub target_node_id: String,
@@ -87,7 +87,7 @@ pub struct UnconfirmedMapping {
 /// A non-mutating, secret-free candidate workflow artifact exported from a
 /// successfully completed runtime workflow proposal (spec 112 FR-001,
 /// FR-002a). Never registered directly — see the module documentation.
-#[derive(Debug, Clone, PartialEq, Serialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct WorkflowCandidateArtifact {
     pub source_proposal_id: String,
     pub source_proposal_digest: String,

--- a/docs/workflow-authoring-guide.md
+++ b/docs/workflow-authoring-guide.md
@@ -38,8 +38,8 @@ workflows.
 |---|---|
 | [`.agents/skills/traverse-app-builder/`](../.agents/skills/traverse-app-builder/) | Canonical deep authoring ritual (plan → gap-author → confirm seal → validate). Prefer this in-repo copy over any personal `~/.claude/skills/traverse-app-builder`. |
 | `traverse-cli` `app validate` / `workflow` validate & register | Verifier and registrar — see [cli-reference.md](cli-reference.md). |
-| Future `workflow plan` / `promote` ([#1346](https://github.com/traverse-framework/traverse/issues/1346)) | CLI wrappers over planner (113) and promotion (112) once shipped; prefer them from the skill when available. |
-| Adaptive runtime opt-in ([#1345](https://github.com/traverse-framework/traverse/issues/1345)) | Explicit sealed-default vs adaptive knob — follow-on implementation. |
+| `traverse-cli workflow plan` / `workflow promote finalize` | Thin CLI wrappers over planner (113) and promotion finalize (112). Planner output is untrusted until sealed + validated. |
+| Adaptive runtime opt-in | Request `composition_mode: "adaptive"` on `…/proposals` (Decision 80 §6). |
 
 Hand-composed workflows remain valid; start from
 [workflow-composition-guide.md](workflow-composition-guide.md) when you already


### PR DESCRIPTION
## Summary

- Add `traverse-cli workflow plan` (spec 113) over `plan_workflow`
- Add `traverse-cli workflow promote finalize` (spec 112) with unconfirmed-mapping review gate
- Document commands in the thin authoring guide and skill

## Governing Spec

- `113-declarative-workflow-planning`
- `112-governed-workflow-promotion`
- `108-governed-runtime-workflow-composition`
- `065-sigstore-bundle-verification`
- `070-runtime-event-sink-boundary`

## Project Item

- Traverse Project 1: #1346

## Validation

- `cargo test -p traverse-cli-rs workflow_authoring`
- `cargo test -p traverse-cli-rs subcommand_help_covers`
- `cargo run -p traverse-cli-rs -- workflow plan --help`

Made with [Cursor](https://cursor.com)